### PR TITLE
Upgrade rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,15 +30,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41ed9a86bf92ae6580e0a31281f65a1b1d867c0cc68d5346e2ae128dddfa6a7d"
+checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e765fd216e48e067936442276d1d57399e37bce53c264d6fefbe298080cb57ee"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
 dependencies = [
  "utf8parse",
 ]
@@ -64,9 +64,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.71"
+version = "1.0.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
+checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
 name = "atomic_refcell"
@@ -111,6 +111,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "630be753d4e58660abd17930c71b647fe46c27ea6b63cc59e1e3851406972e42"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -121,9 +127,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.12.2"
+version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6ed94e98ecff0c12dd1b04c15ec0d7d9458ca8fe806cea6f12954efe74c63b"
+checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 
 [[package]]
 name = "byteorder"
@@ -133,9 +139,12 @@ checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "cc"
-version = "1.0.79"
+version = "1.0.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50d30906286121d95be3d479533b458f87493b30a4b5f79a607db8f5d11aa91f"
+checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "cc-measurement"
@@ -153,9 +162,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.2.7"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34d21f9bf1b425d2968943631ec91202fe5e837264063503708b83013f8fc938"
+checksum = "5fd304a20bff958a57f04c4e96a2e7594cc4490a0e809cbd48bb6437edaa452d"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -164,34 +173,33 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.2.7"
+version = "4.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "914c8c79fb560f238ef6429439a30023c862f7a28e688c58f7203f12b29970bd"
+checksum = "01c6a3f08f1fe5662a35cfe393aec09c4df95f60ee93b7556505260f75eee9e1"
 dependencies = [
  "anstream",
  "anstyle",
- "bitflags",
  "clap_lex",
  "strsim",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.2.0"
+version = "4.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9644cd56d6b87dbe899ef8b053e331c0637664e9e21a33dfcdc36093f5c5c4"
+checksum = "54a9bb5758fc5dfe728d1019941681eccaf0cf8a4189b692a0ee2f2ecf90a050"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.4.1"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a2dd5a6fe8c6e3502f568a6353e5273bbb15193ad9a89e457b9970798efbea1"
+checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
 
 [[package]]
 name = "colorchoice"
@@ -222,9 +230,9 @@ checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.7"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e4c1eaa2012c47becbbad2ab175484c2a84d1185b566fb2cc5b8707343dfe58"
+checksum = "a17b76ff3a4162b0b27f354a0c87015ddad39d35f9c0c36607a3bdd175dde1f1"
 dependencies = [
  "libc",
 ]
@@ -295,10 +303,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "digest"
-version = "0.10.6"
+name = "deranged"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -306,15 +320,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "errno"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
+checksum = "6b30f669a7961ef1631673d2766cc92f52d64f7ef354d4fe0ddfd30ed52f0f4f"
 dependencies = [
  "errno-dragonfly",
  "libc",
@@ -343,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.9"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
+checksum = "be4136b2a15dd319360be1c07d9933517ccf0be8f16bf62a3bee4f0d618df427"
 dependencies = [
  "cfg-if",
  "libc",
@@ -369,44 +383,32 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
  "hermit-abi",
- "io-lifetimes",
  "rustix",
  "windows-sys",
 ]
 
 [[package]]
 name = "itoa"
-version = "1.0.6"
+version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+checksum = "af150ab688ff2122fcef229be89cb50dd66af9e01a4ff320cc137eecc9bacc38"
 
 [[package]]
 name = "js-sys"
-version = "0.3.62"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68c16e1bfd491478ab155fd8b4896b86f9ede344949b641e61501e07c2b8b4d5"
+checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -486,9 +488,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.144"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b00cc1c228a6782d0f076e7b232802e0c5689d41bb5df366f2a6b6621cfdfe1"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linked_list_allocator"
@@ -501,15 +503,15 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.7"
+version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ece97ea872ece730aed82664c424eb4c8291e1ff2480247ccf7409044bc6479f"
+checksum = "57bcfdad1b858c2db7c38303a6d2ad4dfaf5eb53dfeb0910128b2c26d6158503"
 
 [[package]]
 name = "lock_api"
-version = "0.4.9"
+version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435011366fe56583b16cf956f9df0095b405b82d76425bc8981c0e22e60ec4df"
+checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -517,12 +519,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.17"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
-dependencies = [
- "cfg-if",
-]
+checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
 name = "migtd"
@@ -571,15 +570,15 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.17.1"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
+checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
 name = "pci"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "conquer-once",
  "lazy_static",
  "log",
@@ -627,18 +626,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.27"
+version = "1.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4f29d145265ec1c483c7c654450edde0bfe043d3938d6972630663356d9500"
+checksum = "50f3b39ccfb720540debaa0164757101c08ecb8d326b15358ce76a62c7e85965"
 dependencies = [
  "proc-macro2",
 ]
@@ -655,7 +654,7 @@ version = "10.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -683,13 +682,12 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.19"
+version = "0.38.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acf8729d8542766f1b2cf77eb034d52f40d375bb8b615d0b147089946e16613d"
+checksum = "172891ebdceb05aa0005f533a6cbfca599ddd7d966f6f5d4d9b2e70478e70399"
 dependencies = [
- "bitflags",
+ "bitflags 2.3.3",
  "errno",
- "io-lifetimes",
  "libc",
  "linux-raw-sys",
  "windows-sys",
@@ -697,25 +695,35 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.20.0-beta2"
+version = "0.22.0-alpha.0"
 dependencies = [
  "ring",
  "rust_std_stub",
- "sct",
- "webpki",
+ "rustls-webpki",
+ "subtle",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984a9510c24d64bc5c53a6b0d329f883b0f95048fa14ee30223ed35c7e1ba38b"
+dependencies = [
+ "ring",
+ "untrusted",
 ]
 
 [[package]]
 name = "rustversion"
-version = "1.0.12"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f3208ce4d8448b3f3e7d168a73f5e0c43a61e32930de3bceeccedb388b6bf06"
+checksum = "7ffc183a10b4478d04cbbbfc96d0873219d962dd5accaff2ffbd4ceb7df837f4"
 
 [[package]]
 name = "ryu"
-version = "1.0.13"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "same-file"
@@ -728,9 +736,9 @@ dependencies = [
 
 [[package]]
 name = "scopeguard"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scroll"
@@ -753,40 +761,30 @@ dependencies = [
 ]
 
 [[package]]
-name = "sct"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d53dcdb7c9f8158937a7981b48accfd39a43af418591a5d008c7b22b5e1b7ca4"
-dependencies = [
- "ring",
- "untrusted",
-]
-
-[[package]]
 name = "serde"
-version = "1.0.162"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71b2f6e1ab5c2b98c05f0f35b236b22e8df7ead6ffbf51d7808da7f8817e7ab6"
+checksum = "32ac8da02677876d532745a130fc9d8e6edfa81a269b107c5b00829b91d8eb3c"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.162"
+version = "1.0.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2a0814352fd64b58489904a44ea8d90cb1a91dcb6b4f5ebabc32c8318e93cb6"
+checksum = "aafe972d60b0b9bee71a91b92fee2d4fb3c9d7e8f6b179aa99f27203d99a4816"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.96"
+version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+checksum = "076066c5f1078eac5b722a31827a8832fe108bed65dfa75e233c89f8206e976c"
 dependencies = [
  "itoa",
  "ryu",
@@ -795,9 +793,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82e6b795fe2e3b1e845bafcb27aa35405c4d47cdfc92af5fc8d3002f76cebdc0"
+checksum = "479fb9d862239e610720565ca91403019f2f00410f1864c5aa7479b950a76ed8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -841,6 +839,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
+name = "subtle"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81cdd64d312baedb58e21336b31bc043b77e01cc99033ce76ef539f78e965ebc"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -853,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "04361975b3f5e348b2189d8dc55bc942f278b2d482a6a0365de5bdd62d351567"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -897,7 +901,7 @@ dependencies = [
 name = "td-exception"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "log",
  "spin 0.9.8",
@@ -1014,7 +1018,7 @@ version = "0.1.0"
 dependencies = [
  "attestation",
  "bitfield",
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "linked_list_allocator",
  "log",
@@ -1038,10 +1042,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.21"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3403384eaacbca9923fa06940178ac13e4edb725486d70e8e15881d0c836cc"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "time-core",
 ]
 
@@ -1059,9 +1064,9 @@ checksum = "497961ef93d974e23eb6f433eb5fe1b7930b659f06d12dec6fc44a8f554c0bba"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.8"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5464a87b239f13a63a501f2701565754bae92d243d4bb7eb12f6d57d2269bf4"
+checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
 
 [[package]]
 name = "unicode-xid"
@@ -1091,7 +1096,7 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 name = "virtio"
 version = "0.1.0"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "lazy_static",
  "pci",
  "spin 0.9.8",
@@ -1160,9 +1165,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6cb788c4e39112fbe1822277ef6fb3c55cd86b95cb3d3c4c1c9597e4ac74b4"
+checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
 dependencies = [
  "cfg-if",
  "wasm-bindgen-macro",
@@ -1170,24 +1175,24 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35e522ed4105a9d626d885b35d62501b30d9666283a5c8be12c14a8bdafe7822"
+checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "358a79a0cb89d21db8120cbfb91392335913e4890665b1a7981d9e956903b434"
+checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1195,41 +1200,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4783ce29f09b9d93134d41297aded3a712b7b979e9c6f28c32cb88c973a94869"
+checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.28",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.85"
+version = "0.2.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a901d592cafaa4d711bc324edfaff879ac700b19c3dfd60058d2b445be2691eb"
+checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "web-sys"
-version = "0.3.62"
+version = "0.3.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16b5f940c7edfdc6d12126d98c9ef4d1b3d470011c47c76a6581df47ad9ba721"
+checksum = "9b85cbef8c220a6abc02aefd892dfc0fc23afb1c6a426316ec33253a3877249b"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki"
-version = "0.22.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f095d78192e208183081cc07bc5515ef55216397af48b873e5edcd72637fa1bd"
-dependencies = [
- "ring",
- "untrusted",
 ]
 
 [[package]]
@@ -1285,9 +1280,9 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
+checksum = "05d4b17490f70499f20b9e791dcf6a299785ce8af4d709018206dc5b4953e95f"
 dependencies = [
  "windows_aarch64_gnullvm",
  "windows_aarch64_msvc",
@@ -1347,7 +1342,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55b5be8cc34d017d8aabec95bc45a43d0f20e8b2a31a453cabc804fe996f8dca"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 1.3.2",
  "raw-cpuid",
 ]
 
@@ -1358,25 +1353,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "100555a863c0092238c2e0e814c1096c1e5cf066a309c696a87e907b5f8c5d69"
 dependencies = [
  "bit_field",
- "bitflags",
+ "bitflags 1.3.2",
  "rustversion",
  "volatile 0.4.6",
 ]
 
 [[package]]
 name = "xshell"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "962c039b3a7b16cf4e9a4248397c6585c07547412e7d6a6e035389a802dcfe90"
+checksum = "ce2107fe03e558353b4c71ad7626d58ed82efaf56c54134228608893c77023ad"
 dependencies = [
  "xshell-macros",
 ]
 
 [[package]]
 name = "xshell-macros"
-version = "0.2.3"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dbabb1cbd15a1d6d12d9ed6b35cc6777d4af87ab3ba155ea37215f20beab80c"
+checksum = "7e2c411759b501fb9501aac2b1b2d287a6e93e5bdcf13c25306b23e1b716dd0e"
 
 [[package]]
 name = "xtask"

--- a/deps/patches/rustls.diff
+++ b/deps/patches/rustls.diff
@@ -1,123 +1,153 @@
-diff --git a/rustls-mio/Cargo.toml b/rustls-mio/Cargo.toml
-index 739a4c5..e5e65bd 100644
---- a/rustls-mio/Cargo.toml
-+++ b/rustls-mio/Cargo.toml
-@@ -28,7 +28,7 @@ regex = "1.0"
- serde = "1.0"
- serde_derive = "1.0"
- webpki-roots = "0.22"
--ring = "0.16.20"
-+ring = { version = "0.16.20", default-features = false, features = ["alloc"] }
- 
- [[example]]
- name = "tlsclient"
 diff --git a/rustls/Cargo.toml b/rustls/Cargo.toml
-index a960625..af358ca 100644
+index 1e4e1d50..945297ac 100644
 --- a/rustls/Cargo.toml
 +++ b/rustls/Cargo.toml
-@@ -13,15 +13,20 @@ autobenches = false
+@@ -17,9 +17,10 @@ rustversion = { version = "1.0.6", optional = true }
  
  [dependencies]
  log = { version = "0.4.4", optional = true }
 -ring = "0.16.20"
+-subtle = "2.5.0"
+-webpki = { package = "rustls-webpki", version = "0.102.0-alpha.0", features = ["alloc", "std", "ring"] }
 +ring = { version = "0.16.20", default-features = false }
- sct = "0.7.0"
--webpki = { version = "0.22.0", features = ["alloc", "std"] }
-+webpki = "0.22.0"
++subtle = { version = "2.5.0", default-features = false }
++webpki = { package = "rustls-webpki", version = "0.102.0-alpha.0", default-features = false, features = ["alloc", "ring"] }
 +rust_std_stub = { path = "../../../src/std-support/rust-std-stub", optional = true }
  
  [features]
--default = ["logging"]
-+default = ["logging", "std"]
- logging = ["log"]
- dangerous_configuration = []
+ default = ["logging", "tls12"]
+@@ -29,6 +30,9 @@ secret_extraction = []
  quic = []
-+alloc = ["ring/alloc", "webpki/alloc"]
+ tls12 = []
+ read_buf = ["rustversion"]
++alloc = ["ring/alloc"]
 +std = ["alloc", "ring/std", "webpki/std"]
-+
 +no_std = ["rust_std_stub", "alloc"]
  
  [dev-dependencies]
- env_logger = "0.8.2"
-diff --git a/rustls/src/keylog.rs b/rustls/src/keylog.rs
-index af4911b..79d06c4 100644
---- a/rustls/src/keylog.rs
-+++ b/rustls/src/keylog.rs
-@@ -1,8 +1,14 @@
-+#[cfg(feature = "std")]
- use std::env;
-+#[cfg(feature = "std")]
- use std::fs::{File, OpenOptions};
-+#[cfg(feature = "std")]
+ bencher = "0.1.5"
+diff --git a/rustls/src/client/client_conn.rs b/rustls/src/client/client_conn.rs
+index ac768a2e..a665577e 100644
+--- a/rustls/src/client/client_conn.rs
++++ b/rustls/src/client/client_conn.rs
+@@ -26,6 +26,7 @@ use core::marker::PhantomData;
+ use core::ops::{Deref, DerefMut};
+ use core::{fmt, mem};
  use std::io;
 +#[cfg(feature = "std")]
- use std::io::Write;
-+#[cfg(feature = "std")]
- use std::path::Path;
-+#[cfg(feature = "std")]
- use std::sync::Mutex;
+ use std::net::IpAddr;
  
- #[cfg(feature = "logging")]
-@@ -64,12 +70,17 @@ impl KeyLog for NoKeyLog {
-     }
- }
+ /// A trait for the ability to store client session data, so that sessions
+@@ -366,7 +367,13 @@ pub enum ServerName {
  
-+#[cfg(not(feature = "std"))]
-+pub use NoKeyLog as KeyLogFile;
+     /// The server is identified by an IP address. SNI is not
+     /// done.
++    #[cfg(feature = "std")]
+     IpAddress(IpAddr),
 +
- // Internal mutable state for KeyLogFile
-+#[cfg(feature = "std")]
- struct KeyLogFileInner {
-     file: Option<File>,
-     buf: Vec<u8>,
++    /// The server is identified by an IP address. SNI is not
++    /// done.
++    #[cfg(not(feature = "std"))]
++    IpAddress(()),
  }
  
-+#[cfg(feature = "std")]
- impl KeyLogFileInner {
-     fn new(var: Result<String, env::VarError>) -> Self {
-         let path = match var {
-@@ -132,8 +143,10 @@ impl KeyLogFileInner {
- ///
- /// If such a file cannot be opened, or cannot be written then
- /// this does nothing but logs errors at warning-level.
-+#[cfg(feature = "std")]
- pub struct KeyLogFile(Mutex<KeyLogFileInner>);
- 
-+#[cfg(feature = "std")]
- impl KeyLogFile {
-     /// Makes a new `KeyLogFile`.  The environment variable is
-     /// inspected and the named file is opened during this call.
-@@ -143,6 +156,7 @@ impl KeyLogFile {
+ impl fmt::Debug for ServerName {
+@@ -403,10 +410,13 @@ impl TryFrom<&str> for ServerName {
+     fn try_from(s: &str) -> Result<Self, Self::Error> {
+         match DnsNameRef::try_from(s) {
+             Ok(dns) => Ok(Self::DnsName(dns.to_owned())),
++            #[cfg(feature = "std")]
+             Err(InvalidDnsNameError) => match s.parse() {
+                 Ok(ip) => Ok(Self::IpAddress(ip)),
+                 Err(_) => Err(InvalidDnsNameError),
+             },
++            #[cfg(not(feature = "std"))]
++            Err(_) => Err(InvalidDnsNameError),
+         }
      }
  }
+diff --git a/rustls/src/error.rs b/rustls/src/error.rs
+index d15ed194..35036383 100644
+--- a/rustls/src/error.rs
++++ b/rustls/src/error.rs
+@@ -2,6 +2,7 @@ use crate::enums::{AlertDescription, ContentType, HandshakeType};
+ use crate::msgs::handshake::KeyExchangeAlgorithm;
+ use crate::rand;
  
 +#[cfg(feature = "std")]
- impl KeyLog for KeyLogFile {
-     fn log(&self, label: &str, client_random: &[u8], secret: &[u8]) {
-         #[cfg_attr(not(feature = "logging"), allow(unused_variables))]
+ use alloc::sync::Arc;
+ use core::fmt;
+ use std::error::Error as StdError;
+@@ -315,6 +316,7 @@ pub enum CertificateError {
+     /// reasons.
+     ApplicationVerificationFailure,
+ 
++    #[cfg(feature = "std")]
+     /// Any other error.
+     ///
+     /// This can be used by custom verifiers to expose the underlying error
+@@ -326,6 +328,9 @@ pub enum CertificateError {
+     ///
+     /// Enums holding this variant will never compare equal to each other.
+     Other(Arc<dyn StdError + Send + Sync>),
++    #[cfg(not(feature = "std"))]
++    /// Any other error.
++    Other(()),
+ }
+ 
+ impl PartialEq<Self> for CertificateError {
+@@ -397,10 +402,16 @@ pub enum CertRevocationListError {
+     /// The CRL issuer does not specify the cRLSign key usage.
+     IssuerInvalidForCrl,
+ 
++    #[cfg(feature = "std")]
+     /// The CRL is invalid for some other reason.
+     ///
+     /// Enums holding this variant will never compare equal to each other.
+     Other(Arc<dyn StdError + Send + Sync>),
++    #[cfg(not(feature = "std"))]
++    /// The CRL is invalid for some other reason.
++    ///
++    /// Enums holding this variant will never compare equal to each other.
++    Other,
+ 
+     /// The CRL is not correctly encoded.
+     ParseError,
 diff --git a/rustls/src/lib.rs b/rustls/src/lib.rs
-index d6526d2..3c7392d 100644
+index 67b79806..84599ddd 100644
 --- a/rustls/src/lib.rs
 +++ b/rustls/src/lib.rs
-@@ -206,7 +206,9 @@
- //!
+@@ -259,7 +259,9 @@
  
  // Require docs for public APIs, deny unsafe code, etc.
--#![forbid(unsafe_code, unused_must_use, unstable_features)]
-+#![forbid(unsafe_code, unused_must_use)]
+ #![forbid(unsafe_code, unused_must_use)]
+-#![cfg_attr(not(any(read_buf, bench)), forbid(unstable_features))]
 +// If std feature enabled, forbit unstable_features
 +#![cfg_attr(feature = "std", forbid(unstable_features))]
++#![cfg_attr(feature = "std", deny(unused_qualifications))]
  #![deny(
+     clippy::alloc_instead_of_core,
      clippy::clone_on_ref_ptr,
-     clippy::use_self,
-@@ -238,6 +240,22 @@
- // Enable documentation for all features on docs.rs
- #![cfg_attr(docsrs, feature(doc_cfg))]
- 
+@@ -270,8 +272,7 @@
+     missing_docs,
+     unreachable_pub,
+     unused_import_braces,
+-    unused_extern_crates,
+-    unused_qualifications
++    unused_extern_crates
+ )]
+ // Relax these clippy lints:
+ // - ptr_arg: this triggers on references to type aliases that are Vec
+@@ -302,9 +303,24 @@
+ // cross-compiling.
+ #![cfg_attr(read_buf, feature(read_buf))]
+ #![cfg_attr(bench, feature(test))]
 +// Enable no_std support, and no_std support need prelude_import feature.
 +#![cfg_attr(not(feature = "std"), no_std)]
-+#![cfg_attr(not(feature = "std"), feature(prelude_import))]
-+
++#![feature(prelude_import)]
+ 
+ extern crate alloc;
+ 
 +#[cfg(not(feature = "std"))]
 +#[macro_use]
 +extern crate rust_std_stub as std;
@@ -130,33 +160,96 @@ index d6526d2..3c7392d 100644
 +#[macro_use]
 +use std::prelude::*;
 +
- // log for logging (optional).
- #[cfg(feature = "logging")]
- use log;
-diff --git a/rustls/src/verify.rs b/rustls/src/verify.rs
-index be43f55..f8f4664 100644
---- a/rustls/src/verify.rs
-+++ b/rustls/src/verify.rs
-@@ -305,8 +305,10 @@ impl ServerCertVerifier for WebPkiVerifier {
-         now: SystemTime,
-     ) -> Result<ServerCertVerified, Error> {
-         let (cert, chain, trustroots) = prepare(end_entity, intermediates, &self.roots)?;
-+        #[cfg(feature = "std")]
-         let webpki_now = webpki::Time::try_from(now).map_err(|_| Error::FailedToGetCurrentTime)?;
--
-+        #[cfg(not(feature = "std"))]
-+        let webpki_now = webpki::Time::from_seconds_since_unix_epoch(now.as_secs());
-         let ServerName::DnsName(dns_name) = server_name;
+ // Import `test` sysroot crate for `Bencher` definitions.
+ #[cfg(bench)]
+ #[allow(unused_extern_crates)]
+@@ -351,6 +367,7 @@ mod builder;
+ mod enums;
+ mod key;
+ mod key_log;
++#[cfg(feature = "std")]
+ mod key_log_file;
+ mod suites;
+ mod ticketer;
+@@ -392,6 +409,7 @@ pub use crate::error::{
+ };
+ pub use crate::key::{Certificate, PrivateKey};
+ pub use crate::key_log::{KeyLog, NoKeyLog};
++#[cfg(feature = "std")]
+ pub use crate::key_log_file::KeyLogFile;
+ pub use crate::msgs::enums::NamedGroup;
+ pub use crate::msgs::handshake::DistinguishedName;
+@@ -409,6 +427,8 @@ pub use crate::tls13::Tls13CipherSuite;
+ pub use crate::verify::DigitallySignedStruct;
+ pub use crate::versions::{SupportedProtocolVersion, ALL_VERSIONS, DEFAULT_VERSIONS};
+ pub use crate::webpki::{OwnedTrustAnchor, RootCertStore};
++#[cfg(not(feature = "std"))]
++pub use NoKeyLog as KeyLogFile;
  
-         let cert = cert
-@@ -433,7 +435,10 @@ impl ClientCertVerifier for AllowAnyAuthenticatedClient {
-         now: SystemTime,
-     ) -> Result<ClientCertVerified, Error> {
-         let (cert, chain, trustroots) = prepare(end_entity, intermediates, &self.roots)?;
+ /// Items for use in a client.
+ pub mod client {
+diff --git a/rustls/src/webpki/verify.rs b/rustls/src/webpki/verify.rs
+index 8d8f52e5..e25f233f 100644
+--- a/rustls/src/webpki/verify.rs
++++ b/rustls/src/webpki/verify.rs
+@@ -51,7 +51,10 @@ pub fn verify_server_cert_signed_by_trust_anchor(
+ ) -> Result<(), Error> {
+     let chain = intermediate_chain(intermediates);
+     let trust_roots = trust_roots(roots);
++    #[cfg(feature = "std")]
+     let webpki_now = webpki::Time::try_from(now).map_err(|_| Error::FailedToGetCurrentTime)?;
++    #[cfg(not(feature = "std"))]
++    let webpki_now = webpki::Time::from_seconds_since_unix_epoch(now.as_secs());
+ 
+     cert.0
+         .verify_for_usage(
+@@ -83,6 +86,7 @@ pub fn verify_server_name(cert: &ParsedCertificate, server_name: &ServerName) ->
+                 .verify_is_valid_for_subject_name(name)
+                 .map_err(pki_error)?;
+         }
++        #[cfg(feature = "std")]
+         ServerName::IpAddress(ip_addr) => {
+             let ip_addr = webpki::IpAddr::from(*ip_addr);
+             cert.0
+@@ -91,6 +95,8 @@ pub fn verify_server_name(cert: &ParsedCertificate, server_name: &ServerName) ->
+                 ))
+                 .map_err(pki_error)?;
+         }
++        #[cfg(not(feature = "std"))]
++        ServerName::IpAddress(_) => {}
+     }
+     Ok(())
+ }
+@@ -353,7 +359,10 @@ impl ClientCertVerifier for WebPkiClientVerifier {
+         let cert = ParsedCertificate::try_from(end_entity)?;
+         let chain = intermediate_chain(intermediates);
+         let trust_roots = trust_roots(&self.roots);
 +        #[cfg(feature = "std")]
          let now = webpki::Time::try_from(now).map_err(|_| Error::FailedToGetCurrentTime)?;
 +        #[cfg(not(feature = "std"))]
 +        let now = webpki::Time::from_seconds_since_unix_epoch(now.as_secs());
-         cert.verify_is_valid_tls_client_cert(
-             SUPPORTED_SIG_ALGS,
-             &webpki::TlsClientTrustAnchors(&trustroots),
+ 
+         #[allow(trivial_casts)] // Cast to &dyn trait is required.
+         let crls = self
+@@ -439,7 +448,10 @@ fn pki_error(error: webpki::Error) -> Error {
+             CertRevocationListError::BadSignature.into()
+         }
+ 
++        #[cfg(feature = "std")]
+         _ => CertificateError::Other(Arc::new(error)).into(),
++        #[cfg(not(feature = "std"))]
++        _ => CertificateError::Other(()).into(),
+     }
+ }
+ 
+@@ -460,7 +472,10 @@ impl From<webpki::Error> for CertRevocationListError {
+             UnsupportedIndirectCrl => Self::UnsupportedIndirectCrl,
+             UnsupportedRevocationReason => Self::UnsupportedRevocationReason,
+ 
++            #[cfg(feature = "std")]
+             _ => Self::Other(Arc::new(e)),
++            #[cfg(not(feature = "std"))]
++            _ => Self::Other,
+         }
+     }
+ }

--- a/sh_script/preparation.sh
+++ b/sh_script/preparation.sh
@@ -6,7 +6,7 @@ preparation() {
     popd
 
     pushd deps/rustls
-    git reset --hard 79b48e3d4adecc8262811ab781477ad24c09f496
+    git reset --hard ef76fec1459c907e7472a19fb993567ca4b288f5
     git clean -f -d
     patch -p 1 -i ../patches/rustls.diff
     popd

--- a/src/std-support/rust-std-stub/src/lib.rs
+++ b/src/std-support/rust-std-stub/src/lib.rs
@@ -15,6 +15,7 @@ pub use alloc::rc;
 pub use alloc::string;
 pub use alloc::vec;
 
+pub use core::any;
 pub use core::cell;
 pub use core::cmp;
 pub use core::convert;

--- a/src/std-support/rust-std-stub/src/prelude.rs
+++ b/src/std-support/rust-std-stub/src/prelude.rs
@@ -1,10 +1,12 @@
-pub use crate::convert::{AsMut, AsRef, From, Into};
-pub use crate::iter::{Extend, IntoIterator, Iterator};
+pub use crate::any::type_name;
+pub use crate::convert::{AsMut, AsRef, From, Into, TryFrom, TryInto};
+pub use crate::iter::{ExactSizeIterator, Extend, IntoIterator, Iterator};
 pub use crate::marker::{Send, Sized, Sync, Unpin};
 pub use crate::mem::drop;
-pub use crate::ops::{Drop, Fn, FnMut, FnOnce};
+pub use crate::ops::{Drop, Fn, FnMut, FnOnce, Range};
 pub use crate::option::Option::{self, None, Some};
 pub use crate::result::Result::{self, Err, Ok};
+pub use crate::str::FromStr;
 pub use core::prelude::v1::{
     derive, test, Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd,
 };

--- a/src/std-support/rust-std-stub/src/time.rs
+++ b/src/std-support/rust-std-stub/src/time.rs
@@ -1,16 +1,7 @@
+use core::time::Duration;
+
 #[derive(Clone, Debug)]
 pub struct SystemTimeError;
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
-pub struct Duration {
-    secs: u64,
-}
-
-impl Duration {
-    pub fn as_secs(&self) -> u64 {
-        self.secs
-    }
-}
 
 #[derive(Debug, Copy, Clone)]
 pub struct SystemTime(u64);
@@ -20,9 +11,7 @@ pub const UNIX_EPOCH: SystemTime = SystemTime(0);
 impl SystemTime {
     pub fn duration_since(&self, time: SystemTime) -> Result<Duration, SystemTimeError> {
         if self.0 - time.0 > 0 {
-            Ok(Duration {
-                secs: self.0 - time.0,
-            })
+            Ok(Duration::new(self.0 - time.0, 0))
         } else {
             Err(SystemTimeError)
         }

--- a/src/std-support/sys_time/Cargo.toml
+++ b/src/std-support/sys_time/Cargo.toml
@@ -7,6 +7,6 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lazy_static = "1.0"
+lazy_static = { version = "1.4.0", features = ["spin_no_std"] }
 x86_64 = "0.14"
 time = { version = "0.3", default-features = false }


### PR DESCRIPTION
The latest `async-rustls` relies on rustls `0.21` codebase. If we want to utilize this crate, we need to update the `rustls` submiodule.

However, due to a `no_std` issue that has just been fixed in `rustls-webpki`, we have to use the latest `rustls` main branch. We can switch to a release tag once it has a new release.