### PR TITLE
Close warnings reported by Clippy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -760,6 +760,7 @@ dependencies = [
  "cc-measurement",
  "crypto",
  "lexical-core",
+ "log",
  "serde",
  "serde_json",
  "td-shim",

--- a/src/attestation/build.rs
+++ b/src/attestation/build.rs
@@ -30,13 +30,13 @@ fn main() {
 
     // make servtd_attest_preparation
     Command::new("make")
-        .args(&["-C", &lib_path, "servtd_attest_preparation"])
+        .args(["-C", &lib_path, "servtd_attest_preparation"])
         .status()
         .expect("failed to run make servtd_attest_preparation for attestation library!");
 
     // make servtd_attest
     Command::new("make")
-        .args(&["-C", &lib_path, "servtd_attest"])
+        .args(["-C", &lib_path, "servtd_attest"])
         .status()
         .expect("failed to run make servtd_attest for attestation library!");
 

--- a/src/attestation/src/attest.rs
+++ b/src/attestation/src/attest.rs
@@ -40,7 +40,7 @@ pub fn get_quote(td_report: &[u8]) -> Result<Vec<u8>, Error> {
             quote.as_mut_ptr() as *mut c_void,
             &mut quote_size as *mut u32,
         );
-        if result != AttestLibError::MigtdAttestSuccess {
+        if result != AttestLibError::Success {
             return Err(Error::GetQuote);
         }
     }
@@ -72,7 +72,7 @@ pub fn verify_quote(quote: &[u8]) -> Result<Vec<u8>, Error> {
             td_report_verify.as_mut_ptr() as *mut c_void,
             &mut report_verify_size as *mut u32,
         );
-        if result != AttestLibError::MigtdAttestSuccess {
+        if result != AttestLibError::Success {
             return Err(Error::VerifyQuote);
         }
     }

--- a/src/attestation/src/binding.rs
+++ b/src/attestation/src/binding.rs
@@ -7,29 +7,29 @@
 #[derive(Debug, PartialEq)]
 pub(crate) enum AttestLibError {
     /// Success
-    MigtdAttestSuccess = 0x0000,
+    Success = 0x0000,
     /// Unexpected error
-    MigtdAttestErrorUnexpected = 0x0001,
+    Unexpected = 0x0001,
     /// The parameter is incorrect
-    MigtdAttestErrorInvalidParameter = 0x0002,
+    InvalidParameter = 0x0002,
     /// Not enough memory is available to complete this operation
-    MigtdAttestErrorOutOfMemory = 0x0003,
+    OutOfMemory = 0x0003,
     /// vsock related failure
-    MigtdAttestErrorVsockFailure = 0x0004,
+    VsockFailure = 0x0004,
     /// Failed to get the TD Report
-    MigtdAttestErrorReportFailure = 0x0005,
+    ReportFailure = 0x0005,
     /// Failed to extend rtmr
-    MigtdAttestErrorExtendFailure = 0x0006,
+    ExtendFailure = 0x0006,
     /// Request feature is not supported
-    MigtdAttestErrorNotSupported = 0x0007,
+    NotSupported = 0x0007,
     /// Failed to get the TD Quote
-    MigtdAttestErrorQuoteFailure = 0x0008,
+    QuoteFailure = 0x0008,
     /// The device driver return busy
-    MigtdAttestErrorBusy = 0x0009,
+    Busy = 0x0009,
     /// Failed to acess tdx attest device
-    MigtdAttestErrorDeviceFailure = 0x000a,
+    DeviceFailure = 0x000a,
     /// Only supported RTMR index is 2 and 3
-    MigtdAttestErrorInvalidRtmrIndex = 0x000b,
+    InvalidRtmrIndex = 0x000b,
 }
 
 extern "C" {

--- a/src/crypto/src/x509.rs
+++ b/src/crypto/src/x509.rs
@@ -99,17 +99,17 @@ impl<'a> Certificate<'a> {
         let mut country_name = SetOfVec::new();
         country_name.add(DistinguishedName {
             attribute_type: ObjectIdentifier::new("2.5.4.6"),
-            value: PrintableString::new("XX")?.try_into().unwrap(),
+            value: PrintableString::new("XX")?.into(),
         })?;
         let mut locality_name = SetOfVec::new();
         locality_name.add(DistinguishedName {
             attribute_type: ObjectIdentifier::new("2.5.4.7"),
-            value: Utf8String::new("Default City")?.try_into().unwrap(),
+            value: Utf8String::new("Default City")?.into(),
         })?;
         let mut organization_name = SetOfVec::new();
         organization_name.add(DistinguishedName {
             attribute_type: ObjectIdentifier::new("2.5.4.10"),
-            value: Utf8String::new("Default Company Ltd")?.try_into().unwrap(),
+            value: Utf8String::new("Default Company Ltd")?.into(),
         })?;
 
         let issuer = vec![country_name, locality_name, organization_name];

--- a/src/devices/pci/src/config.rs
+++ b/src/devices/pci/src/config.rs
@@ -355,18 +355,13 @@ pub struct PciDevice {
     pub interrup_line: u8,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Copy)]
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum PciBarType {
+    #[default]
     Unused,
     MemorySpace32,
     MemorySpace64,
     IoSpace,
-}
-
-impl Default for PciBarType {
-    fn default() -> Self {
-        PciBarType::Unused
-    }
 }
 
 #[derive(Default, Debug, Clone, PartialEq, Eq, Copy)]

--- a/src/devices/virtio_serial/src/event.rs
+++ b/src/devices/virtio_serial/src/event.rs
@@ -5,7 +5,7 @@
 use core::sync::atomic::{AtomicBool, Ordering};
 pub use td_payload::arch::apic::*;
 use td_payload::arch::idt::register;
-pub use td_payload::{eoi, interrupt_handler_template};
+pub use td_payload::interrupt_handler_template;
 
 use crate::Timer;
 

--- a/src/devices/virtio_serial/src/lib.rs
+++ b/src/devices/virtio_serial/src/lib.rs
@@ -755,9 +755,7 @@ impl VirtioSerial {
             .borrow_mut()
             .pop_used(&mut g2h, &mut h2g)?;
 
-        *self
-            .receive_queues_prefill
-            .index_mut(queue_idx as usize / 2) -= h2g.len();
+        *self.receive_queues_prefill.index_mut(queue_idx / 2) -= h2g.len();
         self.receive_data(port_id, &h2g, len)?;
         self.fill_port_queue(port_id)?;
 

--- a/src/devices/virtio_serial/src/port.rs
+++ b/src/devices/virtio_serial/src/port.rs
@@ -77,7 +77,7 @@ impl VirtioSerialPort {
             let front = self.cache.front_mut().unwrap();
             let expect = data.len() - recvd;
             if front.len() <= expect {
-                data[..front.len()].copy_from_slice(&front);
+                data[..front.len()].copy_from_slice(front);
                 recvd += front.len();
                 self.cache.pop_front();
             } else {

--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -45,7 +45,7 @@ td-benchmark = { path = "../../deps/td-shim/devtools/td-benchmark", default-feat
 default = ["tdx"]
 cet-shstk = ["td-payload/cet-shstk"]
 coverage = ["minicov"]
-main = ["tdx"]
+main = ["tdx", "policy/log"]
 stack-guard = ["td-payload/stack-guard"]
 virtio-vsock = ["vsock/virtio-vsock"]
 virtio-serial = ["virtio_serial"]

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -402,7 +402,7 @@ impl MigrationSession {
         }
 
         let mig_ver = cal_mig_version(info.is_src(), &exchange_information, &remote_information)?;
-        set_mig_version(&info, mig_ver)?;
+        set_mig_version(info, mig_ver)?;
 
         for idx in 0..remote_information.key.fields.len() {
             tdx::tdcall_servtd_wr(

--- a/src/policy/Cargo.toml
+++ b/src/policy/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 cc-measurement = { path = "../../deps/td-shim/cc-measurement"}
 crypto = { path = "../crypto" }
 lexical-core = { version = "0.8.3", default-features = false, features = ["write-integers", "write-floats", "parse-integers", "parse-floats"] }
+log = { version = "0.4.13", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 td-shim = { path = "../../deps/td-shim/td-shim", default-features = false }

--- a/src/policy/src/lib.rs
+++ b/src/policy/src/lib.rs
@@ -8,7 +8,7 @@ extern crate alloc;
 mod config;
 mod verify;
 
-use alloc::{format, string::String};
+use alloc::string::String;
 pub use config::*;
 pub use verify::*;
 
@@ -21,39 +21,9 @@ pub enum PolicyError {
     InvalidEventLog,
     PlatformNotFound(String),
     PlatformNotMatch(String, String),
-    UnqulifiedPlatformInfo(PolicyErrorDetails),
-    UnqulifiedQeInfo(PolicyErrorDetails),
-    UnqulifiedTdxModuleInfo(PolicyErrorDetails),
-    UnqulifiedMigTdInfo(PolicyErrorDetails),
+    UnqulifiedPlatformInfo,
+    UnqulifiedQeInfo,
+    UnqulifiedTdxModuleInfo,
+    UnqulifiedMigTdInfo,
     Crypto,
-}
-
-#[derive(Debug)]
-pub struct PolicyErrorDetails {
-    pub property: String,
-    pub policy: Property,
-    pub local_fmspc: Option<String>,
-    pub remote_fmspc: Option<String>,
-    pub local: String,
-    pub remote: String,
-}
-
-impl PolicyErrorDetails {
-    pub(crate) fn new(
-        property: String,
-        policy: Property,
-        local_fmspc: Option<String>,
-        remote_fmspc: Option<String>,
-        local: &[u8],
-        remote: &[u8],
-    ) -> Self {
-        Self {
-            property,
-            policy,
-            local: format!("{:x?}", local),
-            remote: format!("{:x?}", remote),
-            local_fmspc,
-            remote_fmspc,
-        }
-    }
 }


### PR DESCRIPTION
Warning types:
 - the Err-variant returned from this function is very large
 - unused import
 - use of a fallible conversion when an infallible one could be used
 - the borrowed expression implements the required traits
 - all variants have the same prefix
 - comparing with null is better expressed by the .is_null() method
 - casting to the same type is unnecessary
 - this expression creates a reference which is immediately dereferenced by the compiler
 - this impl can be derived 