### PR TITLE
deps: upgrade td-shim to close the security alert

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,17 +101,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -371,12 +360,12 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "env_logger"
-version = "0.9.3"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
+checksum = "95b3f3e67048839cb0d0781f445682a35113da7121f7c949db0e2be96a4fbece"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -430,12 +419,9 @@ checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
+checksum = "d77f7ec81a6d05a3abb01ab6eb7590f6083d08449fe5a1c8b1e620283546ccb7"
 
 [[package]]
 name = "hex"
@@ -460,6 +446,17 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "itoa"
@@ -786,7 +783,7 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "ring"
-version = "0.17.5"
+version = "0.17.6"
 dependencies = [
  "cc",
  "getrandom",

--- a/deps/patches/rustls.diff
+++ b/deps/patches/rustls.diff
@@ -1,5 +1,5 @@
 diff --git a/rustls/Cargo.toml b/rustls/Cargo.toml
-index bc8b5e77..35f3bc86 100644
+index bc8b5e77..de05409d 100644
 --- a/rustls/Cargo.toml
 +++ b/rustls/Cargo.toml
 @@ -18,14 +18,18 @@ rustversion = { version = "1.0.6", optional = true }
@@ -7,7 +7,7 @@ index bc8b5e77..35f3bc86 100644
  aws-lc-rs = { version = "1.5", optional = true }
  log = { version = "0.4.4", optional = true }
 -ring = { version = "0.17", optional = true }
-+ring = { version = "0.17", features = ["alloc"], default-features = false, optional = true }
++ring = { version = "0.17", features = ["alloc", "less-safe-getrandom-custom-or-rdrand"], default-features = false, optional = true }
  subtle = { version = "2.5.0", default-features = false }
 -webpki = { package = "rustls-webpki", version = "0.102", features = ["std"], default-features = false }
 -pki-types = { package = "rustls-pki-types", version = "1", features = ["std"] }


### PR DESCRIPTION
Crates `env_logger` and `clap` are upgraded to remove the dependency `atty`.