### PR TITLE
sys_time: limit the number of retries for reading rtc time

### DIFF
--- a/src/std-support/sys_time/src/lib.rs
+++ b/src/std-support/sys_time/src/lib.rs
@@ -13,7 +13,7 @@ use time::{Date, Month, PrimitiveDateTime, Time};
 pub mod rtc;
 
 pub fn get_sys_time() -> Option<i64> {
-    let data_time = read_rtc();
+    let data_time = read_rtc()?;
 
     let date_time = PrimitiveDateTime::new(
         Date::from_calendar_date(


### PR DESCRIPTION
For the rtc device, it is possible to read the time and date while an update is in progress and get inconsistent values.

We retry for up to 500 times for the RTC to be ready which takes about 100ms.

Closes https://github.com/intel/MigTD/issues/208