### PR TITLE
policy(v2): make PolicyEvaluationInfo fields mandatory

### DIFF
--- a/.github/workflows/integration-tdx.yml
+++ b/.github/workflows/integration-tdx.yml
@@ -61,8 +61,8 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v2 + TLS + Release)
-        run: cargo image  --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
-      
+        run: cargo image --features test_disable_tcb_mapping_check --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+
       - name: Run Tests
         run: |
           pushd sh_script/test
@@ -76,7 +76,7 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v2 + SPDM + Release)
-        run: cargo image --features spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem
+        run: cargo image --features spdm_attestation,test_disable_tcb_mapping_check --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem
 
       - name: Run Tests - Test pre-binding
         run: |
@@ -135,7 +135,7 @@ jobs:
         run: cargo clean
       
       - name: Build Migration TD binary (policy v2 + TLS + Release)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+        run: cargo image --no-default-features --features stack-guard,virtio-serial,test_disable_tcb_mapping_check --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
       
       - name: Run Tests
         run: |
@@ -147,7 +147,7 @@ jobs:
         run: cargo clean
       
       - name: Build Migration TD binary (policy v2 + TLS + Debug)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer --debug
+        run: cargo image --no-default-features --features stack-guard,virtio-serial,test_disable_tcb_mapping_check --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer --debug
       
       - name: Run Tests
         run: |
@@ -192,7 +192,7 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v2 + SPDM + Release)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem
+        run: cargo image --no-default-features --features stack-guard,virtio-serial,spdm_attestation,test_disable_tcb_mapping_check --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem
 
       - name: Run Tests
         run: |
@@ -204,7 +204,7 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v2 + SPDM + Debug)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --debug
+        run: cargo image --no-default-features --features stack-guard,virtio-serial,spdm_attestation,test_disable_tcb_mapping_check --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --debug
 
       - name: Run Tests
         run: |

--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -79,6 +79,7 @@ oneshot-apic = []
 test_heap_size = ["td-benchmark", "td-payload/test_heap_size"]
 test_stack_size = ["td-benchmark"]
 test_disable_ra_and_accept_all = ["attestation/test", "tdx-tdcall-emu?/test_mock_report"] # Dangerous: can only be used for test purpose to bypass the remote attestation
+test_disable_tcb_mapping_check = ["policy/test_disable_tcb_mapping_check"]# Dangerous: can only be used for test purpose to bypass the tcb mapping check
 spdm_attestation = ["main"]
 test_mock_report = ["AzCVMEmu", "tdx-tdcall-emu/test_mock_report"]
 AzCVMEmu = [

--- a/src/migtd/src/mig_policy.rs
+++ b/src/migtd/src/mig_policy.rs
@@ -262,14 +262,13 @@ mod v2 {
 
         let migtd_tcb = migtd_svn.and_then(|svn| policy.servtd_identity.get_tcb_level_by_svn(svn));
 
-        Ok(PolicyEvaluationInfo {
-            tcb_date: Some(tcb_date.to_string()),
-            tcb_status: Some(tcb_status.as_str().to_string()),
-            tcb_evaluation_number: Some(tcb_evaluation_number),
-            fmspc: Some(fmspc),
-            migtd_tcb_date: migtd_tcb.map(|tcb| tcb.tcb_date.clone()),
-            migtd_tcb_status: migtd_tcb.map(|tcb| tcb.tcb_status.clone()),
-        })
+        PolicyEvaluationInfo::new(
+            Some(tcb_date.to_string()),
+            Some(tcb_status.as_str().to_string()),
+            Some(tcb_evaluation_number),
+            Some(fmspc),
+            migtd_tcb,
+        )
     }
 
     fn get_tcb_date_and_status_from_suppl_data(

--- a/src/policy/Cargo.toml
+++ b/src/policy/Cargo.toml
@@ -19,3 +19,4 @@ td-shim-interface = { path = "../../deps/td-shim/td-shim-interface"}
 std = []
 AzCVMEmu = []
 policy_v2 = []
+test_disable_tcb_mapping_check = []

--- a/src/policy/src/lib.rs
+++ b/src/policy/src/lib.rs
@@ -52,6 +52,8 @@ pub enum PolicyError {
     InvalidReference,
     InvalidServtdIdentity,
     InvalidServtdTcbMapping,
+    PlatformTcbNotFound,
+    ServtdTcbNotFound,
     PolicyHashMismatch,
     InvalidQuote,
     SvnMismatch,


### PR DESCRIPTION
The policy may choose not to enforce checks on these fields.

Close https://github.com/intel/MigTD/issues/478