### PR TITLE
config: fix format of `policy_production_fmspc.json`

### DIFF
--- a/config/policy_production_fmspc.json
+++ b/config/policy_production_fmspc.json
@@ -10,11 +10,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[1, 1, 2, 2, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [1, 1, 2, 2, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -29,11 +29,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[6, 6, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [6, 6, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -48,11 +48,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[1, 1, 2, 2, 2, 255, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [1, 1, 2, 2, 2, 255, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -67,11 +67,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[1, 1, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [1, 1, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -86,11 +86,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[6, 6, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [6, 6, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -105,11 +105,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[2, 2, 2, 2, 2, 255, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [2, 2, 2, 2, 2, 255, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -124,11 +124,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[62, 62, 0, 0, 1, 255, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [62, 62, 0, 0, 1, 255, 0, 2, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -143,11 +143,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[1, 1, 2, 2, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [1, 1, 2, 2, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -162,11 +162,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[6, 6, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [6, 6, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -181,11 +181,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[1, 1, 2, 2, 2, 255, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [1, 1, 2, 2, 2, 255, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -200,11 +200,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[1, 1, 2, 2, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [1, 1, 2, 2, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -219,11 +219,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[6, 6, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [6, 6, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -238,11 +238,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[1, 1, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [1, 1, 2, 2, 3, 1, 0, 3, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },
@@ -257,11 +257,11 @@
                     },
                     "sgxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[1, 1, 2, 2, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [1, 1, 2, 2, 1, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0]
                     },
                     "tdxtcbcomponents": {
                         "operation": "array-greater-or-equal",
-                        "reference": "[3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]"
+                        "reference": [3, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
                     }
                 }
             },


### PR DESCRIPTION
Use array instead of string for reference of `sgxtcbcomponents`and `tdxtcbcomponents`.

Fix: https://github.com/intel/MigTD/issues/118