### PR TITLE
config: remove `mrseam` from default policy

### DIFF
--- a/config/policy.json
+++ b/config/policy.json
@@ -6,10 +6,6 @@
                 "operation":"greater-or-equal",
                 "reference":"self"
             },
-            "MRSEAM": {
-                "operation":"equal",
-                "reference":"self"
-            },
             "MRSIGNERSEAM":{
                 "operation":"equal",
                 "reference":"self"


### PR DESCRIPTION
Migration from a lower SVN source to a higher SVN destination is allowed. This is conflict with the policy that requires `mrseam` to be equal.