### PR TITLE
tools: Support migtd-hash to output TD Info and served_td/servtd_info_hash in JSON format

### DIFF
--- a/tools/migtd-hash/src/lib.rs
+++ b/tools/migtd-hash/src/lib.rs
@@ -34,14 +34,14 @@ const SERVTD_ATTR_IGNORE_RTMR1: u64 = 0x80_0000_0000;
 const SERVTD_ATTR_IGNORE_RTMR2: u64 = 0x100_0000_0000;
 const SERVTD_ATTR_IGNORE_RTMR3: u64 = 0x200_0000_0000;
 
-pub fn calculate_servtd_info_hash(
+pub fn build_td_info(
     manifest: &[u8],
     mut image: File,
     is_ra_disabled: bool,
     is_policy_v2: bool,
     servtd_attr: u64,
     igvmformat: bool,
-) -> Result<Vec<u8>, Error> {
+) -> Result<TdInfoStruct, Error> {
     // Initialize the configurable fields of TD info structure.
     let manifest = serde_json::from_slice::<Manifest>(&manifest)?;
     let mut td_info = TdInfoStruct {
@@ -108,6 +108,10 @@ pub fn calculate_servtd_info_hash(
         td_info.rtmr3.fill(0);
     }
 
+    Ok(td_info)
+}
+
+pub fn calculate_servtd_info_hash(td_info: TdInfoStruct) -> Result<Vec<u8>, Error> {
     // Convert the TD info structure to bytes.
     let mut buffer = [0u8; size_of::<TdInfoStruct>()];
     td_info.pack(&mut buffer);

--- a/tools/migtd-hash/src/main.rs
+++ b/tools/migtd-hash/src/main.rs
@@ -3,12 +3,18 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use clap::Parser;
-use migtd_hash::{calculate_servtd_hash, calculate_servtd_info_hash, SERVTD_TYPE_MIGTD};
+use migtd_hash::{
+    build_td_info, calculate_servtd_hash, calculate_servtd_info_hash, SERVTD_TYPE_MIGTD,
+};
+use serde_json::json;
 use std::{
     fs::{self, File},
     path::PathBuf,
     process::exit,
 };
+
+const SERVTD_HASH_KEY: &str = "servtdHash";
+const SERVTD_INFO_HASH_KEY: &str = "servtdInfoHash";
 
 #[derive(Clone, Parser)]
 struct Config {
@@ -21,6 +27,9 @@ struct Config {
     /// Output binary of tee info hash
     #[clap(short, long)]
     pub output_file: Option<PathBuf>,
+    /// Output the servtd_hash or servtd_info_hash in JSON.
+    #[clap(long)]
+    pub json: bool,
     /// The input MigTD image enables the `test_disable_ra_and_accept_all` feature
     #[clap(short, long)]
     pub test_disable_ra_and_accept_all: bool,
@@ -33,6 +42,9 @@ struct Config {
     /// Indicator to calculate final servtd_hash instead of servtd_info_hash (default false)
     #[clap(short, long)]
     pub calc_servtd_hash: bool,
+    /// Output in TD Info in JSON format
+    #[clap(long)]
+    pub output_td_info: Option<PathBuf>,
 }
 
 fn main() {
@@ -60,7 +72,7 @@ fn main() {
 
     let servtd_attr = config.servtd_attr.unwrap_or(0);
 
-    let servtd_info_hash = calculate_servtd_info_hash(
+    let td_info = build_td_info(
         &manifest,
         image,
         config.test_disable_ra_and_accept_all,
@@ -69,6 +81,30 @@ fn main() {
         igvmformat,
     )
     .unwrap_or_else(|e| {
+        eprintln!("Failed to build TD info: {:?}", e);
+        exit(1);
+    });
+
+    if let Some(output_td_info) = config.output_td_info {
+        let td_info_json = json!({
+            "mrtd": td_info.mrtd.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
+            "rtmr0": td_info.rtmr0.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
+            "rtmr1": td_info.rtmr1.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
+            "rtmr2": td_info.rtmr2.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
+            "rtmr3": td_info.rtmr3.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
+        });
+
+        fs::write(
+            output_td_info,
+            serde_json::to_string(&td_info_json).unwrap(),
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("Failed to write output file: {}", e);
+            exit(1);
+        })
+    }
+
+    let servtd_info_hash = calculate_servtd_info_hash(td_info).unwrap_or_else(|e| {
         eprintln!("Failed to calculate hash: {:?}", e);
         exit(1);
     });
@@ -78,23 +114,40 @@ fn main() {
             exit(1);
         });
 
-    let hash = if config.calc_servtd_hash {
-        servtd_hash
+    let (hash, key) = if config.calc_servtd_hash {
+        (servtd_hash, SERVTD_HASH_KEY)
     } else {
-        servtd_info_hash
+        (servtd_info_hash, SERVTD_INFO_HASH_KEY)
     };
 
     if let Some(output_file) = config.output_file {
-        fs::write(output_file, &hash).unwrap_or_else(|e| {
-            eprintln!("Failed to write output file: {}", e);
-            exit(1);
-        })
+        if config.json {
+            let json = json!({
+                key: hash.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
+            });
+            fs::write(output_file, serde_json::to_string(&json).unwrap()).unwrap_or_else(|e| {
+                eprintln!("Failed to write output file: {}", e);
+                exit(1);
+            });
+        } else {
+            fs::write(output_file, &hash).unwrap_or_else(|e| {
+                eprintln!("Failed to write output file: {}", e);
+                exit(1);
+            })
+        }
     } else {
-        println!(
-            "{}",
-            hash.iter()
-                .map(|byte| format!("{:02x}", byte))
-                .collect::<String>()
-        )
+        if config.json {
+            let json = json!({
+                key: hash.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
+            });
+            println!("{}", serde_json::to_string_pretty(&json).unwrap())
+        } else {
+            println!(
+                "{}",
+                hash.iter()
+                    .map(|byte| format!("{:02x}", byte))
+                    .collect::<String>()
+            )
+        }
     }
 }


### PR DESCRIPTION
This PR adds the following options to `migtd-hash` tool
- `--output-td-info <file>`: to output TD info (in JSON) required by constructing tcb_mapping.
- `--json`: Output the servtd_hash / servtd_info_hash in JSON format.