### PR TITLE
upgrade td-shim submodule and use the shared memory shadow provided by `td-payload`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,8 +647,7 @@ dependencies = [
  "td-logger",
  "td-paging",
  "td-payload",
- "td-shim",
- "td-uefi-pi",
+ "td-shim-interface",
  "tdx-tdcall",
  "virtio",
  "virtio_serial",
@@ -667,8 +666,8 @@ dependencies = [
  "crypto",
  "migtd",
  "serde_json",
+ "td-shim-interface",
  "td-shim-tools",
- "td-uefi-pi",
 ]
 
 [[package]]
@@ -764,7 +763,7 @@ dependencies = [
  "serde",
  "serde_json",
  "td-shim",
- "td-uefi-pi",
+ "td-shim-interface",
 ]
 
 [[package]]
@@ -1153,7 +1152,7 @@ version = "0.1.0"
 dependencies = [
  "log",
  "scroll",
- "td-uefi-pi",
+ "td-shim-interface",
 ]
 
 [[package]]
@@ -1204,7 +1203,7 @@ dependencies = [
  "td-logger",
  "td-paging",
  "td-shim",
- "td-uefi-pi",
+ "td-shim-interface",
  "tdx-tdcall",
  "x86",
  "x86_64",
@@ -1224,9 +1223,19 @@ dependencies = [
  "ring",
  "scroll",
  "td-layout",
- "td-uefi-pi",
+ "td-shim-interface",
  "tdx-tdcall",
  "which",
+ "zerocopy",
+]
+
+[[package]]
+name = "td-shim-interface"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "r-efi",
+ "scroll",
  "zerocopy",
 ]
 
@@ -1255,17 +1264,8 @@ dependencies = [
  "td-layout",
  "td-loader",
  "td-shim",
- "td-uefi-pi",
+ "td-shim-interface",
  "zeroize",
-]
-
-[[package]]
-name = "td-uefi-pi"
-version = "0.1.0"
-dependencies = [
- "log",
- "r-efi",
- "scroll",
 ]
 
 [[package]]
@@ -1311,7 +1311,7 @@ dependencies = [
  "td-paging",
  "td-payload",
  "td-shim",
- "td-uefi-pi",
+ "td-shim-interface",
  "tdx-tdcall",
  "zerocopy",
 ]
@@ -1425,7 +1425,7 @@ dependencies = [
  "rust_std_stub",
  "spin 0.9.8",
  "td-payload",
- "td-uefi-pi",
+ "td-shim-interface",
  "tdx-tdcall",
  "virtio",
 ]

--- a/src/devices/vsock/Cargo.toml
+++ b/src/devices/vsock/Cargo.toml
@@ -17,10 +17,10 @@ rust_std_stub = { path = "../../std-support/rust-std-stub" }
 spin = "0.9.2"
 tdx-tdcall = { path = "../../../deps/td-shim/tdx-tdcall" }
 td-payload = { path = "../../../deps/td-shim/td-payload", feature = "tdx" }
-td-uefi-pi = { path = "../../../deps/td-shim/td-uefi-pi" }
+td-shim-interface = { path = "../../../deps/td-shim/td-shim-interface", optional = true }
 
 [features]
 default = ["virtio/tdcall", "virtio-vsock"]
-vmcall-vsock = []
+vmcall-vsock = ["td-shim-interface"]
 virtio-vsock = []
 fuzz = []

--- a/src/devices/vsock/src/transport/vmcall.rs
+++ b/src/devices/vsock/src/transport/vmcall.rs
@@ -20,7 +20,7 @@ use core::arch::asm;
 use core::convert::TryInto;
 use core::sync::atomic::{AtomicBool, Ordering};
 use td_payload::{eoi, interrupt_handler_template};
-use td_uefi_pi::pi::guid;
+use td_shim_interface::td_uefi_pi::pi::guid;
 use tdx_tdcall::tdx;
 
 const CURRENT_VERSION: u8 = 0;

--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -22,14 +22,13 @@ rust_std_stub = { path = "../std-support/rust-std-stub" }
 r-efi = "3.2.0"
 scroll = { version = "0.10", default-features = false, features = ["derive"]}
 spin = "0.9.2"
-td-uefi-pi = { path = "../../deps/td-shim/td-uefi-pi"}
 tdx-tdcall = { path = "../../deps/td-shim/tdx-tdcall"}
 td-logger = { path = "../../deps/td-shim/td-logger"}
 td-layout = { path = "../../deps/td-shim/td-layout"}
 td-loader = { path = "../../deps/td-shim/td-loader"}
 td-paging = { path = "../../deps/td-shim/td-paging"}
 td-payload = { path = "../../deps/td-shim/td-payload", features = ["tdx"] }
-td-shim = { path = "../../deps/td-shim/td-shim"}
+td-shim-interface = { path = "../../deps/td-shim/td-shim-interface"}
 virtio = { path="../devices/virtio" }
 vsock = { path="../devices/vsock" }
 virtio_serial = { path="../devices/virtio_serial", optional = true }

--- a/src/migtd/src/config.rs
+++ b/src/migtd/src/config.rs
@@ -4,7 +4,7 @@
 
 use r_efi::efi::Guid;
 use td_layout::build_time::{TD_SHIM_CONFIG_BASE, TD_SHIM_CONFIG_SIZE};
-use td_uefi_pi::{fv, pi};
+use td_shim_interface::td_uefi_pi::{fv, pi};
 
 pub const CONFIG_VOLUME_BASE: usize = TD_SHIM_CONFIG_BASE as usize;
 pub const CONFIG_VOLUME_SIZE: usize = TD_SHIM_CONFIG_SIZE as usize;

--- a/src/migtd/src/event_log.rs
+++ b/src/migtd/src/event_log.rs
@@ -14,7 +14,7 @@ use core::mem::size_of;
 use crypto::hash::digest_sha384;
 use spin::Once;
 use td_payload::acpi::get_acpi_tables;
-use td_shim::acpi::Ccel;
+use td_shim_interface::acpi::Ccel;
 use tdx_tdcall::tdx;
 use zerocopy::{AsBytes, FromBytes};
 

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -6,7 +6,7 @@ use alloc::vec::Vec;
 use core::mem::size_of;
 use scroll::Pread;
 use td_payload::mm::shared::SharedMemory;
-use td_uefi_pi::hob as hob_lib;
+use td_shim_interface::td_uefi_pi::hob as hob_lib;
 use tdx_tdcall::{
     td_call,
     tdx::{self, tdcall_servtd_wr},

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -131,11 +131,11 @@ impl MigrationSession {
         #[cfg(not(feature = "vmcall-interrupt"))]
         tdx::tdvmcall_service(cmd_mem.as_bytes(), rsp_mem.as_mut_bytes(), 0, 0)?;
 
-        let private_mem = Self::copy_from_shared_memory(rsp_mem.as_bytes());
+        let private_mem = rsp_mem.copy_to_private_shadow();
 
         // Parse the response data
         // Check the GUID of the reponse
-        let rsp = VmcallServiceResponse::try_read(private_mem.as_bytes())
+        let rsp = VmcallServiceResponse::try_read(private_mem)
             .ok_or(MigrationResult::InvalidParameter)?;
         if rsp.read_guid() != VMCALL_SERVICE_COMMON_GUID.as_bytes() {
             return Err(MigrationResult::InvalidParameter);
@@ -190,10 +190,10 @@ impl MigrationSession {
                     #[cfg(not(feature = "vmcall-interrupt"))]
                     tdx::tdvmcall_service(cmd_mem.as_bytes(), rsp_mem.as_mut_bytes(), 0, 0)?;
 
-                    let private_mem = Self::copy_from_shared_memory(rsp_mem.as_bytes());
+                    let private_mem = rsp_mem.copy_to_private_shadow();
 
                     // Parse out the response data
-                    let rsp = VmcallServiceResponse::try_read(private_mem.as_bytes())
+                    let rsp = VmcallServiceResponse::try_read(private_mem)
                         .ok_or(MigrationResult::InvalidParameter)?;
                     // Check the GUID of the reponse
                     if rsp.read_guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes() {
@@ -298,11 +298,11 @@ impl MigrationSession {
 
         tdx::tdvmcall_service(cmd_mem.as_bytes(), rsp_mem.as_mut_bytes(), 0, 0)?;
 
-        let private_mem = Self::copy_from_shared_memory(rsp_mem.as_bytes());
+        let private_mem = rsp_mem.copy_to_private_shadow();
 
         // Parse the response data
         // Check the GUID of the reponse
-        let rsp = VmcallServiceResponse::try_read(private_mem.as_bytes())
+        let rsp = VmcallServiceResponse::try_read(private_mem)
             .ok_or(MigrationResult::InvalidParameter)?;
         if rsp.read_guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes() {
             return Err(MigrationResult::InvalidParameter);
@@ -461,12 +461,6 @@ impl MigrationSession {
         };
 
         Some(mig_info)
-    }
-
-    fn copy_from_shared_memory(shared: &[u8]) -> Vec<u8> {
-        let mut private = Vec::new();
-        private.extend_from_slice(shared);
-        private
     }
 }
 

--- a/src/policy/Cargo.toml
+++ b/src/policy/Cargo.toml
@@ -14,7 +14,7 @@ log = { version = "0.4.13", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 td-shim = { path = "../../deps/td-shim/td-shim", default-features = false }
-td-uefi-pi = { path = "../../deps/td-shim/td-uefi-pi"}
+td-shim-interface = { path = "../../deps/td-shim/td-shim-interface"}
 
 [features]
 std = []

--- a/src/policy/src/config.rs
+++ b/src/policy/src/config.rs
@@ -9,7 +9,7 @@ use serde::{
     de::{Error, Visitor},
     Deserialize, Deserializer,
 };
-use td_uefi_pi::pi::guid::Guid;
+use td_shim_interface::td_uefi_pi::pi::guid::Guid;
 
 #[derive(Debug, Deserialize)]
 pub struct MigPolicy {

--- a/tests/test-td-payload/Cargo.toml
+++ b/tests/test-td-payload/Cargo.toml
@@ -15,7 +15,7 @@ bitfield = "0.13.2"
 bitflags = "1.2.1"
 linked_list_allocator = "0.10.4"
 log = "0.4.13"
-td-uefi-pi =  { path = "../../deps/td-shim/td-uefi-pi" }
+td-shim-interface =  { path = "../../deps/td-shim/td-shim-interface" }
 td-logger =  { path = "../../deps/td-shim/td-logger" }
 td-layout = { path = "../../deps/td-shim/td-layout" }
 td-paging = { path = "../../deps/td-shim/td-paging"}

--- a/tests/test-td-payload/src/main.rs
+++ b/tests/test-td-payload/src/main.rs
@@ -38,7 +38,7 @@ use serde_json::{Result, Value};
 use td_payload::print;
 use td_shim::e820::{E820Entry, E820Type};
 use td_shim::TD_E820_TABLE_HOB_GUID;
-use td_uefi_pi::{fv, hob as hob_lib, pi};
+use td_shim_interface::td_uefi_pi::{fv, hob as hob_lib, pi};
 use zerocopy::FromBytes;
 
 const E820_TABLE_SIZE: usize = 128;

--- a/tests/test-td-payload/src/testattestation.rs
+++ b/tests/test-td-payload/src/testattestation.rs
@@ -12,9 +12,9 @@ use migtd::config;
 use serde::{Deserialize, Serialize};
 use td_layout::memslice;
 use td_payload::print;
-use td_uefi_pi::fv as fv_lib;
-use td_uefi_pi::hob as hob_lib;
-use td_uefi_pi::pi::fv;
+use td_shim_interface::td_uefi_pi::fv as fv_lib;
+use td_shim_interface::td_uefi_pi::hob as hob_lib;
+use td_shim_interface::td_uefi_pi::pi::fv;
 use test_td_payload::{TestCase, TestResult};
 
 pub const VIRTIO_PCI_VENDOR_ID: u16 = 0x1af4;

--- a/tools/migtd-hash/Cargo.toml
+++ b/tools/migtd-hash/Cargo.toml
@@ -12,4 +12,4 @@ crypto = { path = "../../src/crypto" }
 migtd = { path = "../../src/migtd", default-features = false }
 serde_json = "1.0"
 td-shim-tools = { path = "../../deps/td-shim/td-shim-tools", default-feature = false, features = ["tee"] }
-td-uefi-pi = { path = "../../deps/td-shim/td-uefi-pi" }
+td-shim-interface = { path = "../../deps/td-shim/td-shim-interface" }

--- a/tools/migtd-hash/src/lib.rs
+++ b/tools/migtd-hash/src/lib.rs
@@ -10,8 +10,8 @@ use std::{
     io::{Read, Seek, SeekFrom},
     mem::size_of,
 };
+use td_shim_interface::td_uefi_pi::{fv, pi};
 use td_shim_tools::tee_info_hash::{Manifest, TdInfoStruct};
-use td_uefi_pi::{fv, pi};
 
 const MIGTD_IMAGE_SIZE: u64 = 0x100_0000;
 


### PR DESCRIPTION
Closes: https://github.com/intel/MigTD/issues/87