### PR TITLE
use docker for reproducible build

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:22.04
+
+# Adding rust binaries to PATH.
+ENV PATH="$PATH:/root/.cargo/bin"
+WORKDIR /root
+
+# Install all required packages in one go to optimize the image
+# https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run
+# DEBIAN_FRONTEND is set for tzdata.
+RUN apt-get update && \
+    DEBIAN_FRONTEND="noninteractive" apt-get install --no-install-recommends -y \
+    build-essential unzip ca-certificates curl gcc git libssl-dev pkg-config ssh \
+    clang llvm nasm \
+    ocaml ocamlbuild wget pkg-config libtool autoconf autotools-dev automake \
+    screen expect \
+    # cleanup
+    && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Install rustup and a fixed version of Rust.
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2023-08-28
+RUN rustup component add rust-src
+RUN cargo install cargo-xbuild
+
+RUN git clone --recursive https://github.com/intel/MigTD.git

--- a/readme.md
+++ b/readme.md
@@ -263,4 +263,16 @@ echo "qom-set /objects/tdx0/ vsockport 0" | nc -U /tmp/qmp-sock-dst
 Ask migtd-src to start pre-migration:
 ```
 echo "qom-set /objects/tdx0/ vsockport 0" | nc -U /tmp/qmp-sock-src
+
+## Reproducible Build
+
+Reproducible build of MigTD binary requires same system user and
+source code path (see https://github.com/intel/MigTD/issues/51).
+
+The [Dockerfile](./Dockerfile) is provided to build the docker image with
+the MigTD compilation environment for reproducible build. You can use the
+[docker.sh](./sh_script/docker.sh) to build and run the docker container:
+
+```
+./sh_script/docker.sh -f container
 ```

--- a/sh_script/docker.sh
+++ b/sh_script/docker.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+set -e
+
+FOLDER=""
+
+usage() {
+    cat << EOM
+Usage: $(basename "$0") [OPTION]...
+  -d <docker file>     Path of Dockerfile.
+EOM
+}
+
+error() {
+    echo -e "\e[1;31mERROR: $*\e[0;0m"
+    exit 1
+}
+
+process_args() {
+    while getopts ":f:h" option; do
+        case "$option" in
+            f) FOLDER=$OPTARG;;
+            h) usage
+               exit 0
+               ;;
+            *)
+               echo "Invalid option '-$OPTARG'"
+               usage
+               exit 1
+               ;;
+        esac
+    done
+
+    if [[ -z ${FOLDER} ]]; then
+        error "Please specify the folder of where the Dockerfile is located through -f."
+    fi
+
+    if [[ ! -f "${FOLDER}/Dockerfile" ]]; then
+        error "Dockerfile does not exist."
+    fi
+}
+
+process_args $@
+
+pushd ${FOLDER}
+
+# If the docker image does not exist, build the docker image
+set +e && docker image inspect migtd.build.env:latest > /dev/null 2>&1 && set -e
+if [ $? != 0 ]; then
+    docker build -t migtd.build.env \
+            --build-arg https_proxy=$https_proxy \
+            --build-arg http_proxy=$http_proxy \
+            .
+fi
+
+popd
+
+# Run the docker image
+docker run -it --rm migtd.build.env


### PR DESCRIPTION
The reproducible build of MigTD binary requires same user and code path, so we provide a `Dockerfile` for reproducibility.

Fix: https://github.com/intel/MigTD/issues/51