### PR TITLE
Enlarge the stack size for SPDM integration

### DIFF
--- a/src/migtd/src/lib.rs
+++ b/src/migtd/src/lib.rs
@@ -25,7 +25,7 @@ pub extern "C" fn _start(hob: u64, payload: u64) -> ! {
     use td_payload::arch;
     use td_payload::mm::layout::*;
 
-    const STACK_SIZE: usize = 0x1_0000;
+    const STACK_SIZE: usize = 0x20_0000;
     const HEAP_SIZE: usize = 0x20_0000;
     const PT_SIZE: usize = 0x8_0000;
 


### PR DESCRIPTION
Spdm mainly use stack, so enlarge the stack size to avoid stack overflow.