### PR TITLE
Async rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,6 +69,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b13c32d80ecc7ab747b80c3784bce54ee8a7a0cc4fbda9bf4cda2cf6fe90854"
 
 [[package]]
+name = "async_rustls"
+version = "0.1.0"
+dependencies = [
+ "futures-io",
+ "rust_std_stub",
+ "rustls",
+]
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -343,6 +352,13 @@ checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.1.0"
+dependencies = [
+ "rust_std_stub",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 
 members = [
+    "src/async_rustls",
     "src/attestation",
     "src/crypto",
     "src/devices/pci",

--- a/src/async_rustls/Cargo.toml
+++ b/src/async_rustls/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "async_rustls"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rust_std_stub = { path = "../std-support/rust-std-stub" }
+futures-io = { path = "../std-support/futures-io" }
+rustls = { path = "../../deps/rustls/rustls", default-features = false, features = ["no_std", "alloc"] }
+
+[features]
+dangerous_configuration = ["rustls/dangerous_configuration"]
+early-data = []

--- a/src/async_rustls/src/client.rs
+++ b/src/async_rustls/src/client.rs
@@ -1,0 +1,220 @@
+use super::*;
+use crate::common::IoSession;
+
+/// A wrapper around an underlying raw stream which implements the TLS or SSL
+/// protocol.
+#[derive(Debug)]
+pub struct TlsStream<IO> {
+    pub(crate) io: IO,
+    pub(crate) session: ClientConnection,
+    pub(crate) state: TlsState,
+
+    #[cfg(feature = "early-data")]
+    pub(crate) early_waker: Option<core::task::Waker>,
+}
+
+impl<IO> TlsStream<IO> {
+    #[inline]
+    pub fn get_ref(&self) -> (&IO, &ClientConnection) {
+        (&self.io, &self.session)
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self) -> (&mut IO, &mut ClientConnection) {
+        (&mut self.io, &mut self.session)
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> (IO, ClientConnection) {
+        (self.io, self.session)
+    }
+}
+
+impl<IO> IoSession for TlsStream<IO> {
+    type Io = IO;
+    type Session = ClientConnection;
+
+    #[inline]
+    fn skip_handshake(&self) -> bool {
+        self.state.is_early_data()
+    }
+
+    #[inline]
+    fn get_mut(&mut self) -> (&mut TlsState, &mut Self::Io, &mut Self::Session) {
+        (&mut self.state, &mut self.io, &mut self.session)
+    }
+
+    #[inline]
+    fn into_io(self) -> Self::Io {
+        self.io
+    }
+}
+
+impl<IO> AsyncRead for TlsStream<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.state {
+            #[cfg(feature = "early-data")]
+            TlsState::EarlyData(..) => {
+                let this = self.get_mut();
+
+                // In the EarlyData state, we have not really established a Tls connection.
+                // Before writing data through `AsyncWrite` and completing the tls handshake,
+                // we ignore read readiness and return to pending.
+                //
+                // In order to avoid event loss,
+                // we need to register a waker and wake it up after tls is connected.
+                if this
+                    .early_waker
+                    .as_ref()
+                    .filter(|waker| cx.waker().will_wake(waker))
+                    .is_none()
+                {
+                    this.early_waker = Some(cx.waker().clone());
+                }
+
+                Poll::Pending
+            }
+            TlsState::Stream | TlsState::WriteShutdown => {
+                let this = self.get_mut();
+                let mut stream =
+                    Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+
+                match stream.as_mut_pin().poll_read(cx, buf) {
+                    Poll::Ready(Ok(n)) => {
+                        if n == 0 || stream.eof {
+                            this.state.shutdown_read();
+                        }
+
+                        Poll::Ready(Ok(n))
+                    }
+                    Poll::Ready(Err(err)) if err.kind() == io::ErrorKind::ConnectionAborted => {
+                        this.state.shutdown_read();
+                        Poll::Ready(Err(err))
+                    }
+                    output => output,
+                }
+            }
+            TlsState::ReadShutdown | TlsState::FullyShutdown => Poll::Ready(Ok(0)),
+        }
+    }
+}
+
+impl<IO> AsyncWrite for TlsStream<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Note: that it does not guarantee the final data to be sent.
+    /// To be cautious, you must manually call `flush`.
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+
+        #[allow(clippy::match_single_binding)]
+        match this.state {
+            #[cfg(feature = "early-data")]
+            TlsState::EarlyData(ref mut pos, ref mut data) => {
+                use rust_std_stub::io::Write;
+
+                // write early data
+                if let Some(mut early_data) = stream.session.early_data() {
+                    let len = match early_data.write(buf) {
+                        Ok(n) => n,
+                        Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => {
+                            return Poll::Pending
+                        }
+                        Err(err) => return Poll::Ready(Err(err)),
+                    };
+                    if len != 0 {
+                        data.extend_from_slice(&buf[..len]);
+                        return Poll::Ready(Ok(len));
+                    }
+                }
+
+                // complete handshake
+                while stream.session.is_handshaking() {
+                    ready!(stream.handshake(cx))?;
+                }
+
+                // write early data (fallback)
+                if !stream.session.is_early_data_accepted() {
+                    while *pos < data.len() {
+                        let len = ready!(stream.as_mut_pin().poll_write(cx, &data[*pos..]))?;
+                        *pos += len;
+                    }
+                }
+
+                // end
+                this.state = TlsState::Stream;
+
+                if let Some(waker) = this.early_waker.take() {
+                    waker.wake();
+                }
+
+                stream.as_mut_pin().poll_write(cx, buf)
+            }
+            _ => stream.as_mut_pin().poll_write(cx, buf),
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+
+        #[cfg(feature = "early-data")]
+        {
+            if let TlsState::EarlyData(ref mut pos, ref mut data) = this.state {
+                // complete handshake
+                while stream.session.is_handshaking() {
+                    ready!(stream.handshake(cx))?;
+                }
+
+                // write early data (fallback)
+                if !stream.session.is_early_data_accepted() {
+                    while *pos < data.len() {
+                        let len = ready!(stream.as_mut_pin().poll_write(cx, &data[*pos..]))?;
+                        *pos += len;
+                    }
+                }
+
+                this.state = TlsState::Stream;
+
+                if let Some(waker) = this.early_waker.take() {
+                    waker.wake();
+                }
+            }
+        }
+
+        stream.as_mut_pin().poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // complete handshake
+        #[cfg(feature = "early-data")]
+        if matches!(self.state, TlsState::EarlyData(..)) {
+            ready!(self.as_mut().poll_flush(cx))?;
+        }
+
+        if self.state.writeable() {
+            self.session.send_close_notify();
+            self.state.shutdown_write();
+        }
+
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+        stream.as_mut_pin().poll_close(cx)
+    }
+}

