### PR TITLE
config: measure the `payload` section to mrtd

### DIFF
--- a/config/metadata.json
+++ b/config/metadata.json
@@ -14,7 +14,7 @@
             "MemoryAddress": "0xFF081000",
             "MemoryDataSize": "0xD76000",
             "Type": "Payload",
-            "Attributes": "0x0"
+            "Attributes": "0x1"
         },
         {
             "DataOffset": "0x0",

--- a/config/policy.json
+++ b/config/policy.json
@@ -58,10 +58,6 @@
             }
         },
         "EventLog": {
-            "Digest.MigTdCore": {
-                "operation": "equal",
-                "reference": "self"
-            },
             "Digest.MigTdPolicy": {
                 "operation": "equal",
                 "reference": "self"

--- a/src/policy/src/verify.rs
+++ b/src/policy/src/verify.rs
@@ -843,7 +843,7 @@ mod tests {
     #[test]
     fn test_eventlogpolicy_verify_mismatch_payload() {
         let payload = vec![0xffu8; 1024];
-        let policy = include_str!("../test/policy_full2.json");
+        let policy = include_str!("../test/policy.json");
         let trust_anchor = vec![0xffu8; 128];
         let svn = u64::to_le_bytes(0xf);
         let root_key = vec![0xffu8; 96];

--- a/src/policy/test/policy_003.json
+++ b/src/policy/test/policy_003.json
@@ -42,10 +42,6 @@
             }
         },
         "EventLog": {
-            "Digest.MigTdCore": {
-                "operation": "equal",
-                "reference": "self"
-            },
             "Digest.MigTdPolicy": {
                 "operation": "equal",
                 "reference": "self"

--- a/src/policy/test/policy_006.json
+++ b/src/policy/test/policy_006.json
@@ -20,10 +20,6 @@
             }
         },
         "EventLog": {
-            "Digest.MigTdCore": {
-                "operation": "equal",
-                "reference": "self"
-            },
             "Digest.SecureBootKey": {
                 "operation": "equal",
                 "reference": "self"

--- a/src/policy/test/policy_full2.json
+++ b/src/policy/test/policy_full2.json
@@ -46,10 +46,6 @@
             }
         },
         "EventLog": {
-            "Digest.MigTdCore": {
-                "operation": "equal",
-                "reference": "self"
-            },
             "Digest.SecureBootKey": {
                 "operation": "equal",
                 "reference": "self"

--- a/src/policy/test/policy_invalid_guid.json
+++ b/src/policy/test/policy_invalid_guid.json
@@ -42,10 +42,6 @@
             }
         },
         "EventLog": {
-            "Digest.MigTdCore": {
-                "operation": "equal",
-                "reference": "self"
-            },
             "Digest.MigTdPolicy": {
                 "operation": "equal",
                 "reference": "self"


### PR DESCRIPTION
Change the attribute value of `payload` section to `1`.

Closes https://github.com/intel/MigTD/issues/84