### PR TITLE
use `TOML` encoding for `rust-toolchain` file

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -32,6 +32,7 @@ jobs:
           submodules: recursive
       - uses: actions-rs/toolchain@v1
         with:
+          toolchain: nightly-2023-08-28
           profile: minimal
           override: true
           components: rust-src, llvm-tools-preview

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,1 +1,2 @@
-nightly-2023-08-28
+[toolchain]
+channel = "nightly-2023-08-28"


### PR DESCRIPTION
Dependabot can't parse the rust-toolchain with legacy foramt.