--- a/src/async_rustls/src/common/handshake.rs
+++ b/src/async_rustls/src/common/handshake.rs
@@ -1,0 +1,70 @@
+use crate::common::{Stream, TlsState};
+use core::future::Future;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use futures_io::{AsyncRead, AsyncWrite};
+use rust_std_stub::{io, mem};
+use rustls::{ConnectionCommon, SideData};
+
+pub(crate) trait IoSession {
+    type Io;
+    type Session;
+
+    fn skip_handshake(&self) -> bool;
+    fn get_mut(&mut self) -> (&mut TlsState, &mut Self::Io, &mut Self::Session);
+    fn into_io(self) -> Self::Io;
+}
+
+pub(crate) enum MidHandshake<IS: IoSession> {
+    Handshaking(IS),
+    End,
+    Error { io: IS::Io, error: io::Error },
+}
+
+impl<IS, SD> Future for MidHandshake<IS>
+where
+    IS: IoSession + Unpin,
+    IS::Io: AsyncRead + AsyncWrite + Unpin,
+    IS::Session: DerefMut + Deref<Target = ConnectionCommon<SD>> + Unpin,
+    SD: SideData,
+{
+    type Output = Result<IS, (io::Error, IS::Io)>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        let mut stream = match mem::replace(this, MidHandshake::End) {
+            MidHandshake::Handshaking(stream) => stream,
+            // Starting the handshake returned an error; fail the future immediately.
+            MidHandshake::Error { io, error } => return Poll::Ready(Err((error, io))),
+            _ => panic!("unexpected polling after handshake"),
+        };
+
+        if !stream.skip_handshake() {
+            let (state, io, session) = stream.get_mut();
+            let mut tls_stream = Stream::new(io, session).set_eof(!state.readable());
+
+            macro_rules! try_poll {
+                ( $e:expr ) => {
+                    match $e {
+                        Poll::Ready(Ok(_)) => (),
+                        Poll::Ready(Err(err)) => return Poll::Ready(Err((err, stream.into_io()))),
+                        Poll::Pending => {
+                            *this = MidHandshake::Handshaking(stream);
+                            return Poll::Pending;
+                        }
+                    }
+                };
+            }
+
+            while tls_stream.session.is_handshaking() {
+                try_poll!(tls_stream.handshake(cx));
+            }
+
+            try_poll!(Pin::new(&mut tls_stream).poll_flush(cx));
+        }
+
+        Poll::Ready(Ok(stream))
+    }
+}

