### PR TITLE
Fix oss-fuzz build failure issue

### DIFF
--- a/src/crypto/fuzz/Cargo.toml
+++ b/src/crypto/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ libfuzzer-sys = { version = "0.4", optional = true }
 afl = { version = "*", optional = true }
 arbitrary = "=1.1.3"
 der = { version = "0.5.1", features = ["oid", "alloc"] }
+serde = "=1.0.198"
 
 [dependencies.crypto]
 path = ".."

--- a/src/devices/virtio/fuzz/Cargo.toml
+++ b/src/devices/virtio/fuzz/Cargo.toml
@@ -16,6 +16,7 @@ conquer-once = { version = "0.3.2", default-features = false }
 bitmap-allocator = { git = "https://github.com/rcore-os/bitmap-allocator", rev = "03bd9909" }
 spin = "0.9.2"
 arbitrary = "=1.1.3"
+serde = "=1.0.198"
 
 [features]
 default = ["libfuzzer-sys"]

--- a/src/devices/vsock/fuzz/Cargo.toml
+++ b/src/devices/vsock/fuzz/Cargo.toml
@@ -17,6 +17,7 @@ spin = "0.9.2"
 libfuzzer-sys = { version = "0.4", optional = true }
 afl = {version = "*", optional = true }
 arbitrary = "=1.1.3"
+serde = "=1.0.198"
 
 [dependencies.vsock]
 path = ".."

--- a/src/migtd/fuzz/Cargo.toml
+++ b/src/migtd/fuzz/Cargo.toml
@@ -13,6 +13,7 @@ libfuzzer-sys = { version = "0.4", optional = true }
 afl = { version = "*", optional = true }
 r-efi = "3.2.0"
 arbitrary = "=1.1.3"
+serde = "=1.0.198"
 
 [patch.crates-io]
 ring = { path = "../../../deps/td-shim/library/ring" }

--- a/src/policy/fuzz/Cargo.toml
+++ b/src/policy/fuzz/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = { version = "1.0", default-features = false, features = ["alloc"] }
 afl = {version = "*", optional = true }
 arbitrary = "=1.1.3"
 log = "0.4.13"
+serde = "=1.0.198"
 
 [features]
 default = ["libfuzzer-sys"]


### PR DESCRIPTION
Since the compiler of oss-fuzz is not the latest version, so it will meet build failure for crate "serde 1.0.204". So we use a fixed version serde "1.0.198" to fix the issue.