### PR TITLE
migtd: abstract vmcall operations into `VmcallService`

### DIFF
--- a/src/migtd/src/migration/data.rs
+++ b/src/migtd/src/migration/data.rs
@@ -145,6 +145,10 @@ impl<'a> VmcallServiceResponse<'a> {
 
         T::read_from(&self.data[24 + offset..24 + offset + size_of::<T>()])
     }
+
+    pub fn data(&self) -> &[u8] {
+        &self.data[24..]
+    }
 }
 
 #[repr(packed)]


### PR DESCRIPTION
There are several duplicate code blocks for setting up buffers, executing and parsing return values for `TDVMCALL<Service>`.
    
Here the vmcall operations are abstracted into a struct `VmcallService` to eliminite the duplicate code.