--- a/src/async_rustls/src/common/mod.rs
+++ b/src/async_rustls/src/common/mod.rs
@@ -1,0 +1,360 @@
+mod handshake;
+
+#[cfg(feature = "early-data")]
+use alloc::vec::Vec;
+use core::ops::{Deref, DerefMut};
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use futures_io::{AsyncRead, AsyncWrite};
+pub(crate) use handshake::{IoSession, MidHandshake};
+use rust_std_stub::io::{self, IoSlice, Read, Write};
+use rustls::{ConnectionCommon, SideData};
+
+#[derive(Debug)]
+pub enum TlsState {
+    #[cfg(feature = "early-data")]
+    EarlyData(usize, Vec<u8>),
+    Stream,
+    ReadShutdown,
+    WriteShutdown,
+    FullyShutdown,
+}
+
+impl TlsState {
+    #[inline]
+    pub fn shutdown_read(&mut self) {
+        match *self {
+            TlsState::WriteShutdown | TlsState::FullyShutdown => *self = TlsState::FullyShutdown,
+            _ => *self = TlsState::ReadShutdown,
+        }
+    }
+
+    #[inline]
+    pub fn shutdown_write(&mut self) {
+        match *self {
+            TlsState::ReadShutdown | TlsState::FullyShutdown => *self = TlsState::FullyShutdown,
+            _ => *self = TlsState::WriteShutdown,
+        }
+    }
+
+    #[inline]
+    pub fn writeable(&self) -> bool {
+        !matches!(*self, TlsState::WriteShutdown | TlsState::FullyShutdown)
+    }
+
+    #[inline]
+    pub fn readable(&self) -> bool {
+        !matches!(*self, TlsState::ReadShutdown | TlsState::FullyShutdown)
+    }
+
+    #[inline]
+    #[cfg(feature = "early-data")]
+    pub fn is_early_data(&self) -> bool {
+        matches!(self, TlsState::EarlyData(..))
+    }
+
+    #[inline]
+    #[cfg(not(feature = "early-data"))]
+    pub fn is_early_data(&self) -> bool {
+        false
+    }
+}
+
+pub struct Stream<'a, IO, S> {
+    pub io: &'a mut IO,
+    pub session: &'a mut S,
+    pub eof: bool,
+}
+
+impl<'a, IO: AsyncRead + AsyncWrite + Unpin, S, SD> Stream<'a, IO, S>
+where
+    S: DerefMut + Deref<Target = ConnectionCommon<SD>>,
+    SD: SideData,
+{
+    pub fn new(io: &'a mut IO, session: &'a mut S) -> Self {
+        Stream {
+            io,
+            session,
+            // The state so far is only used to detect EOF, so either Stream
+            // or EarlyData state should both be all right.
+            eof: false,
+        }
+    }
+
+    pub fn set_eof(mut self, eof: bool) -> Self {
+        self.eof = eof;
+        self
+    }
+
+    pub fn as_mut_pin(&mut self) -> Pin<&mut Self> {
+        Pin::new(self)
+    }
+
+    pub fn read_io(&mut self, cx: &mut Context) -> Poll<io::Result<usize>> {
+        let mut reader = SyncReadAdapter { io: self.io, cx };
+
+        let n = match self.session.read_tls(&mut reader) {
+            Ok(n) => n,
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => return Poll::Pending,
+            Err(err) => return Poll::Ready(Err(err)),
+        };
+
+        let stats = self.session.process_new_packets().map_err(|err| {
+            // In case we have an alert to send describing this error,
+            // try a last-gasp write -- but don't predate the primary
+            // error.
+            let _ = self.write_io(cx);
+
+            io::Error::new(io::ErrorKind::InvalidData, err)
+        })?;
+
+        if stats.peer_has_closed() && self.session.is_handshaking() {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "tls handshake alert",
+            )));
+        }
+
+        Poll::Ready(Ok(n))
+    }
+
+    pub fn write_io(&mut self, cx: &mut Context) -> Poll<io::Result<usize>> {
+        struct Writer<'a, 'b, T> {
+            io: &'a mut T,
+            cx: &'a mut Context<'b>,
+        }
+
+        impl<'a, 'b, T: Unpin> Writer<'a, 'b, T> {
+            #[inline]
+            fn poll_with<U>(
+                &mut self,
+                f: impl FnOnce(Pin<&mut T>, &mut Context<'_>) -> Poll<io::Result<U>>,
+            ) -> io::Result<U> {
+                match f(Pin::new(self.io), self.cx) {
+                    Poll::Ready(result) => result,
+                    Poll::Pending => Err(io::ErrorKind::WouldBlock.into()),
+                }
+            }
+        }
+
+        impl<'a, 'b, T: AsyncWrite + Unpin> Write for Writer<'a, 'b, T> {
+            #[inline]
+            fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+                self.poll_with(|io, cx| io.poll_write(cx, buf))
+            }
+
+            #[inline]
+            fn write_vectored(&mut self, bufs: &[IoSlice<'_>]) -> io::Result<usize> {
+                self.poll_with(|io, cx| io.poll_write_vectored(cx, bufs))
+            }
+
+            #[inline]
+            fn flush(&mut self) -> io::Result<()> {
+                self.poll_with(|io, cx| io.poll_flush(cx))
+            }
+        }
+
+        let mut writer = Writer { io: self.io, cx };
+
+        match self.session.write_tls(&mut writer) {
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => Poll::Pending,
+            result => Poll::Ready(result),
+        }
+    }
+
+    pub fn handshake(&mut self, cx: &mut Context) -> Poll<io::Result<(usize, usize)>> {
+        let mut wrlen = 0;
+        let mut rdlen = 0;
+
+        loop {
+            let mut write_would_block = false;
+            let mut read_would_block = false;
+            let mut need_flush = false;
+
+            while self.session.wants_write() {
+                match self.write_io(cx) {
+                    Poll::Ready(Ok(n)) => {
+                        wrlen += n;
+                        need_flush = true;
+                    }
+                    Poll::Pending => {
+                        write_would_block = true;
+                        break;
+                    }
+                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                }
+            }
+
+            if need_flush {
+                match Pin::new(&mut self.io).poll_flush(cx) {
+                    Poll::Ready(Ok(())) => (),
+                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                    Poll::Pending => write_would_block = true,
+                }
+            }
+
+            while !self.eof && self.session.wants_read() {
+                match self.read_io(cx) {
+                    Poll::Ready(Ok(0)) => self.eof = true,
+                    Poll::Ready(Ok(n)) => rdlen += n,
+                    Poll::Pending => {
+                        read_would_block = true;
+                        break;
+                    }
+                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                }
+            }
+
+            return match (self.eof, self.session.is_handshaking()) {
+                (true, true) => {
+                    let err = io::Error::new(io::ErrorKind::UnexpectedEof, "tls handshake eof");
+                    Poll::Ready(Err(err))
+                }
+                (_, false) => Poll::Ready(Ok((rdlen, wrlen))),
+                (_, true) if write_would_block || read_would_block => {
+                    if rdlen != 0 || wrlen != 0 {
+                        Poll::Ready(Ok((rdlen, wrlen)))
+                    } else {
+                        Poll::Pending
+                    }
+                }
+                (..) => continue,
+            };
+        }
+    }
+}
+
+impl<'a, IO: AsyncRead + AsyncWrite + Unpin, S, SD> AsyncRead for Stream<'a, IO, S>
+where
+    S: DerefMut + Deref<Target = ConnectionCommon<SD>>,
+    SD: SideData,
+{
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut io_pending = false;
+
+        // read a packet
+        while !self.eof && self.session.wants_read() {
+            match self.read_io(cx) {
+                Poll::Ready(Ok(0)) => {
+                    self.eof = true;
+                    break;
+                }
+                Poll::Ready(Ok(_)) => (),
+                Poll::Pending => {
+                    io_pending = true;
+                    break;
+                }
+                Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+            }
+        }
+
+        match self.session.reader().read(buf) {
+            // If Rustls returns `Ok(0)` (while `buf` is non-empty), the peer closed the
+            // connection with a `CloseNotify` message and no more data will be forthcoming.
+            //
+            // Rustls yielded more data: advance the buffer, then see if more data is coming.
+            //
+            // We don't need to modify `self.eof` here, because it is only a temporary mark.
+            // rustls will only return 0 if is has received `CloseNotify`,
+            // in which case no additional processing is required.
+            Ok(n) => Poll::Ready(Ok(n)),
+
+            // Rustls doesn't have more data to yield, but it believes the connection is open.
+            Err(ref err) if err.kind() == io::ErrorKind::WouldBlock => {
+                if !io_pending {
+                    // If `wants_read()` is satisfied, rustls will not return `WouldBlock`.
+                    // but if it does, we can try again.
+                    //
+                    // If the rustls state is abnormal, it may cause a cyclic wakeup.
+                    // but tokio's cooperative budget will prevent infinite wakeup.
+                    cx.waker().wake_by_ref();
+                }
+
+                Poll::Pending
+            }
+
+            Err(err) => Poll::Ready(Err(err)),
+        }
+    }
+}
+
+impl<'a, IO: AsyncRead + AsyncWrite + Unpin, C, SD> AsyncWrite for Stream<'a, IO, C>
+where
+    C: DerefMut + Deref<Target = ConnectionCommon<SD>>,
+    SD: SideData,
+{
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let mut pos = 0;
+
+        while pos != buf.len() {
+            let mut would_block = false;
+
+            match self.session.writer().write(&buf[pos..]) {
+                Ok(n) => pos += n,
+                Err(err) => return Poll::Ready(Err(err)),
+            };
+
+            while self.session.wants_write() {
+                match self.write_io(cx) {
+                    Poll::Ready(Ok(0)) | Poll::Pending => {
+                        would_block = true;
+                        break;
+                    }
+                    Poll::Ready(Ok(_)) => (),
+                    Poll::Ready(Err(err)) => return Poll::Ready(Err(err)),
+                }
+            }
+
+            return match (pos, would_block) {
+                (0, true) => Poll::Pending,
+                (n, true) => Poll::Ready(Ok(n)),
+                (_, false) => continue,
+            };
+        }
+
+        Poll::Ready(Ok(pos))
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<io::Result<()>> {
+        self.session.writer().flush()?;
+        while self.session.wants_write() {
+            ready!(self.write_io(cx))?;
+        }
+        Pin::new(&mut self.io).poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        while self.session.wants_write() {
+            ready!(self.write_io(cx))?;
+        }
+        Pin::new(&mut self.io).poll_close(cx)
+    }
+}
+
+/// An adapter that implements a [`Read`] interface for [`AsyncRead`] types and an
+/// associated [`Context`].
+///
+/// Turns `Poll::Pending` into `WouldBlock`.
+pub struct SyncReadAdapter<'a, 'b, T> {
+    pub io: &'a mut T,
+    pub cx: &'a mut Context<'b>,
+}
+
+impl<'a, 'b, T: AsyncRead + Unpin> Read for SyncReadAdapter<'a, 'b, T> {
+    #[inline]
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match Pin::new(&mut self.io).poll_read(self.cx, buf) {
+            Poll::Ready(Ok(n)) => Ok(n),
+            Poll::Ready(Err(err)) => Err(err),
+            Poll::Pending => Err(io::ErrorKind::WouldBlock.into()),
+        }
+    }
+}

