### PR TITLE
migtd: record hash of event in event log

### DIFF
--- a/src/migtd/src/event_log.rs
+++ b/src/migtd/src/event_log.rs
@@ -94,9 +94,9 @@ pub fn write_tagged_event_log(
     tagged_event_data: &[u8],
 ) -> Result<usize> {
     let mut log_size = event_log_size(event_log).ok_or_else(|| anyhow!("Parsing event log"))?;
-    let event = TaggedEvent::new(tagged_event_id, tagged_event_data);
-
     let digest = calculate_digest(tagged_event_data)?;
+    let event = TaggedEvent::new(tagged_event_id, &digest);
+
     extend_rtmr(&digest, 3)?;
 
     let event_header = CcEventHeader {


### PR DESCRIPTION
Events of migtd, such as policy events, are particularly large in size. Since the event log is written into the RATLS certificate, this results in a significant increase in the size of the RATLS certificate. Using the hash of the event instead of the raw data can save space in the event log and reduce the size of the certificate.