### PR TITLE
config: complete the content of the default policy

### DIFF
--- a/config/policy.json
+++ b/config/policy.json
@@ -28,6 +28,10 @@
                 "operation":"equal",
                 "reference":"self"
             },
+            "MRTD": { 
+                "operation": "equal", 
+                "reference": "self" 
+            }, 
             "MRCONFIGID":{
                 "operation":"equal",
                 "reference":"self"
@@ -39,6 +43,22 @@
             "MROWNERCONFIG":{
                 "operation":"equal",
                 "reference":"self"
+            },
+            "RTMR0": { 
+                "operation": "equal", 
+                "reference": "self" 
+            }, 
+            "RTMR1": { 
+                "operation": "equal", 
+                "reference": "self" 
+            }, 
+            "RTMR2": { 
+                "operation": "equal", 
+                "reference": "self" 
+            }, 
+            "RTMR3": { 
+                "operation": "equal", 
+                "reference": "self" 
             }
         },
         "EventLog": {


### PR DESCRIPTION
MRTD and RTMRs need to be verified while checking MigTD policy.

Fix: https://github.com/intel/MigTD/issues/23