--- a/src/async_rustls/src/lib.rs
+++ b/src/async_rustls/src/lib.rs
@@ -1,0 +1,450 @@
+#![no_std]
+
+extern crate alloc;
+
+macro_rules! ready {
+    ( $e:expr ) => {
+        match $e {
+            core::task::Poll::Ready(t) => t,
+            core::task::Poll::Pending => return core::task::Poll::Pending,
+        }
+    };
+}
+
+pub mod client;
+mod common;
+pub mod server;
+
+use alloc::sync::Arc;
+#[cfg(feature = "early-data")]
+use alloc::vec::Vec;
+use common::{MidHandshake, Stream, TlsState};
+use core::future::Future;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use futures_io::{AsyncRead, AsyncWrite};
+use rust_std_stub::io;
+use rustls::crypto::ring::Ring;
+use rustls::{ClientConfig, ClientConnection, CommonState, ServerConfig, ServerConnection};
+
+pub use rustls;
+
+/// A wrapper around a `rustls::ClientConfig`, providing an async `connect` method.
+#[derive(Clone)]
+pub struct TlsConnector {
+    inner: Arc<ClientConfig<Ring>>,
+    #[cfg(feature = "early-data")]
+    early_data: bool,
+}
+
+/// A wrapper around a `rustls::ServerConfig`, providing an async `accept` method.
+#[derive(Clone)]
+pub struct TlsAcceptor {
+    inner: Arc<ServerConfig<Ring>>,
+}
+
+impl From<Arc<ClientConfig<Ring>>> for TlsConnector {
+    fn from(inner: Arc<ClientConfig<Ring>>) -> TlsConnector {
+        TlsConnector {
+            inner,
+            #[cfg(feature = "early-data")]
+            early_data: false,
+        }
+    }
+}
+
+impl From<Arc<ServerConfig<Ring>>> for TlsAcceptor {
+    fn from(inner: Arc<ServerConfig<Ring>>) -> TlsAcceptor {
+        TlsAcceptor { inner }
+    }
+}
+
+impl TlsConnector {
+    /// Enable 0-RTT.
+    ///
+    /// If you want to use 0-RTT,
+    /// You must also set `ClientConfig.enable_early_data` to `true`.
+    #[cfg(feature = "early-data")]
+    pub fn early_data(mut self, flag: bool) -> TlsConnector {
+        self.early_data = flag;
+        self
+    }
+
+    #[inline]
+    pub fn connect<IO>(&self, domain: rustls::ServerName, stream: IO) -> Connect<IO>
+    where
+        IO: AsyncRead + AsyncWrite + Unpin,
+    {
+        self.connect_with(domain, stream, |_| ())
+    }
+
+    pub fn connect_with<IO, F>(&self, domain: rustls::ServerName, stream: IO, f: F) -> Connect<IO>
+    where
+        IO: AsyncRead + AsyncWrite + Unpin,
+        F: FnOnce(&mut ClientConnection),
+    {
+        let mut session = match ClientConnection::new(self.inner.clone(), domain) {
+            Ok(session) => session,
+            Err(error) => {
+                return Connect(MidHandshake::Error {
+                    io: stream,
+                    // TODO(eliza): should this really return an `io::Error`?
+                    // Probably not...
+                    error: io::Error::new(io::ErrorKind::Other, error),
+                });
+            }
+        };
+        f(&mut session);
+
+        Connect(MidHandshake::Handshaking(client::TlsStream {
+            io: stream,
+
+            #[cfg(not(feature = "early-data"))]
+            state: TlsState::Stream,
+
+            #[cfg(feature = "early-data")]
+            state: if self.early_data && session.early_data().is_some() {
+                TlsState::EarlyData(0, Vec::new())
+            } else {
+                TlsState::Stream
+            },
+
+            #[cfg(feature = "early-data")]
+            early_waker: None,
+
+            session,
+        }))
+    }
+}
+
+impl TlsAcceptor {
+    #[inline]
+    pub fn accept<IO>(&self, stream: IO) -> Accept<IO>
+    where
+        IO: AsyncRead + AsyncWrite + Unpin,
+    {
+        self.accept_with(stream, |_| ())
+    }
+
+    pub fn accept_with<IO, F>(&self, stream: IO, f: F) -> Accept<IO>
+    where
+        IO: AsyncRead + AsyncWrite + Unpin,
+        F: FnOnce(&mut ServerConnection),
+    {
+        let mut session = match ServerConnection::new(self.inner.clone()) {
+            Ok(session) => session,
+            Err(error) => {
+                return Accept(MidHandshake::Error {
+                    io: stream,
+                    // TODO(eliza): should this really return an `io::Error`?
+                    // Probably not...
+                    error: io::Error::new(io::ErrorKind::Other, error),
+                });
+            }
+        };
+        f(&mut session);
+
+        Accept(MidHandshake::Handshaking(server::TlsStream {
+            session,
+            io: stream,
+            state: TlsState::Stream,
+        }))
+    }
+}
+
+pub struct LazyConfigAcceptor<IO> {
+    acceptor: rustls::server::Acceptor,
+    io: Option<IO>,
+}
+
+impl<IO> LazyConfigAcceptor<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    #[inline]
+    pub fn new(acceptor: rustls::server::Acceptor, io: IO) -> Self {
+        Self {
+            acceptor,
+            io: Some(io),
+        }
+    }
+}
+
+impl<IO> Future for LazyConfigAcceptor<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    type Output = Result<StartHandshake<IO>, io::Error>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+        loop {
+            let io = match this.io.as_mut() {
+                Some(io) => io,
+                None => {
+                    panic!("Acceptor cannot be polled after acceptance.");
+                }
+            };
+
+            let mut reader = common::SyncReadAdapter { io, cx };
+            match this.acceptor.read_tls(&mut reader) {
+                Ok(0) => return Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into())),
+                Ok(_) => {}
+                Err(e) if e.kind() == io::ErrorKind::WouldBlock => return Poll::Pending,
+                Err(e) => return Poll::Ready(Err(e)),
+            }
+
+            match this.acceptor.accept() {
+                Ok(Some(accepted)) => {
+                    let io = this.io.take().unwrap();
+                    return Poll::Ready(Ok(StartHandshake { accepted, io }));
+                }
+                Ok(None) => continue,
+                Err(err) => {
+                    return Poll::Ready(Err(io::Error::new(io::ErrorKind::InvalidInput, err)))
+                }
+            }
+        }
+    }
+}
+
+pub struct StartHandshake<IO> {
+    accepted: rustls::server::Accepted,
+    io: IO,
+}
+
+impl<IO> StartHandshake<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    pub fn client_hello(&self) -> rustls::server::ClientHello<'_> {
+        self.accepted.client_hello()
+    }
+
+    pub fn into_stream(self, config: Arc<ServerConfig<Ring>>) -> Accept<IO> {
+        self.into_stream_with(config, |_| ())
+    }
+
+    pub fn into_stream_with<F>(self, config: Arc<ServerConfig<Ring>>, f: F) -> Accept<IO>
+    where
+        F: FnOnce(&mut ServerConnection),
+    {
+        let mut conn = match self.accepted.into_connection(config) {
+            Ok(conn) => conn,
+            Err(error) => {
+                return Accept(MidHandshake::Error {
+                    io: self.io,
+                    // TODO(eliza): should this really return an `io::Error`?
+                    // Probably not...
+                    error: io::Error::new(io::ErrorKind::Other, error),
+                });
+            }
+        };
+        f(&mut conn);
+
+        Accept(MidHandshake::Handshaking(server::TlsStream {
+            session: conn,
+            io: self.io,
+            state: TlsState::Stream,
+        }))
+    }
+}
+
+/// Future returned from `TlsConnector::connect` which will resolve
+/// once the connection handshake has finished.
+pub struct Connect<IO>(MidHandshake<client::TlsStream<IO>>);
+
+/// Future returned from `TlsAcceptor::accept` which will resolve
+/// once the accept handshake has finished.
+pub struct Accept<IO>(MidHandshake<server::TlsStream<IO>>);
+
+/// Like [Connect], but returns `IO` on failure.
+pub struct FallibleConnect<IO>(MidHandshake<client::TlsStream<IO>>);
+
+/// Like [Accept], but returns `IO` on failure.
+pub struct FallibleAccept<IO>(MidHandshake<server::TlsStream<IO>>);
+
+impl<IO> Connect<IO> {
+    #[inline]
+    pub fn into_fallible(self) -> FallibleConnect<IO> {
+        FallibleConnect(self.0)
+    }
+
+    pub fn get_ref(&self) -> Option<&IO> {
+        match &self.0 {
+            MidHandshake::Handshaking(sess) => Some(sess.get_ref().0),
+            MidHandshake::Error { io, .. } => Some(io),
+            MidHandshake::End => None,
+        }
+    }
+
+    pub fn get_mut(&mut self) -> Option<&mut IO> {
+        match &mut self.0 {
+            MidHandshake::Handshaking(sess) => Some(sess.get_mut().0),
+            MidHandshake::Error { io, .. } => Some(io),
+            MidHandshake::End => None,
+        }
+    }
+}
+
+impl<IO> Accept<IO> {
+    #[inline]
+    pub fn into_fallible(self) -> FallibleAccept<IO> {
+        FallibleAccept(self.0)
+    }
+
+    pub fn get_ref(&self) -> Option<&IO> {
+        match &self.0 {
+            MidHandshake::Handshaking(sess) => Some(sess.get_ref().0),
+            MidHandshake::Error { io, .. } => Some(io),
+            MidHandshake::End => None,
+        }
+    }
+
+    pub fn get_mut(&mut self) -> Option<&mut IO> {
+        match &mut self.0 {
+            MidHandshake::Handshaking(sess) => Some(sess.get_mut().0),
+            MidHandshake::Error { io, .. } => Some(io),
+            MidHandshake::End => None,
+        }
+    }
+}
+
+impl<IO: AsyncRead + AsyncWrite + Unpin> Future for Connect<IO> {
+    type Output = io::Result<client::TlsStream<IO>>;
+
+    #[inline]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx).map_err(|(err, _)| err)
+    }
+}
+
+impl<IO: AsyncRead + AsyncWrite + Unpin> Future for Accept<IO> {
+    type Output = io::Result<server::TlsStream<IO>>;
+
+    #[inline]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx).map_err(|(err, _)| err)
+    }
+}
+
+impl<IO: AsyncRead + AsyncWrite + Unpin> Future for FallibleConnect<IO> {
+    type Output = Result<client::TlsStream<IO>, (io::Error, IO)>;
+
+    #[inline]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+impl<IO: AsyncRead + AsyncWrite + Unpin> Future for FallibleAccept<IO> {
+    type Output = Result<server::TlsStream<IO>, (io::Error, IO)>;
+
+    #[inline]
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        Pin::new(&mut self.0).poll(cx)
+    }
+}
+
+/// Unified TLS stream type
+///
+/// This abstracts over the inner `client::TlsStream` and `server::TlsStream`, so you can use
+/// a single type to keep both client- and server-initiated TLS-encrypted connections.
+#[allow(clippy::large_enum_variant)] // https://github.com/rust-lang/rust-clippy/issues/9798
+#[derive(Debug)]
+pub enum TlsStream<T> {
+    Client(client::TlsStream<T>),
+    Server(server::TlsStream<T>),
+}
+
+impl<T> TlsStream<T> {
+    pub fn get_ref(&self) -> (&T, &CommonState) {
+        use TlsStream::*;
+        match self {
+            Client(io) => {
+                let (io, session) = io.get_ref();
+                (io, session)
+            }
+            Server(io) => {
+                let (io, session) = io.get_ref();
+                (io, session)
+            }
+        }
+    }
+
+    pub fn get_mut(&mut self) -> (&mut T, &mut CommonState) {
+        use TlsStream::*;
+        match self {
+            Client(io) => {
+                let (io, session) = io.get_mut();
+                (io, &mut *session)
+            }
+            Server(io) => {
+                let (io, session) = io.get_mut();
+                (io, &mut *session)
+            }
+        }
+    }
+}
+
+impl<T> From<client::TlsStream<T>> for TlsStream<T> {
+    fn from(s: client::TlsStream<T>) -> Self {
+        Self::Client(s)
+    }
+}
+
+impl<T> From<server::TlsStream<T>> for TlsStream<T> {
+    fn from(s: server::TlsStream<T>) -> Self {
+        Self::Server(s)
+    }
+}
+
+impl<T> AsyncRead for TlsStream<T>
+where
+    T: AsyncRead + AsyncWrite + Unpin,
+{
+    #[inline]
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            TlsStream::Client(x) => Pin::new(x).poll_read(cx, buf),
+            TlsStream::Server(x) => Pin::new(x).poll_read(cx, buf),
+        }
+    }
+}
+
+impl<T> AsyncWrite for TlsStream<T>
+where
+    T: AsyncRead + AsyncWrite + Unpin,
+{
+    #[inline]
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        match self.get_mut() {
+            TlsStream::Client(x) => Pin::new(x).poll_write(cx, buf),
+            TlsStream::Server(x) => Pin::new(x).poll_write(cx, buf),
+        }
+    }
+
+    #[inline]
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Client(x) => Pin::new(x).poll_flush(cx),
+            TlsStream::Server(x) => Pin::new(x).poll_flush(cx),
+        }
+    }
+
+    #[inline]
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        match self.get_mut() {
+            TlsStream::Client(x) => Pin::new(x).poll_close(cx),
+            TlsStream::Server(x) => Pin::new(x).poll_close(cx),
+        }
+    }
+}

