### PR TITLE
devices/vsock: check the packet length before use

### DIFF
--- a/src/devices/vsock/src/transport/virtio_pci.rs
+++ b/src/devices/vsock/src/transport/virtio_pci.rs
@@ -230,7 +230,8 @@ impl VirtioVsock {
                 .ok_or(VsockTransportError::DmaAllocation)?;
         }
 
-        let packet_hdr = Packet::new_unchecked(&hdr_buf[..]);
+        let packet_hdr = Packet::new_checked(&hdr_buf[..])
+            .map_err(|_| VsockTransportError::InvalidVsockPacket)?;
         let data_len = packet_hdr.data_len();
         if data_len != 0 {
             if data_len > pkt[1].len {

--- a/src/devices/vsock/src/transport/vmcall.rs
+++ b/src/devices/vsock/src/transport/vmcall.rs
@@ -94,6 +94,9 @@ impl VmcallVsock {
         let mut header = Vec::new();
         let mut data = Vec::new();
 
+        if pkt.len() < HEADER_LEN {
+            return Err(VsockTransportError::InvalidVsockPacket);
+        }
         // Read out the packet header into a safe place
         header.extend_from_slice(&pkt[..HEADER_LEN]);
 


### PR DESCRIPTION
The input vsock packets are untrusted and they should be checked before they can be used.

We can check its length or use the `new_checked` method to make sure the read/write on the slice won't panic.

Fix: https://github.com/intel/MigTD/issues/36