### PR TITLE
Update script to support v8.0+ QEMU

### DIFF
--- a/sh_script/test/mig-td.sh
+++ b/sh_script/test/mig-td.sh
@@ -75,7 +75,6 @@ QEMU_CMD="${QEMU_EXEC} \
 -smp 1,threads=1,sockets=1 \
 -m 32M \
 -object tdx-guest,id=tdx0,sept-ve-disable=off,debug=off,quote-generation-service=vsock:1:4050 \
--object memory-backend-memfd-private,id=ram1,size=32M \
 -machine q35,memory-backend=ram1,confidential-guest-support=tdx0,kernel_irqchip=split \
 -bios ${MIGTD} \
 -name migtd-${MIGTD_TYPE},process=migtd-${MIGTD_TYPE},debug-threads=on \
@@ -83,6 +82,14 @@ QEMU_CMD="${QEMU_EXEC} \
 -nographic -vga none -nic none \
 -serial mon:stdio \
 -pidfile /var/run/migtd-${MIGTD_TYPE}.pid"
+
+    QEMU_VERSION=`${QEMU_EXEC} --version | grep -oP 'version \K[^\s]+'`
+    if [ "$(printf '%s\n' "8.0.0" "${QEMU_VERSION}" | sort -V | head -n1)" == "8.0.0" ]; then
+        QEMU_CMD+=" -object memory-backend-ram,id=ram1,size=32M,private=on "
+    else
+        QEMU_CMD+=" -object memory-backend-memfd-private,id=ram1,size=32M "
+    fi
+
     if [[ $NO_DEVICE != true ]]; then
         if [[ ${VIRTIO_SERIAL} == true ]]; then
             QEMU_CMD+=" -device virtio-serial-pci,id=virtio-serial0 "

--- a/sh_script/test/user-td.sh
+++ b/sh_script/test/user-td.sh
@@ -140,7 +140,6 @@ QEMU_CMD="${QEMU_EXEC} \
 -cpu host,pmu=off,-kvm-steal-time,-shstk,tsc-freq=1000000000 \
 -smp 2,threads=1,sockets=1 \
 -m 8G \
--object memory-backend-memfd-private,id=ram1,size=8G \
 -machine q35,memory-backend=ram1,confidential-guest-support=tdx0,kernel_irqchip=split \
 -bios ${OVMF} \
 -chardev stdio,id=mux,mux=on,logfile=lm-${TD_TYPE}.log \
@@ -153,6 +152,13 @@ QEMU_CMD="${QEMU_EXEC} \
 -device virtio-serial,romfile= \
 -device virtconsole,chardev=mux -serial chardev:mux -monitor chardev:mux"
 OBJ_SUBCOMMAND=" -object tdx-guest,id=tdx0,sept-ve-disable=on,debug=off"
+
+    QEMU_VERSION=`${QEMU_EXEC} --version | grep -oP 'version \K[^\s]+'`
+    if [ "$(printf '%s\n' "8.0.0" "${QEMU_VERSION}" | sort -V | head -n1)" == "8.0.0" ]; then
+        QEMU_CMD+=" -object memory-backend-ram,id=ram1,size=8G,private=on "
+    else
+        QEMU_CMD+=" -object memory-backend-memfd-private,id=ram1,size=8G "
+    fi
 
     if [[ ${PRE_BINDING} == "true" ]]; then
         OBJ_SUBCOMMAND+=",migtd-hash=${SERVTD_HASH},migtd-attr=0x0000000000000001"


### PR DESCRIPTION
This PR used to support v8.0+ qemu
```
The v8.1 qemu uses different command line arguments:
-object memory-backend-memfd-private,id=ram1,size=${mem} \
-machine q35,kernel_irqchip=split,memory-encryption=tdx,memory-backend=ram1 \
Changes to:

-object memory-backend-ram,id=mem0,size=${mem},private=on \
-machine q35,kernel_irqchip=split,memory-encryption=tdx,memory-backend=mem0 \
```