### PR TITLE
Remove dependency on lexical crates.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -504,70 +504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lexical-core"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2cde5de06e8d4c2faabc400238f9ae1c74d5412d03a7bd067645ccbc47070e46"
-dependencies = [
- "lexical-parse-float",
- "lexical-parse-integer",
- "lexical-util",
- "lexical-write-float",
- "lexical-write-integer",
-]
-
-[[package]]
-name = "lexical-parse-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "683b3a5ebd0130b8fb52ba0bdc718cc56815b6a097e28ae5a6997d0ad17dc05f"
-dependencies = [
- "lexical-parse-integer",
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-parse-integer"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d0994485ed0c312f6d965766754ea177d07f9c00c9b82a5ee62ed5b47945ee9"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-util"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5255b9ff16ff898710eb9eb63cb39248ea8a5bb036bea8085b1a767ff6c4e3fc"
-dependencies = [
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-float"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accabaa1c4581f05a3923d1b4cfd124c329352288b7b9da09e766b0668116862"
-dependencies = [
- "lexical-util",
- "lexical-write-integer",
- "static_assertions",
-]
-
-[[package]]
-name = "lexical-write-integer"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1b6f3d1f4422866b68192d62f77bc5c700bee84f3069f2469d7bc8c77852446"
-dependencies = [
- "lexical-util",
- "static_assertions",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -758,7 +694,6 @@ version = "0.1.0"
 dependencies = [
  "cc-measurement",
  "crypto",
- "lexical-core",
  "log",
  "serde",
  "serde_json",
@@ -1062,12 +997,6 @@ checksum = "5b9eb1a2f4c41445a3a0ff9abc5221c5fcd28e1f13cd7c0397706f9ac938ddb0"
 dependencies = [
  "lock_api",
 ]
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"

--- a/src/policy/Cargo.toml
+++ b/src/policy/Cargo.toml
@@ -9,7 +9,6 @@ edition = "2018"
 [dependencies]
 cc-measurement = { path = "../../deps/td-shim/cc-measurement"}
 crypto = { path = "../crypto" }
-lexical-core = { version = "0.8.3", default-features = false, features = ["write-integers", "write-floats", "parse-integers", "parse-floats"] }
 log = { version = "0.4.13", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"]}
 serde_json = { version = "1.0", default-features = false, features = ["alloc"] }

--- a/src/policy/src/config.rs
+++ b/src/policy/src/config.rs
@@ -4,7 +4,6 @@
 
 use alloc::{collections::BTreeMap, fmt::Write, string::String, vec::Vec};
 use core::{mem::size_of, ops, str::FromStr};
-use lexical_core::parse;
 use serde::{
     de::{Error, Visitor},
     Deserialize, Deserializer,
@@ -315,13 +314,13 @@ fn parse_range(input: &str) -> Option<ops::Range<usize>> {
     let start = if parts[0].is_empty() {
         usize::MIN
     } else {
-        parse::<usize>(parts[0].as_bytes()).ok()?
+        usize::from_str(parts[0]).ok()?
     };
 
     let end: usize = if parts[1].is_empty() {
         usize::MAX
     } else {
-        parse::<usize>(parts[1].as_bytes()).ok()?
+        usize::from_str(parts[1]).ok()?
     };
 
     Some(start..end)


### PR DESCRIPTION
The family of lexical crates have a variety of unresolved safety issues and no activity in the last two years. Considering we're only using it in two places, it makes morse sense to just use the built in conversion for usize and reduce the number of dependencies.