### PR TITLE
CI: set `AFL_NO_AFFINITY` to fix random fuzz failure

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -15,6 +15,7 @@ env:
   CC_x86_64_unknown_none: clang
   RUST_TOOLCHAIN: nightly-2023-08-28
   TOOLCHAIN_PROFILE: minimal
+  AFL_NO_AFFINITY: 1
 
 jobs:
   test:


### PR DESCRIPTION
Setting AFL_NO_AFFINITY disables attempts to bind to a specific CPU core on Linux systems.

Fix: https://github.com/intel/MigTD/issues/62