--- a/src/async_rustls/src/server.rs
+++ b/src/async_rustls/src/server.rs
@@ -1,0 +1,122 @@
+use super::*;
+use crate::common::IoSession;
+
+/// A wrapper around an underlying raw stream which implements the TLS or SSL
+/// protocol.
+#[derive(Debug)]
+pub struct TlsStream<IO> {
+    pub(crate) io: IO,
+    pub(crate) session: ServerConnection,
+    pub(crate) state: TlsState,
+}
+
+impl<IO> TlsStream<IO> {
+    #[inline]
+    pub fn get_ref(&self) -> (&IO, &ServerConnection) {
+        (&self.io, &self.session)
+    }
+
+    #[inline]
+    pub fn get_mut(&mut self) -> (&mut IO, &mut ServerConnection) {
+        (&mut self.io, &mut self.session)
+    }
+
+    #[inline]
+    pub fn into_inner(self) -> (IO, ServerConnection) {
+        (self.io, self.session)
+    }
+}
+
+impl<IO> IoSession for TlsStream<IO> {
+    type Io = IO;
+    type Session = ServerConnection;
+
+    #[inline]
+    fn skip_handshake(&self) -> bool {
+        false
+    }
+
+    #[inline]
+    fn get_mut(&mut self) -> (&mut TlsState, &mut Self::Io, &mut Self::Session) {
+        (&mut self.state, &mut self.io, &mut self.session)
+    }
+
+    #[inline]
+    fn into_io(self) -> Self::Io {
+        self.io
+    }
+}
+
+impl<IO> AsyncRead for TlsStream<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+
+        match &this.state {
+            TlsState::Stream | TlsState::WriteShutdown => {
+                match stream.as_mut_pin().poll_read(cx, buf) {
+                    Poll::Ready(Ok(n)) => {
+                        if n == 0 || stream.eof {
+                            this.state.shutdown_read();
+                        }
+
+                        Poll::Ready(Ok(n))
+                    }
+                    Poll::Ready(Err(err)) if err.kind() == io::ErrorKind::UnexpectedEof => {
+                        this.state.shutdown_read();
+                        Poll::Ready(Err(err))
+                    }
+                    output => output,
+                }
+            }
+            TlsState::ReadShutdown | TlsState::FullyShutdown => Poll::Ready(Ok(0)),
+            #[cfg(feature = "early-data")]
+            s => unreachable!("server TLS can not hit this state: {:?}", s),
+        }
+    }
+}
+
+impl<IO> AsyncWrite for TlsStream<IO>
+where
+    IO: AsyncRead + AsyncWrite + Unpin,
+{
+    /// Note: that it does not guarantee the final data to be sent.
+    /// To be cautious, you must manually call `flush`.
+    fn poll_write(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+        stream.as_mut_pin().poll_write(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+        stream.as_mut_pin().poll_flush(cx)
+    }
+
+    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        if self.state.writeable() {
+            self.session.send_close_notify();
+            self.state.shutdown_write();
+        }
+
+        let this = self.get_mut();
+        let mut stream =
+            Stream::new(&mut this.io, &mut this.session).set_eof(!this.state.readable());
+        stream.as_mut_pin().poll_close(cx)
+    }
+}

