### PR TITLE
upgrade rust nightly version

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2023-08-28
+          toolchain: nightly-2023-12-31
           override: true
           components: clippy
 
@@ -65,7 +65,7 @@ jobs:
         uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2023-08-28
+          toolchain: nightly-2023-12-31
           override: true
           components: rustfmt
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -13,7 +13,7 @@ env:
   AS: nasm
   AR_x86_64_unknown_none: llvm-ar
   CC_x86_64_unknown_none: clang
-  RUST_TOOLCHAIN: nightly-2023-08-28
+  RUST_TOOLCHAIN: nightly-2023-12-31
   TOOLCHAIN_PROFILE: minimal
   AFL_NO_AFFINITY: 1
 
@@ -32,7 +32,7 @@ jobs:
           submodules: recursive
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly-2023-08-28
+          toolchain: nightly-2023-12-31
           profile: minimal
           override: true
           components: rust-src, llvm-tools-preview

--- a/.github/workflows/integration-tdx.yml
+++ b/.github/workflows/integration-tdx.yml
@@ -11,7 +11,7 @@ name: Integration Test on TDX Server
 
 env:
   AS: nasm
-  RUST_TOOLCHAIN: nightly-2023-08-28
+  RUST_TOOLCHAIN: nightly-2023-12-31
   TOOLCHAIN_PROFILE: minimal
 
 jobs:

--- a/.github/workflows/library.yml
+++ b/.github/workflows/library.yml
@@ -13,7 +13,7 @@ env:
   AS: nasm
   AR: llvm-ar
   CC: clang
-  NIGHTLY_RUST_TOOLCHAIN: nightly-2023-08-28
+  NIGHTLY_RUST_TOOLCHAIN: nightly-2023-12-31
   TOOLCHAIN_PROFILE: minimal
 
 jobs:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ name: main
 
 env:
   AS: nasm
-  RUST_TOOLCHAIN: nightly-2023-08-28
+  RUST_TOOLCHAIN: nightly-2023-12-31
   TOOLCHAIN_PROFILE: minimal
 
 jobs:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1447,14 +1447,15 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "which"
-version = "4.4.2"
+version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+checksum = "9bf3ea8596f3a0dd5980b46430f2058dfe2c36a27ccfbb1845d6fbfcd9ba6e14"
 dependencies = [
  "either",
  "home",
  "once_cell",
  "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -1604,9 +1605,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
 dependencies = [
  "byteorder",
  "zerocopy-derive",
@@ -1614,9 +1615,9 @@ dependencies = [
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.6.6"
+version = "0.7.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install rustup and a fixed version of Rust.
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2023-08-28
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2023-12-31
 RUN rustup component add rust-src
 RUN cargo install cargo-xbuild
 

--- a/readme.md
+++ b/readme.md
@@ -24,8 +24,8 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
 ```
 * Install toolchain and components required by MigTD:
 ```
-rustup toolchain install nightly-2023-08-28
-rustup component add --toolchain nightly-2023-08-28 rust-src
+rustup toolchain install nightly-2023-12-31
+rustup component add --toolchain nightly-2023-12-31 rust-src
 cargo install cargo-xbuild
 ```
 

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "nightly-2023-08-28"
+channel = "nightly-2023-12-31"

--- a/src/devices/pci/src/lib.rs
+++ b/src/devices/pci/src/lib.rs
@@ -2,7 +2,6 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
-#![feature(core_intrinsics)]
 #![cfg_attr(not(test), no_std)]
 
 mod config;

--- a/src/devices/vsock/src/transport/event.rs
+++ b/src/devices/vsock/src/transport/event.rs
@@ -5,7 +5,7 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 pub use td_payload::arch::apic::*;
 use td_payload::arch::idt::register;
-pub use td_payload::{eoi, interrupt_handler_template};
+pub use td_payload::interrupt_handler_template;
 
 use crate::VsockTimeout;
 

--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -35,7 +35,7 @@ vsock = { path="../devices/vsock" }
 virtio_serial = { path="../devices/virtio_serial", optional = true }
 x86 = "0.47.0"
 x86_64 = "0.14.9"
-zerocopy = "0.6"
+zerocopy = { version = "0.7", features = ["derive"] }
 base64 = { version = "0.21.5", default-features = false, features = ["alloc"] }
 
 minicov = { version = "0.2", default-features = false, optional = true }

--- a/src/migtd/src/migration/data.rs
+++ b/src/migtd/src/migration/data.rs
@@ -5,7 +5,7 @@
 use core::convert::TryInto;
 use core::{mem::size_of, slice::from_raw_parts, slice::from_raw_parts_mut};
 use r_efi::efi::Guid;
-use zerocopy::{AsBytes, FromBytes};
+use zerocopy::{AsBytes, FromBytes, FromZeroes};
 
 use super::MigrationResult;
 
@@ -148,7 +148,7 @@ impl<'a> VmcallServiceResponse<'a> {
 }
 
 #[repr(packed)]
-#[derive(Debug, FromBytes, AsBytes)]
+#[derive(Debug, FromZeroes, FromBytes, AsBytes)]
 pub struct ServiceQueryResponse {
     pub version: u8,
     pub command: u8,
@@ -158,7 +158,7 @@ pub struct ServiceQueryResponse {
 }
 
 #[repr(packed)]
-#[derive(FromBytes, AsBytes)]
+#[derive(FromZeroes, FromBytes, AsBytes)]
 pub struct ServiceMigWaitForReqResponse {
     pub version: u8,
     pub command: u8,
@@ -167,7 +167,7 @@ pub struct ServiceMigWaitForReqResponse {
 }
 
 #[repr(packed)]
-#[derive(FromBytes, AsBytes)]
+#[derive(FromZeroes, FromBytes, AsBytes)]
 pub struct ServiceMigWaitForReqShutdown {
     pub version: u8,
     pub command: u8,
@@ -175,7 +175,7 @@ pub struct ServiceMigWaitForReqShutdown {
 }
 
 #[repr(packed)]
-#[derive(FromBytes, AsBytes)]
+#[derive(FromZeroes, FromBytes, AsBytes)]
 pub struct ServiceMigReportStatusResponse {
     pub version: u8,
     pub command: u8,

--- a/tests/test-td-payload/Cargo.toml
+++ b/tests/test-td-payload/Cargo.toml
@@ -27,7 +27,7 @@ tdx-tdcall = { path = "../../deps/td-shim/tdx-tdcall" , optional = true }
 scroll = { version = "0.10.0", default-features = false, features = ["derive"]}
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
-zerocopy = "0.6.0"
+zerocopy = { version = "0.7", features = ["derive"] }
 
 minicov = { version = "0.2", default-features = false, optional = true }
 


### PR DESCRIPTION
Fix the `AFL` issue:

```
error[E0599]: no function or associated item named `from_encoded_bytes_unchecked` found for struct `OsStr` in the current scope
Error:    --> /home/runner/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_lex-0.7.0/src/ext.rs:282:16
    |
282 |         OsStr::from_encoded_bytes_unchecked(second),
    |                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `OsStr`

For more information about this error, try `rustc --explain E0599`.
```