### PR TITLE
migtd: set `MIG_VERSION` before programming MSK

### DIFF
--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -7,7 +7,11 @@ use core::mem::size_of;
 use scroll::Pread;
 use td_payload::mm::shared::SharedMemory;
 use td_uefi_pi::hob as hob_lib;
-use tdx_tdcall::tdx;
+use tdx_tdcall::{
+    td_call,
+    tdx::{self, tdcall_servtd_wr},
+    TdcallArgs,
+};
 use zerocopy::AsBytes;
 
 type Result<T> = core::result::Result<T, MigrationResult>;
@@ -15,9 +19,15 @@ type Result<T> = core::result::Result<T, MigrationResult>;
 use super::{data::*, *};
 use crate::ratls;
 
+const TDCALL_STATUS_SUCCESS: u64 = 0;
 const TDCS_FIELD_MIG_DEC_KEY: u64 = 0x9810_0003_0000_0010;
 const TDCS_FIELD_MIG_ENC_KEY: u64 = 0x9810_0003_0000_0018;
-const MSK_SIZE: usize = 32;
+const TDCS_FIELD_MIG_VERSION: u64 = 0x9810_0001_0000_0020;
+// TDX Module global-scope metadata field
+const GSM_FIELD_MIN_EXPORT_VERSION: u64 = 0x2000000100000001;
+const GSM_FIELD_MAX_EXPORT_VERSION: u64 = 0x2000000100000002;
+const GSM_FIELD_MIN_IMPORT_VERSION: u64 = 0x2000000100000003;
+const GSM_FIELD_MAX_IMPORT_VERSION: u64 = 0x2000000100000004;
 
 pub struct MigrationInformation {
     pub mig_info: MigtdMigrationInformation,
@@ -25,10 +35,42 @@ pub struct MigrationInformation {
     pub mig_policy: Option<MigtdMigpolicy>,
 }
 
+impl MigrationInformation {
+    pub fn is_src(&self) -> bool {
+        self.mig_info.migration_source == 1
+    }
+}
+
 #[derive(Debug, Clone, Copy)]
 struct RequestInformation {
     request_id: u64,
     operation: u8,
+}
+
+struct ExchangeInformation {
+    min_ver: u16,
+    max_ver: u16,
+    key: MigrationSessionKey,
+}
+
+impl Default for ExchangeInformation {
+    fn default() -> Self {
+        Self {
+            key: MigrationSessionKey::new(),
+            min_ver: 0,
+            max_ver: 0,
+        }
+    }
+}
+
+impl ExchangeInformation {
+    fn as_bytes(&self) -> &[u8] {
+        unsafe { core::slice::from_raw_parts(self as *const Self as *const u8, size_of::<Self>()) }
+    }
+
+    fn as_bytes_mut(&mut self) -> &mut [u8] {
+        unsafe { core::slice::from_raw_parts_mut(self as *mut Self as *mut u8, size_of::<Self>()) }
+    }
 }
 
 enum MigrationState {
@@ -277,7 +319,6 @@ impl MigrationSession {
 
     fn migrate(info: &MigrationInformation) -> Result<()> {
         let mut msk = MigrationSessionKey::new();
-        let mut msk_peer = MigrationSessionKey::new();
 
         for idx in 0..msk.fields.len() {
             let ret = tdx::tdcall_servtd_rd(
@@ -312,42 +353,67 @@ impl MigrationSession {
             transport = vsock;
         };
 
+        let mut remote_information = ExchangeInformation::default();
+        let mut exchange_information = ExchangeInformation {
+            key: msk,
+            ..Default::default()
+        };
+
         // Establish TLS layer connection and negotiate the MSK
-        if info.mig_info.migration_source == 1 {
+        if info.is_src() {
+            let min_export_version = tdcall_sys_rd(GSM_FIELD_MIN_EXPORT_VERSION)?.1;
+            let max_export_version = tdcall_sys_rd(GSM_FIELD_MAX_EXPORT_VERSION)?.1;
+            if min_export_version > u16::MAX as u64 || max_export_version > u16::MAX as u64 {
+                return Err(MigrationResult::InvalidParameter);
+            }
+            exchange_information.min_ver = min_export_version as u16;
+            exchange_information.max_ver = max_export_version as u16;
+
             // TLS client
             let mut ratls_client =
                 ratls::client(transport).map_err(|_| MigrationResult::SecureSessionError)?;
 
             // MigTD-S send Migration Session Forward key to peer
-            ratls_client.write(msk.as_bytes())?;
-            let size = ratls_client.read(msk_peer.as_bytes_mut())?;
-            if size < MSK_SIZE {
+            ratls_client.write(exchange_information.as_bytes())?;
+            let size = ratls_client.read(remote_information.as_bytes_mut())?;
+            if size < size_of::<ExchangeInformation>() {
                 return Err(MigrationResult::NetworkError);
             }
         } else {
+            let min_import_version = tdcall_sys_rd(GSM_FIELD_MIN_IMPORT_VERSION)?.1;
+            let max_import_version = tdcall_sys_rd(GSM_FIELD_MAX_IMPORT_VERSION)?.1;
+            if min_import_version > u16::MAX as u64 || max_import_version > u16::MAX as u64 {
+                return Err(MigrationResult::InvalidParameter);
+            }
+            exchange_information.min_ver = min_import_version as u16;
+            exchange_information.max_ver = max_import_version as u16;
+
             // TLS server
             let mut ratls_server =
                 ratls::server(transport).map_err(|_| MigrationResult::SecureSessionError)?;
 
-            ratls_server.write(msk.as_bytes())?;
-            let size = ratls_server.read(msk_peer.as_bytes_mut())?;
-            if size < MSK_SIZE {
+            ratls_server.write(exchange_information.as_bytes())?;
+            let size = ratls_server.read(remote_information.as_bytes_mut())?;
+            if size < size_of::<ExchangeInformation>() {
                 return Err(MigrationResult::NetworkError);
             }
         }
 
-        for idx in 0..msk.fields.len() {
+        let mig_ver = cal_mig_version(info.is_src(), &exchange_information, &remote_information)?;
+        set_mig_version(&info, mig_ver)?;
+
+        for idx in 0..remote_information.key.fields.len() {
             tdx::tdcall_servtd_wr(
                 info.mig_info.binding_handle,
                 TDCS_FIELD_MIG_DEC_KEY + idx as u64,
-                msk_peer.fields[idx],
+                remote_information.key.fields[idx],
                 &info.mig_info.target_td_uuid,
             )
             .map_err(|_| MigrationResult::TdxModuleError)?;
         }
         log::info!("Set MSK and report status\n");
-        msk.clear();
-        msk_peer.clear();
+        exchange_information.key.clear();
+        remote_information.key.clear();
 
         Ok(())
     }
@@ -399,5 +465,136 @@ impl MigrationSession {
         let mut private = Vec::new();
         private.extend_from_slice(shared);
         private
+    }
+}
+
+/// Used to read a TDX Module global-scope metadata field.
+///
+/// Details can be found in TDX Module v1.5 ABI spec section 'TDG.SYS.RD Leaf'.
+pub fn tdcall_sys_rd(field_identifier: u64) -> core::result::Result<(u64, u64), TdCallError> {
+    const TDVMCALL_SYS_RD: u64 = 0x0000b;
+
+    let mut args = TdcallArgs {
+        rax: TDVMCALL_SYS_RD,
+        rdx: field_identifier,
+        ..Default::default()
+    };
+
+    let ret = td_call(&mut args);
+
+    if ret != TDCALL_STATUS_SUCCESS {
+        return Err(ret.into());
+    }
+
+    Ok((args.rdx, args.r8))
+}
+
+fn cal_mig_version(
+    is_src: bool,
+    local_info: &ExchangeInformation,
+    remote_info: &ExchangeInformation,
+) -> Result<u16> {
+    let (min_export, max_export, min_import, max_import) = if is_src {
+        (
+            local_info.min_ver,
+            local_info.max_ver,
+            remote_info.min_ver,
+            remote_info.max_ver,
+        )
+    } else {
+        (
+            remote_info.min_ver,
+            remote_info.max_ver,
+            local_info.min_ver,
+            local_info.max_ver,
+        )
+    };
+
+    if min_export > max_export
+        || min_import > max_import
+        || max_export < min_import
+        || max_import < min_export
+    {
+        return Err(MigrationResult::InvalidParameter);
+    }
+
+    Ok(core::cmp::min(max_export, max_import))
+}
+
+fn set_mig_version(info: &MigrationInformation, mig_ver: u16) -> Result<()> {
+    tdcall_servtd_wr(
+        info.mig_info.binding_handle,
+        TDCS_FIELD_MIG_VERSION,
+        mig_ver as u64,
+        &info.mig_info.target_td_uuid,
+    )?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use crate::migration::{session::cal_mig_version, MigrationResult};
+
+    use super::ExchangeInformation;
+
+    #[test]
+    fn test_cal_mig_version() {
+        let mut local_info = ExchangeInformation::default();
+        let mut remote_info = ExchangeInformation::default();
+
+        // local: [0, 0], remote: [0, 0]
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Ok(0)));
+
+        // local: [1, 0], remote: [0, 0]
+        local_info.min_ver = 1;
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Err(MigrationResult::InvalidParameter)));
+
+        // local: [0, 0], remote: [1, 0]
+        local_info.min_ver = 0;
+        remote_info.min_ver = 1;
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Err(MigrationResult::InvalidParameter)));
+
+        // local: [4, 4], remote: [1, 3]
+        remote_info.max_ver = 3;
+        local_info.min_ver = 4;
+        local_info.max_ver = 4;
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Err(MigrationResult::InvalidParameter)));
+
+        // local: [4, 4], remote: [5, 6]
+        remote_info.min_ver = 5;
+        remote_info.max_ver = 6;
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Err(MigrationResult::InvalidParameter)));
+
+        // local: [4, 5], remote: [5, 6]
+        local_info.max_ver = 5;
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Ok(5)));
+
+        // local: [4, 6], remote: [5, 6]
+        local_info.max_ver = 6;
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Ok(6)));
+
+        // local: [5, 5], remote: [5, 6]
+        local_info.min_ver = 5;
+        local_info.max_ver = 5;
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Ok(5)));
+
+        // local: [5, 6], remote: [5, 6]
+        local_info.max_ver = 6;
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Ok(6)));
+
+        // local: [6, 7], remote: [5, 6]
+        local_info.min_ver = 6;
+        local_info.max_ver = 7;
+        let result = cal_mig_version(true, &local_info, &remote_info);
+        assert!(matches!(result, Ok(6)));
     }
 }


### PR DESCRIPTION
MigTD-s and MigTD-d exchange their MSK together with the version information and then they will evaluate the versions.

If there are one or more versions that meet both requirements, they will set the maximum one, otherwise the pre-migration flow will abort.

Closes https://github.com/intel/MigTD/issues/103