### PR TITLE
vsock: prevent recv() returning 0 on non-data packets

### DIFF
--- a/src/devices/vsock/src/stream.rs
+++ b/src/devices/vsock/src/stream.rs
@@ -286,7 +286,7 @@ impl VsockStream {
             return Err(VsockError::Illegal);
         }
 
-        if self.data_queue.is_empty() {
+        while self.data_queue.is_empty() {
             loop {
                 self.recv_packet_connected().await?;
 


### PR DESCRIPTION
Fix issue where recv() would return 0 bytes when recv_packet_connected() successfully processes non-OP_RW packets (like credit updates).

Ensure recv() only returns when actual data is available or connection is closed.

Closes https://github.com/intel/MigTD/issues/454