### PR TITLE
Fix cargo build warnings.

### DIFF
--- a/src/devices/vsock/Cargo.toml
+++ b/src/devices/vsock/Cargo.toml
@@ -16,7 +16,7 @@ log = "0.4.13"
 rust_std_stub = { path = "../../std-support/rust-std-stub" }
 spin = "0.9.2"
 tdx-tdcall = { path = "../../../deps/td-shim/tdx-tdcall" }
-td-payload = { path = "../../../deps/td-shim/td-payload", feature = "tdx" }
+td-payload = { path = "../../../deps/td-shim/td-payload", features = ["tdx"] }
 td-shim-interface = { path = "../../../deps/td-shim/td-shim-interface", optional = true }
 
 [features]

--- a/tools/migtd-hash/Cargo.toml
+++ b/tools/migtd-hash/Cargo.toml
@@ -11,5 +11,5 @@ clap = { version = "4.0", features = ["derive"] }
 crypto = { path = "../../src/crypto" }
 migtd = { path = "../../src/migtd", default-features = false }
 serde_json = "1.0"
-td-shim-tools = { path = "../../deps/td-shim/td-shim-tools", default-feature = false, features = ["tee"] }
+td-shim-tools = { path = "../../deps/td-shim/td-shim-tools", default-features = false, features = ["tee"] }
 td-shim-interface = { path = "../../deps/td-shim/td-shim-interface" }


### PR DESCRIPTION
There are some manifest warnings due to "unused manifest key" because of misspelled keywords. This change addresses those warnings.