--- a/src/std-support/futures-io/Cargo.toml
+++ b/src/std-support/futures-io/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "futures-io"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+rust_std_stub = { path = "../rust-std-stub" }

--- a/src/std-support/futures-io/src/lib.rs
+++ b/src/std-support/futures-io/src/lib.rs
@@ -1,0 +1,550 @@
+//! Asynchronous I/O
+//!
+//! This crate contains the `AsyncRead`, `AsyncWrite`, `AsyncSeek`, and
+//! `AsyncBufRead` traits, the asynchronous analogs to
+//! `std::io::{Read, Write, Seek, BufRead}`. The primary difference is
+//! that these traits integrate with the asynchronous task system.
+//!
+//! All items of this library are only available when the `std` feature of this
+//! library is activated, and it is activated by default.
+
+#![no_std]
+#![warn(
+    missing_debug_implementations,
+    missing_docs,
+    rust_2018_idioms,
+    unreachable_pub
+)]
+// It cannot be included in the published code because this lints have false positives in the minimum required version.
+#![cfg_attr(test, warn(single_use_lifetimes))]
+#![doc(test(
+    no_crate_inject,
+    attr(
+        deny(warnings, rust_2018_idioms, single_use_lifetimes),
+        allow(dead_code, unused_assignments, unused_variables)
+    )
+))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
+
+extern crate alloc;
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::ops::DerefMut;
+use core::pin::Pin;
+use core::task::{Context, Poll};
+use rust_std_stub::io;
+
+// Re-export some types from `std::io` so that users don't have to deal
+// with conflicts when `use`ing `futures::io` and `std::io`.
+#[allow(unreachable_pub)] // https://github.com/rust-lang/rust/issues/57411
+#[doc(no_inline)]
+pub use io::{Error, ErrorKind, IoSlice, IoSliceMut, Result};
+
+/// Read bytes asynchronously.
+///
+/// This trait is analogous to the `std::io::Read` trait, but integrates
+/// with the asynchronous task system. In particular, the `poll_read`
+/// method, unlike `Read::read`, will automatically queue the current task
+/// for wakeup and return if data is not yet available, rather than blocking
+/// the calling thread.
+pub trait AsyncRead {
+    /// Attempt to read from the `AsyncRead` into `buf`.
+    ///
+    /// On success, returns `Poll::Ready(Ok(num_bytes_read))`.
+    ///
+    /// If no data is available for reading, the method returns
+    /// `Poll::Pending` and arranges for the current task (via
+    /// `cx.waker().wake_by_ref()`) to receive a notification when the object becomes
+    /// readable or is closed.
+    ///
+    /// # Implementation
+    ///
+    /// This function may not return errors of kind `WouldBlock` or
+    /// `Interrupted`.  Implementations must convert `WouldBlock` into
+    /// `Poll::Pending` and either internally retry or convert
+    /// `Interrupted` into another error kind.
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8])
+        -> Poll<Result<usize>>;
+
+    /// Attempt to read from the `AsyncRead` into `bufs` using vectored
+    /// IO operations.
+    ///
+    /// This method is similar to `poll_read`, but allows data to be read
+    /// into multiple buffers using a single operation.
+    ///
+    /// On success, returns `Poll::Ready(Ok(num_bytes_read))`.
+    ///
+    /// If no data is available for reading, the method returns
+    /// `Poll::Pending` and arranges for the current task (via
+    /// `cx.waker().wake_by_ref()`) to receive a notification when the object becomes
+    /// readable or is closed.
+    /// By default, this method delegates to using `poll_read` on the first
+    /// nonempty buffer in `bufs`, or an empty one if none exists. Objects which
+    /// support vectored IO should override this method.
+    ///
+    /// # Implementation
+    ///
+    /// This function may not return errors of kind `WouldBlock` or
+    /// `Interrupted`.  Implementations must convert `WouldBlock` into
+    /// `Poll::Pending` and either internally retry or convert
+    /// `Interrupted` into another error kind.
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<Result<usize>> {
+        for b in bufs {
+            if !b.is_empty() {
+                return self.poll_read(cx, b);
+            }
+        }
+
+        self.poll_read(cx, &mut [])
+    }
+}
+
+/// Write bytes asynchronously.
+///
+/// This trait is analogous to the `std::io::Write` trait, but integrates
+/// with the asynchronous task system. In particular, the `poll_write`
+/// method, unlike `Write::write`, will automatically queue the current task
+/// for wakeup and return if the writer cannot take more data, rather than blocking
+/// the calling thread.
+pub trait AsyncWrite {
+    /// Attempt to write bytes from `buf` into the object.
+    ///
+    /// On success, returns `Poll::Ready(Ok(num_bytes_written))`.
+    ///
+    /// If the object is not ready for writing, the method returns
+    /// `Poll::Pending` and arranges for the current task (via
+    /// `cx.waker().wake_by_ref()`) to receive a notification when the object becomes
+    /// writable or is closed.
+    ///
+    /// # Implementation
+    ///
+    /// This function may not return errors of kind `WouldBlock` or
+    /// `Interrupted`.  Implementations must convert `WouldBlock` into
+    /// `Poll::Pending` and either internally retry or convert
+    /// `Interrupted` into another error kind.
+    ///
+    /// `poll_write` must try to make progress by flushing the underlying object if
+    /// that is the only way the underlying object can become writable again.
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>>;
+
+    /// Attempt to write bytes from `bufs` into the object using vectored
+    /// IO operations.
+    ///
+    /// This method is similar to `poll_write`, but allows data from multiple buffers to be written
+    /// using a single operation.
+    ///
+    /// On success, returns `Poll::Ready(Ok(num_bytes_written))`.
+    ///
+    /// If the object is not ready for writing, the method returns
+    /// `Poll::Pending` and arranges for the current task (via
+    /// `cx.waker().wake_by_ref()`) to receive a notification when the object becomes
+    /// writable or is closed.
+    ///
+    /// By default, this method delegates to using `poll_write` on the first
+    /// nonempty buffer in `bufs`, or an empty one if none exists. Objects which
+    /// support vectored IO should override this method.
+    ///
+    /// # Implementation
+    ///
+    /// This function may not return errors of kind `WouldBlock` or
+    /// `Interrupted`.  Implementations must convert `WouldBlock` into
+    /// `Poll::Pending` and either internally retry or convert
+    /// `Interrupted` into another error kind.
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<Result<usize>> {
+        for b in bufs {
+            if !b.is_empty() {
+                return self.poll_write(cx, b);
+            }
+        }
+
+        self.poll_write(cx, &[])
+    }
+
+    /// Attempt to flush the object, ensuring that any buffered data reach
+    /// their destination.
+    ///
+    /// On success, returns `Poll::Ready(Ok(()))`.
+    ///
+    /// If flushing cannot immediately complete, this method returns
+    /// `Poll::Pending` and arranges for the current task (via
+    /// `cx.waker().wake_by_ref()`) to receive a notification when the object can make
+    /// progress towards flushing.
+    ///
+    /// # Implementation
+    ///
+    /// This function may not return errors of kind `WouldBlock` or
+    /// `Interrupted`.  Implementations must convert `WouldBlock` into
+    /// `Poll::Pending` and either internally retry or convert
+    /// `Interrupted` into another error kind.
+    ///
+    /// It only makes sense to do anything here if you actually buffer data.
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>>;
+
+    /// Attempt to close the object.
+    ///
+    /// On success, returns `Poll::Ready(Ok(()))`.
+    ///
+    /// If closing cannot immediately complete, this function returns
+    /// `Poll::Pending` and arranges for the current task (via
+    /// `cx.waker().wake_by_ref()`) to receive a notification when the object can make
+    /// progress towards closing.
+    ///
+    /// # Implementation
+    ///
+    /// This function may not return errors of kind `WouldBlock` or
+    /// `Interrupted`.  Implementations must convert `WouldBlock` into
+    /// `Poll::Pending` and either internally retry or convert
+    /// `Interrupted` into another error kind.
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>>;
+}
+
+// /// Seek bytes asynchronously.
+// ///
+// /// This trait is analogous to the `std::io::Seek` trait, but integrates
+// /// with the asynchronous task system. In particular, the `poll_seek`
+// /// method, unlike `Seek::seek`, will automatically queue the current task
+// /// for wakeup and return if data is not yet available, rather than blocking
+// /// the calling thread.
+// pub trait AsyncSeek {
+//     /// Attempt to seek to an offset, in bytes, in a stream.
+//     ///
+//     /// A seek beyond the end of a stream is allowed, but behavior is defined
+//     /// by the implementation.
+//     ///
+//     /// If the seek operation completed successfully,
+//     /// this method returns the new position from the start of the stream.
+//     /// That position can be used later with [`SeekFrom::Start`].
+//     ///
+//     /// # Errors
+//     ///
+//     /// Seeking to a negative offset is considered an error.
+//     ///
+//     /// # Implementation
+//     ///
+//     /// This function may not return errors of kind `WouldBlock` or
+//     /// `Interrupted`.  Implementations must convert `WouldBlock` into
+//     /// `Poll::Pending` and either internally retry or convert
+//     /// `Interrupted` into another error kind.
+//     fn poll_seek(
+//         self: Pin<&mut Self>,
+//         cx: &mut Context<'_>,
+//         pos: SeekFrom,
+//     ) -> Poll<Result<u64>>;
+// }
+
+/// Read bytes asynchronously.
+///
+/// This trait is analogous to the `std::io::BufRead` trait, but integrates
+/// with the asynchronous task system. In particular, the `poll_fill_buf`
+/// method, unlike `BufRead::fill_buf`, will automatically queue the current task
+/// for wakeup and return if data is not yet available, rather than blocking
+/// the calling thread.
+pub trait AsyncBufRead: AsyncRead {
+    /// Attempt to return the contents of the internal buffer, filling it with more data
+    /// from the inner reader if it is empty.
+    ///
+    /// On success, returns `Poll::Ready(Ok(buf))`.
+    ///
+    /// If no data is available for reading, the method returns
+    /// `Poll::Pending` and arranges for the current task (via
+    /// `cx.waker().wake_by_ref()`) to receive a notification when the object becomes
+    /// readable or is closed.
+    ///
+    /// This function is a lower-level call. It needs to be paired with the
+    /// [`consume`] method to function properly. When calling this
+    /// method, none of the contents will be "read" in the sense that later
+    /// calling [`poll_read`] may return the same contents. As such, [`consume`] must
+    /// be called with the number of bytes that are consumed from this buffer to
+    /// ensure that the bytes are never returned twice.
+    ///
+    /// [`poll_read`]: AsyncRead::poll_read
+    /// [`consume`]: AsyncBufRead::consume
+    ///
+    /// An empty buffer returned indicates that the stream has reached EOF.
+    ///
+    /// # Implementation
+    ///
+    /// This function may not return errors of kind `WouldBlock` or
+    /// `Interrupted`.  Implementations must convert `WouldBlock` into
+    /// `Poll::Pending` and either internally retry or convert
+    /// `Interrupted` into another error kind.
+    fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>>;
+
+    /// Tells this buffer that `amt` bytes have been consumed from the buffer,
+    /// so they should no longer be returned in calls to [`poll_read`].
+    ///
+    /// This function is a lower-level call. It needs to be paired with the
+    /// [`poll_fill_buf`] method to function properly. This function does
+    /// not perform any I/O, it simply informs this object that some amount of
+    /// its buffer, returned from [`poll_fill_buf`], has been consumed and should
+    /// no longer be returned. As such, this function may do odd things if
+    /// [`poll_fill_buf`] isn't called before calling it.
+    ///
+    /// The `amt` must be `<=` the number of bytes in the buffer returned by
+    /// [`poll_fill_buf`].
+    ///
+    /// [`poll_read`]: AsyncRead::poll_read
+    /// [`poll_fill_buf`]: AsyncBufRead::poll_fill_buf
+    fn consume(self: Pin<&mut Self>, amt: usize);
+}
+
+macro_rules! deref_async_read {
+    () => {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize>> {
+            Pin::new(&mut **self).poll_read(cx, buf)
+        }
+
+        fn poll_read_vectored(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &mut [IoSliceMut<'_>],
+        ) -> Poll<Result<usize>> {
+            Pin::new(&mut **self).poll_read_vectored(cx, bufs)
+        }
+    };
+}
+
+impl<T: ?Sized + AsyncRead + Unpin> AsyncRead for Box<T> {
+    deref_async_read!();
+}
+
+impl<T: ?Sized + AsyncRead + Unpin> AsyncRead for &mut T {
+    deref_async_read!();
+}
+
+impl<P> AsyncRead for Pin<P>
+where
+    P: DerefMut + Unpin,
+    P::Target: AsyncRead,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize>> {
+        self.get_mut().as_mut().poll_read(cx, buf)
+    }
+
+    fn poll_read_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &mut [IoSliceMut<'_>],
+    ) -> Poll<Result<usize>> {
+        self.get_mut().as_mut().poll_read_vectored(cx, bufs)
+    }
+}
+
+macro_rules! delegate_async_read_to_stdio {
+    () => {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &mut [u8],
+        ) -> Poll<Result<usize>> {
+            Poll::Ready(io::Read::read(&mut *self, buf))
+        }
+
+        fn poll_read_vectored(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            bufs: &mut [IoSliceMut<'_>],
+        ) -> Poll<Result<usize>> {
+            Poll::Ready(io::Read::read_vectored(&mut *self, bufs))
+        }
+    };
+}
+
+impl AsyncRead for &[u8] {
+    delegate_async_read_to_stdio!();
+}
+
+macro_rules! deref_async_write {
+    () => {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize>> {
+            Pin::new(&mut **self).poll_write(cx, buf)
+        }
+
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<Result<usize>> {
+            Pin::new(&mut **self).poll_write_vectored(cx, bufs)
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            Pin::new(&mut **self).poll_flush(cx)
+        }
+
+        fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            Pin::new(&mut **self).poll_close(cx)
+        }
+    };
+}
+
+impl<T: ?Sized + AsyncWrite + Unpin> AsyncWrite for Box<T> {
+    deref_async_write!();
+}
+
+impl<T: ?Sized + AsyncWrite + Unpin> AsyncWrite for &mut T {
+    deref_async_write!();
+}
+
+impl<P> AsyncWrite for Pin<P>
+where
+    P: DerefMut + Unpin,
+    P::Target: AsyncWrite,
+{
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        self.get_mut().as_mut().poll_write(cx, buf)
+    }
+
+    fn poll_write_vectored(
+        self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        bufs: &[IoSlice<'_>],
+    ) -> Poll<Result<usize>> {
+        self.get_mut().as_mut().poll_write_vectored(cx, bufs)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.get_mut().as_mut().poll_flush(cx)
+    }
+
+    fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.get_mut().as_mut().poll_close(cx)
+    }
+}
+
+macro_rules! delegate_async_write_to_stdio {
+    () => {
+        fn poll_write(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            buf: &[u8],
+        ) -> Poll<Result<usize>> {
+            Poll::Ready(io::Write::write(&mut *self, buf))
+        }
+
+        fn poll_write_vectored(
+            mut self: Pin<&mut Self>,
+            _: &mut Context<'_>,
+            bufs: &[IoSlice<'_>],
+        ) -> Poll<Result<usize>> {
+            Poll::Ready(io::Write::write_vectored(&mut *self, bufs))
+        }
+
+        fn poll_flush(mut self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<()>> {
+            Poll::Ready(io::Write::flush(&mut *self))
+        }
+
+        fn poll_close(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<()>> {
+            self.poll_flush(cx)
+        }
+    };
+}
+
+impl AsyncWrite for Vec<u8> {
+    delegate_async_write_to_stdio!();
+}
+
+// macro_rules! deref_async_seek {
+//     () => {
+//         fn poll_seek(
+//             mut self: Pin<&mut Self>,
+//             cx: &mut Context<'_>,
+//             pos: SeekFrom,
+//         ) -> Poll<Result<u64>> {
+//             Pin::new(&mut **self).poll_seek(cx, pos)
+//         }
+//     };
+// }
+
+// impl<T: ?Sized + AsyncSeek + Unpin> AsyncSeek for Box<T> {
+//     deref_async_seek!();
+// }
+
+// impl<T: ?Sized + AsyncSeek + Unpin> AsyncSeek for &mut T {
+//     deref_async_seek!();
+// }
+
+// impl<P> AsyncSeek for Pin<P>
+// where
+//     P: DerefMut + Unpin,
+//     P::Target: AsyncSeek,
+// {
+//     fn poll_seek(
+//         self: Pin<&mut Self>,
+//         cx: &mut Context<'_>,
+//         pos: SeekFrom,
+//     ) -> Poll<Result<u64>> {
+//         self.get_mut().as_mut().poll_seek(cx, pos)
+//     }
+// }
+
+// macro_rules! deref_async_buf_read {
+//     () => {
+//         fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
+//             Pin::new(&mut **self.get_mut()).poll_fill_buf(cx)
+//         }
+
+//         fn consume(mut self: Pin<&mut Self>, amt: usize) {
+//             Pin::new(&mut **self).consume(amt)
+//         }
+//     };
+// }
+
+// impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for Box<T> {
+//     deref_async_buf_read!();
+// }
+
+// impl<T: ?Sized + AsyncBufRead + Unpin> AsyncBufRead for &mut T {
+//     deref_async_buf_read!();
+// }
+
+// impl<P> AsyncBufRead for Pin<P>
+// where
+//     P: DerefMut + Unpin,
+//     P::Target: AsyncBufRead,
+// {
+//     fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Result<&[u8]>> {
+//         self.get_mut().as_mut().poll_fill_buf(cx)
+//     }
+
+//     fn consume(self: Pin<&mut Self>, amt: usize) {
+//         self.get_mut().as_mut().consume(amt)
+//     }
+// }
+
+// macro_rules! delegate_async_buf_read_to_stdio {
+//     () => {
+//         fn poll_fill_buf(self: Pin<&mut Self>, _: &mut Context<'_>) -> Poll<Result<&[u8]>> {
+//             Poll::Ready(io::BufRead::fill_buf(self.get_mut()))
+//         }
+
+//         fn consume(self: Pin<&mut Self>, amt: usize) {
+//             io::BufRead::consume(self.get_mut(), amt)
+//         }
+//     };
+// }
+
+// impl AsyncBufRead for &[u8] {
+//     delegate_async_buf_read_to_stdio!();
+// }


### PR DESCRIPTION
Using prelude std for [async-rustls](https://github.com/smol-rs/async-rustls) and [futures-io](https://github.com/rust-lang/futures-rs) to make them compatible with `no_std`