### PR TITLE
tools: introduce `servtd-hash`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2969dcb958b36655471fc61f7e416fa76033bdd4bfed0678d8fee1e2d07a1f0"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anstream"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
 
 [[package]]
+name = "argparse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f8ebf5827e4ac4fd5946560e6a99776ea73b596d80898f357007317a7141e47"
+
+[[package]]
 name = "atomic_refcell"
 version = "0.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -83,6 +98,17 @@ dependencies = [
  "spin 0.9.8",
  "td-payload",
  "tdx-tdcall",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -126,6 +152,15 @@ name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-padding"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8894febbff9f758034a5b8e12d87918f56dfc64a8e1fe757d65e29041538d93"
 dependencies = [
  "generic-array",
 ]
@@ -222,6 +257,12 @@ checksum = "e763eef8846b13b380f37dfecda401770b0ca4e56e95170237bd7c25c7db3582"
 
 [[package]]
 name = "const-oid"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
+
+[[package]]
+name = "const-oid"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4c78c047431fee22c1a7bb92e00ad095a02a983affe4d8a72e2a2c62c1b94f3"
@@ -265,6 +306,7 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
 dependencies = [
+ "const-oid 0.6.2",
  "der_derive 0.4.1",
 ]
 
@@ -274,7 +316,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6919815d73839e7ad218de758883aae3a257ba6759ce7a9992501efbb53d705c"
 dependencies = [
- "const-oid",
+ "const-oid 0.7.1",
  "der_derive 0.5.0",
 ]
 
