### PR TITLE
Support multiple TDX Module identities

### DIFF
--- a/config/policy_pre_production_fmspc.json
+++ b/config/policy_pre_production_fmspc.json
@@ -1206,6 +1206,28 @@
                     },
                     "TDXModuleMajorVersion": {
                         "operation": "equal",
+                        "reference": 2
+                    },
+                    "TDXModuleSVN": {
+                        "operation": "equal",
+                        "reference": 0
+                    }
+                }
+            }
+        },
+        {
+            "TDXModule": {
+                "TDXModule_Identity": {
+                    "ATTRIBUTES": {
+                        "operation": "equal",
+                        "reference": "0000000000000000"
+                    },
+                    "MRSIGNERSEAM": {
+                        "operation": "equal",
+                        "reference": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                    },
+                    "TDXModuleMajorVersion": {
+                        "operation": "equal",
                         "reference": 1
                     },
                     "TDXModuleSVN": {

--- a/src/policy/src/config.rs
+++ b/src/policy/src/config.rs
@@ -37,13 +37,6 @@ impl MigPolicy {
         })
     }
 
-    pub fn get_tdx_module_info_policy(&self) -> Option<&TdxModuleInfo> {
-        self.blocks.iter().find_map(|p| match p {
-            Policy::TdxModule(t) => Some(t),
-            _ => None,
-        })
-    }
-
     pub fn get_migtd_info_policy(&self) -> Option<&MigTdInfo> {
         self.blocks.iter().find_map(|p| match p {
             Policy::Migtd(m) => Some(m),

--- a/src/policy/test/policy_full1.json
+++ b/src/policy/test/policy_full1.json
@@ -53,6 +53,28 @@
             }
         },
         {
+            "TDXModule": {
+                "TDXModule_Identity": {
+                    "TDXModuleMajorVersion": {
+                        "operation": "equal",
+                        "reference": 2
+                    },
+                    "TDXModuleSVN": {
+                        "operation": "equal",
+                        "reference": 0
+                    },
+                    "MRSIGNERSEAM": {
+                        "operation": "equal",
+                        "reference": "000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+                    },
+                    "ATTRIBUTES": {
+                        "operation": "equal",
+                        "reference": "0000000000000000"
+                    }
+                }
+            }
+        },
+        {
             "MigTD": {
                 "TDINFO": {
                     "ATTRIBUTES": {

--- a/tools/migtd-policy-generator/src/platform_tcb/mod.rs
+++ b/tools/migtd-policy-generator/src/platform_tcb/mod.rs
@@ -8,22 +8,26 @@ use crate::policy::PlatformPolicy;
 use fmspc::{fetch_fmspc_list, get_all_e5_platform};
 use tcb_info::fetch_platform_tcb;
 
+use self::tcb_info::PlatformTcb;
+
 pub mod fmspc;
 pub mod tcb_info;
 
-pub fn get_platform_info(for_production: bool) -> Result<Vec<PlatformPolicy>> {
+pub fn get_platform_info(for_production: bool) -> Result<(Vec<PlatformPolicy>, Vec<PlatformTcb>)> {
     match fetch_fmspc_list(for_production) {
         Ok(list) => {
+            let mut tcbs = Vec::new();
             let mut platforms = Vec::new();
             for platform in get_all_e5_platform(&list) {
                 if let Ok(platform_tcb) = fetch_platform_tcb(for_production, &platform.fmspc) {
                     if let Some(platform_tcb) = platform_tcb {
                         let platform = PlatformPolicy::new(&platform_tcb);
                         platforms.push(platform);
+                        tcbs.push(platform_tcb)
                     }
                 }
             }
-            Ok(platforms)
+            Ok((platforms, tcbs))
         }
         Err(err) => {
             eprintln!("Error fetching fmspc list: {}", err);

--- a/tools/migtd-policy-generator/src/platform_tcb/tcb_info.rs
+++ b/tools/migtd-policy-generator/src/platform_tcb/tcb_info.rs
@@ -46,7 +46,28 @@ pub struct PlatformTcb {
 #[serde(rename_all = "camelCase")]
 pub struct TcbInfo {
     pub fmspc: String,
+    pub tdx_module_identities: Vec<TdxModuleIdentity>,
     pub tcb_levels: Vec<TcbLevel>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TdxModuleIdentity {
+    pub id: String,
+    pub mrsigner: String,
+    pub attributes: String,
+    pub tcb_levels: Vec<TdxMdouleTcbLevel>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TdxMdouleTcbLevel {
+    pub tcb: TdxModuleTcb,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TdxModuleTcb {
+    pub isvsvn: u64,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
`migtd-policy-generator` fetch the `tcbInfo` of all the platforms from backend server and enumerate all the possible `tdxModuleIdentities`.

Closes: https://github.com/intel/MigTD/issues/193