### PR TITLE
readme: document the TDVMCALL leaves required by getting quote

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,10 @@ cargo hash --image /path/to/migtd.bin --servtd-info /path/to/servtd_info.json
 
 * MigTD depends on `sgx-dcap-pccs` and `tdx-qgs` to do remote attestation. Please refer to [linux-sgx](https://github.com/intel/linux-sgx/tree/tdx_1.5_mvp_23q1) for details or follow the [tdx-tools wiki](https://github.com/intel/tdx-tools/wiki/5.-TDX-End-to-End-Attestation) to setup the environment.
 
+3. Guest-Hypervisor Communication Interface (GHCI) required for remote attestation
+
+* MigTD relies on `TDG.VP.VMCALL<GetQuote>` and `TDG.VP.VMCALL<SetupEventNotifyInterrupt>` interfaces provided by hypervisor to get quote. Please make sure your hypervisor implements these leaves.
+
 ### Steps to run pre-migration
 
 #### Virtio-vsock approach


### PR DESCRIPTION
Document the requirement for the `GetQuote` and `SetupEventNotifyInterrupt` of remote attestation.

Resolve https://github.com/intel/MigTD/issues/39