### PR TITLE
Fix rust toolchain and add pytest to docker

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -12,13 +12,15 @@ RUN apt-get update && \
     build-essential unzip ca-certificates curl gcc git libssl-dev pkg-config ssh \
     clang llvm nasm \
     ocaml ocamlbuild wget pkg-config libtool autoconf autotools-dev automake \
-    screen expect \
+    screen expect python3 python3-pip \
+    && pip install pytest --break-system-packages \
     # cleanup
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Install rustup and a fixed version of Rust.
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain nightly-2023-12-31
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.83.0
 RUN rustup component add rust-src
 RUN cargo install cargo-xbuild
+RUN rustup target add x86_64-unknown-none
 
 RUN git clone --recursive https://github.com/intel/MigTD.git


### PR DESCRIPTION
Docker file specifies old nightly toolchain which is being overwritten by rust-toolchain anyway.
Add missing x86_64-unknown-none target.

After these changes the docker image is ready for building.

Add python, pip, and pytest into container.