### PR TITLE
virtio: add timeout check waiting for virtqueue event

### DIFF
--- a/src/devices/virtio_serial/src/lib.rs
+++ b/src/devices/virtio_serial/src/lib.rs
@@ -468,7 +468,7 @@ impl VirtioSerial {
             .set_timeout(DEFAULT_TIMEOUT)
             .ok_or(VirtioSerialError::InvalidParameter)?;
 
-        while !vq.borrow_mut().can_pop() {
+        while !vq.borrow_mut().can_pop() && !self.timer.is_timeout() {
             if !wait_for_event(&IRQ_FLAG, self.timer.as_ref()) && !vq.borrow_mut().can_pop() {
                 return Err(VirtioSerialError::Timeout);
             }
@@ -563,7 +563,7 @@ impl VirtioSerial {
             .set_timeout(DEFAULT_TIMEOUT)
             .ok_or(VirtioSerialError::InvalidParameter)?;
 
-        while !vq.borrow_mut().can_pop() {
+        while !vq.borrow_mut().can_pop() && !self.timer.is_timeout() {
             if !wait_for_event(&IRQ_FLAG, self.timer.as_ref()) && !vq.borrow_mut().can_pop() {
                 return Err(VirtioSerialError::Timeout);
             }
@@ -606,7 +606,7 @@ impl VirtioSerial {
             .set_timeout(timeout)
             .ok_or(VirtioSerialError::InvalidParameter)?;
 
-        while !vq.borrow_mut().can_pop() {
+        while !vq.borrow_mut().can_pop() && !self.timer.is_timeout() {
             if !wait_for_event(&IRQ_FLAG, self.timer.as_ref()) && !vq.borrow_mut().can_pop() {
                 return Err(VirtioSerialError::Timeout);
             }
@@ -705,7 +705,7 @@ impl VirtioSerial {
         loop {
             let vq = self.queues.index(Self::port_queue_index(port_id) as usize);
 
-            while !vq.borrow_mut().can_pop() {
+            while !vq.borrow_mut().can_pop() && !self.timer.is_timeout() {
                 if !wait_for_event(&IRQ_FLAG, self.timer.as_ref()) && !vq.borrow_mut().can_pop() {
                     return Err(VirtioSerialError::Timeout);
                 }

--- a/src/devices/vsock/src/transport/virtio_pci.rs
+++ b/src/devices/vsock/src/transport/virtio_pci.rs
@@ -374,7 +374,7 @@ impl VsockTransport for VirtioVsock {
             .set_timeout(timeout)
             .ok_or(VsockTransportError::InvalidParameter)?;
 
-        while !self.tx.borrow_mut().can_pop() {
+        while !self.tx.borrow_mut().can_pop() && !self.timer.is_timeout() {
             if !wait_for_event(&TX_FLAG, self.timer.as_ref()) && !self.tx.borrow_mut().can_pop() {
                 return Err(VsockTransportError::Timeout);
             }
@@ -407,7 +407,7 @@ impl VsockTransport for VirtioVsock {
             .ok_or(VsockTransportError::InvalidParameter)?;
 
         loop {
-            while !self.rx.borrow_mut().can_pop() {
+            while !self.rx.borrow_mut().can_pop() && !self.timer.is_timeout() {
                 if !wait_for_event(&RX_FLAG, self.timer.as_ref()) && !self.rx.borrow_mut().can_pop()
                 {
                     return Err(VsockTransportError::Timeout);


### PR DESCRIPTION
The while loop may stuck if device sends notification but there is no actual available buffer in the ring.

Closes https://github.com/intel/MigTD/issues/238