### PR TITLE
Fix SPDM_CONFIG env. variable setting in build command

### DIFF
--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -216,6 +216,13 @@ impl BuildArgs {
         let sh = Shell::new()?;
         sh.set_var("CC_x86_64_unknown_none", "clang");
         sh.set_var("AR_x86_64_unknown_none", "llvm-ar");
+        sh.set_var(
+            "SPDM_CONFIG",
+            PROJECT_ROOT
+                .join("config/spdm_config.json")
+                .to_str()
+                .unwrap(),
+        );
 
         cmd!(
             sh,


### PR DESCRIPTION
- Set SPDM_CONFIG env. variable in xtask build.rs for cargo image to use
config/spdm_config.json instead of the default spdmlib config.

Signed-off-by: Bo Zhang (ACC) <zhanb@microsoft.com>