### PR TITLE
policy: compare dst and src when op is greater_or_equal

### DIFF
--- a/src/migtd/src/mig_policy.rs
+++ b/src/migtd/src/mig_policy.rs
@@ -8,7 +8,11 @@ use tdx_tdcall::tdreport;
 
 use crate::{config::get_policy, event_log::get_event_log};
 
-pub fn authenticate_policy(td_report_peer: &[u8], event_log_peer: &[u8]) -> PolicyVerifyReulst {
+pub fn authenticate_policy(
+    is_src: bool,
+    td_report_peer: &[u8],
+    event_log_peer: &[u8],
+) -> PolicyVerifyReulst {
     let td_report = if let Ok(td_report) = tdreport::tdcall_report(&[0u8; 64]) {
         td_report
     } else {
@@ -28,6 +32,7 @@ pub fn authenticate_policy(td_report_peer: &[u8], event_log_peer: &[u8]) -> Poli
     };
 
     verify_policy(
+        is_src,
         policy,
         td_report.as_bytes(),
         event_log,


### PR DESCRIPTION
When the operation of a property in policy is greater or equal and the reference value if `self`, we should compare between dst and src, otherwise the only qualified value will be equal to `self`.

Since MigTD-dst always start a TLS server and MigTD-src always start a TLS client, we can distinguish between migtd-s and d in this way when verifying the policy.

Fix: https://github.com/intel/MigTD/issues/22