@@ -328,6 +370,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "errno"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -374,6 +429,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
+name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "home"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +454,12 @@ checksum = "5444c27eef6923071f7ebcc33e3444508466a76f7a2b93da00ed6e19f30c1ddb"
 dependencies = [
  "windows-sys",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "itoa"
@@ -499,6 +578,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
 
 [[package]]
+name = "memchr"
+version = "2.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
+
+[[package]]
 name = "migtd"
 version = "0.3.1"
 dependencies = [
@@ -535,6 +620,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "migtd-hash"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "crypto",
+ "migtd",
+ "serde_json",
+ "td-shim-tools",
+ "td-uefi-pi",
+]
+
+[[package]]
 name = "minicov"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -545,10 +643,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-traits"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39e3200413f237f41ab11ad6d161bc7239c84dcb631773ccd7de3dfe4b5c267c"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "parse_int"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d695b79916a2c08bcff7be7647ab60d1402885265005a6658ffe6d763553c5a"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "pci"
@@ -638,6 +754,35 @@ checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
 dependencies = [
  "bitflags 1.3.2",
 ]
+
+[[package]]
+name = "regex"
+version = "1.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ring"
@@ -992,6 +1137,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "td-shim-tools"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "argparse",
+ "block-padding",
+ "byteorder",
+ "cfg-if",
+ "clap",
+ "der 0.4.5",
+ "env_logger",
+ "hex",
+ "log",
+ "parse_int",
+ "r-efi",
+ "regex",
+ "ring",
+ "scroll",
+ "serde",
+ "serde_json",
+ "sha2",
+ "td-layout",
+ "td-loader",
+ "td-shim",
+ "td-uefi-pi",
+ "zeroize",
+]
+
+[[package]]
 name = "td-uefi-pi"
 version = "0.1.0"
 dependencies = [
@@ -1009,6 +1183,15 @@ dependencies = [
  "scroll",
  "spin 0.9.8",
  "x86_64",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff1bc3d3f05aff0403e8ac0d92ced918ec05b666a43f83297ccef5bea8a3d449"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
     "src/migtd",
     "src/policy",
     "tests/test-td-payload",
+    "tools/migtd-hash",
     "xtask",
     ]
 

--- a/tools/migtd-hash/Cargo.toml
+++ b/tools/migtd-hash/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "migtd-hash"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+anyhow = "1.0"
+clap = { version = "4.0", features = ["derive"] }
+crypto = { path = "../../src/crypto" }
+migtd = { path = "../../src/migtd" }
+serde_json = "1.0"
+td-shim-tools = { path = "../../deps/td-shim/td-shim-tools", default-feature = false, features = ["tee"] }
+td-uefi-pi = { path = "../../deps/td-shim/td-uefi-pi" }

--- a/tools/migtd-hash/src/lib.rs
+++ b/tools/migtd-hash/src/lib.rs
@@ -1,0 +1,94 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use anyhow::{anyhow, Error, Result};
+use crypto::{hash::digest_sha384, SHA384_DIGEST_SIZE};
+use migtd::config::{CONFIG_VOLUME_SIZE, MIGTD_POLICY_FFS_GUID, MIGTD_ROOT_CA_FFS_GUID};
+use std::{
+    fs::File,
+    io::{Read, Seek, SeekFrom},
+    mem::size_of,
+};
+use td_shim_tools::tee_info_hash::{Manifest, TdInfoStruct};
+use td_uefi_pi::{fv, pi};
+
+const MIGTD_IMAGE_SIZE: u64 = 0x100_0000;
+
+pub fn calculate_servtd_hash(manifest: &[u8], mut image: File) -> Result<Vec<u8>, Error> {
+    // Initialize the configurable fields of TD info structure.
+    let manifest = serde_json::from_slice::<Manifest>(&manifest)?;
+    let mut td_info = TdInfoStruct {
+        attributes: manifest.attributes,
+        xfam: manifest.xfam,
+        mrconfig_id: manifest.mrconfigid,
+        mrowner: manifest.mrowner,
+        mrownerconfig: manifest.mrownerconfig,
+        ..Default::default()
+    };
+
+    // Calculate the MRTD with MigTD image
+    td_info.build_mrtd(&mut image, MIGTD_IMAGE_SIZE);
+    // Calculate RTMR0 and RTMR1
+    td_info.build_rtmr_with_seperator(0);
+    // Calculate RTMR2 with CFV
+    let mut cfv = vec![0u8; CONFIG_VOLUME_SIZE];
+    image.seek(SeekFrom::Start(0))?;
+    image.read(&mut cfv)?;
+    td_info.rtmr2.copy_from_slice(rtmr2(&cfv)?.as_slice());
+
+    // Convert the TD info structure to bytes.
+    let mut buffer = [0u8; size_of::<TdInfoStruct>()];
+    td_info.pack(&mut buffer);
+
+    // Calculate digest.
+    digest_sha384(&buffer).map_err(|_| anyhow!("Calculate digest"))
+}
+
+fn rtmr2(cfv: &[u8]) -> Result<Vec<u8>, Error> {
+    let policy = fv::get_file_from_fv(cfv, pi::fv::FV_FILETYPE_RAW, MIGTD_POLICY_FFS_GUID)
+        .ok_or(anyhow!("Unable to get policy from image"))?;
+    let root_ca = fv::get_file_from_fv(cfv, pi::fv::FV_FILETYPE_RAW, MIGTD_ROOT_CA_FFS_GUID)
+        .ok_or(anyhow!("Unable to get root CA from image"))?;
+
+    let mut rtmr2 = Rtmr::new();
+    rtmr2.extend_with_raw_data(policy)?;
+    rtmr2.extend_with_raw_data(root_ca)?;
+
+    Ok(rtmr2.as_bytes().to_vec())
+}
+
+struct Rtmr {
+    reg: [u8; SHA384_DIGEST_SIZE * 2],
+}
+
+impl Rtmr {
+    fn new() -> Self {
+        Self {
+            reg: [0u8; SHA384_DIGEST_SIZE * 2],
+        }
+    }
+
+    fn extend_with_raw_data(&mut self, data: &[u8]) -> Result<(), Error> {
+        let digest = calculate_digest(data)?;
+
+        self.reg[SHA384_DIGEST_SIZE..].copy_from_slice(&digest);
+        let digest = calculate_digest(&self.reg)?;
+        self.reg[..SHA384_DIGEST_SIZE].copy_from_slice(&digest);
+
+        Ok(())
+    }
+
+    fn as_bytes(&self) -> &[u8] {
+        &self.reg[..SHA384_DIGEST_SIZE]
+    }
+}
+
+fn calculate_digest(data: &[u8]) -> Result<Vec<u8>, Error> {
+    let digest = digest_sha384(data).map_err(|_| anyhow!("Calculate digest"))?;
+    if digest.len() != SHA384_DIGEST_SIZE {
+        return Err(anyhow!("Calculate digest"));
+    }
+
+    Ok(digest)
+}

--- a/tools/migtd-hash/src/main.rs
+++ b/tools/migtd-hash/src/main.rs
@@ -1,0 +1,56 @@
+// Copyright (c) 2023 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use clap::Parser;
+use migtd_hash::calculate_servtd_hash;
+use std::{
+    fs::{self, File},
+    path::PathBuf,
+    process::exit,
+};
+
+#[derive(Clone, Parser)]
+struct Config {
+    /// A json format manifest that contains values of TD info fields
+    #[clap(short, long)]
+    pub manifest: String,
+    /// Path of MigTD image file
+    #[clap(short, long)]
+    pub image: String,
+    /// Output binary of tee info hash
+    #[clap(short, long)]
+    pub output_file: Option<PathBuf>,
+}
+
+fn main() {
+    let config = Config::parse();
+
+    let image = File::open(config.image).unwrap_or_else(|e| {
+        eprintln!("Failed to open MigTD image: {}", e);
+        exit(1);
+    });
+    let manifest = fs::read(config.manifest).unwrap_or_else(|e| {
+        eprintln!("Failed to open manifest file: {}", e);
+        exit(1);
+    });
+
+    let hash = calculate_servtd_hash(&manifest, image).unwrap_or_else(|e| {
+        eprintln!("Failed to calculate hash: {:?}", e);
+        exit(1);
+    });
+
+    if let Some(output_file) = config.output_file {
+        fs::write(output_file, &hash).unwrap_or_else(|e| {
+            eprintln!("Failed to write output file: {}", e);
+            exit(1);
+        })
+    } else {
+        println!(
+            "{}",
+            hash.iter()
+                .map(|byte| format!("{:02x}", byte))
+                .collect::<String>()
+        )
+    }
+}

--- a/xtask/src/servtd_info_hash.rs
+++ b/xtask/src/servtd_info_hash.rs
@@ -16,7 +16,6 @@ lazy_static! {
         Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap();
     static ref DEFAULT_OUTPUT: PathBuf = PROJECT_ROOT.join("migtd.servtd_info_hash");
     static ref DEFAULT_SERVTD_INFO: PathBuf = PROJECT_ROOT.join("config/servtd_info.json");
-    static ref SHIM_FOLDER: PathBuf = PROJECT_ROOT.join("deps/td-shim");
 }
 
 #[derive(Clone, Args)]
@@ -32,17 +31,12 @@ pub(crate) struct ServtdInfoHashArgs {
 impl ServtdInfoHashArgs {
     pub fn generate(&self) -> Result<()> {
         let sh = Shell::new()?;
-        sh.change_dir(SHIM_FOLDER.as_path());
-        let cmd = cmd!(
-            sh,
-            "cargo run -p td-shim-tools --bin td-shim-tee-info-hash --features tee -- "
-        )
-        .args(&["-l", "off"])
-        .args(&["--image", self.image()?.to_str().unwrap()])
-        .args(&["--manifest", self.servtd_info()?.to_str().unwrap()]);
+        let cmd = cmd!(sh, "cargo run -p migtd-hash  -- ")
+            .args(&["--image", self.image()?.to_str().unwrap()])
+            .args(&["--manifest", self.servtd_info()?.to_str().unwrap()]);
 
         let cmd = if self.output.is_some() {
-            cmd.args(&["--out_bin", self.output()?.to_str().unwrap()])
+            cmd.args(&["--output-file", self.output()?.to_str().unwrap()])
         } else {
             cmd
         };


### PR DESCRIPTION
`sertd-hash` is used to calculate `TEE_INFO_HASH` of migtd using migtd image and configuration manifest.

`td-shim/td-shim-tools` is used to calculate mrtd and rtmr[0-1] and extended to calculate the rtmr2 which is used by migtd.

Closes https://github.com/intel/MigTD/issues/86