### PR TITLE
vsock/virtio-serial: pop all the received packets

### DIFF
--- a/src/crypto/Cargo.toml
+++ b/src/crypto/Cargo.toml
@@ -9,7 +9,7 @@ cfg-if = "1.0"
 der = {version = "0.7.9", features = ["oid", "alloc", "derive"]}
 pki-types = { package = "rustls-pki-types", version = "1" }
 rust_std_stub = { path = "../std-support/rust-std-stub" }
-rustls = { version = "=0.23.12", default-features = false, features = ["ring" ], optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring" ], optional = true }
 ring = { path = "../../deps/td-shim/library/ring", default-features = false, features = ["alloc", "less-safe-getrandom-custom-or-rdrand"], optional = true }
 sys_time = { path = "../std-support/sys_time" }
 zeroize = "1.5.7"

--- a/src/devices/virtio_serial/src/lib.rs
+++ b/src/devices/virtio_serial/src/lib.rs
@@ -854,6 +854,18 @@ impl VirtioSerial {
     fn port_queue_pop(port_id: u32) -> Option<Vec<u8>> {
         RECEIVE_QUEUES.lock().get_mut(&port_id)?.pop_front()
     }
+
+    fn can_recv(&self, port_id: u32) -> bool {
+        RECEIVE_QUEUES
+            .lock()
+            .get(&port_id)
+            .is_some_and(|q| !q.is_empty())
+            || self
+                .queues
+                .index(Self::port_queue_index(port_id) as usize)
+                .borrow_mut()
+                .can_pop()
+    }
 }
 
 /// Align `size` up to a page.


### PR DESCRIPTION
After receiving from vsock/virtio-serial transport layer, pop all the data packet from device and try to fill the caller's buffer as much as possible.