### PR TITLE
Add get_quote implementation for igvm.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,7 @@ version = "0.1.0"
 dependencies = [
  "crypto",
  "der",
+ "log",
  "spin 0.9.8",
  "td-payload",
  "td-payload-emu",

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,90 @@
+AZCVMEMU_FEATURES ?= AzCVMEmu
+IGVM_FILE ?= target/release/migtd.igvm
+LOG_LEVEL ?= info
+# Common features for IGVM images
+IGVM_FEATURES_BASE ?= vmcall-raw,stack-guard,main,vmcall-interrupt,oneshot-apic
+# test_accept_all feature skips policy verification, bypasses RATLS security
+IGVM_FEATURES_ACCEPT_ALL ?= $(IGVM_FEATURES_BASE),test_accept_all
+# test_reject_all feature forces migrations to be rejected by returning Unsupported and skipping exchange_msk
+IGVM_FEATURES_REJECT_ALL ?= $(IGVM_FEATURES_BASE),test_reject_all
+# test_disable_ra_and_accept_all feature disables remote attestation and skips policy verification, bypassing RATLS security
+# test feature skips the compilation of attestation library when the remote attestation is not enabled or needed
+IGVM_FEATURES_DISABLE_RA_AND_ACCEPT_ALL ?= $(IGVM_FEATURES_BASE),test_disable_ra_and_accept_all
+# test get quote and exit.
+IGVM_FEATURES_GET_QUOTE ?= $(IGVM_FEATURES_BASE),test_get_quote
+
+.PHONY: help build-AzCVMEmu test-migtd-emu build-test-migtd-emu
+.PHONY: build-igvm-accept build-igvm-accept-all build-igvm-reject build-igvm-reject-all
+.PHONY: generate-hash-accept-all-tls build-igvm-accept-all-tls build-igvm-accept-all-tls-all
+.PHONY: pre-build build-igvm generate-hash build-igvm-all
+.PHONY: build-igvm-get-quote build-igvm-get-quote-all
+
+.DEFAULT_GOAL := build-igvm-all
+
+help:
+	@echo "Available targets:"
+	@echo "  build-AzCVMEmu                  - Build with AzCVMEmu features"
+	@echo "  test-migtd-emu                  - Run emulation tests"
+	@echo "  build-test-migtd-emu            - Build and run emulation tests"
+	@echo "  build-igvm-all                  - Build IGVM"
+	@echo "  build-igvm-accept-all           - Build IGVM with accept all policy"
+	@echo "  build-igvm-reject-all           - Build IGVM with reject all policy"
+	@echo "  build-igvm-accept-all-tls-all   - Build IGVM with disabled RA and accept all policy with TLS"
+	@echo "  build-igvm-get-quote-all        - Build IGVM that only calls get quote and returns."
+
+build-AzCVMEmu:
+	cargo build --no-default-features --features $(AZCVMEMU_FEATURES)
+
+test-migtd-emu:
+	./migtdemu.sh --both
+
+build-test-migtd-emu: build-AzCVMEmu test-migtd-emu
+
+pre-build:
+	@if ! command -v rustc >/dev/null 2>&1 || ! rustc --version | grep -q "1.83.0"; then \
+		echo "Installing Rust 1.83.0..."; \
+		curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain 1.83.0; \
+		. ~/.cargo/env; \
+	else \
+		echo "Rust 1.83.0 already installed"; \
+	fi
+	@if ! rustup target list --installed | grep -q "x86_64-unknown-none"; then \
+		echo "Adding x86_64-unknown-none target..."; \
+		rustup target add x86_64-unknown-none; \
+	else \
+		echo "x86_64-unknown-none target already installed"; \
+	fi
+	git submodule update --init --recursive
+	chmod +x ./sh_script/preparation.sh
+	./sh_script/preparation.sh
+
+build-igvm-accept:
+	cargo image --no-default-features --features $(IGVM_FEATURES_ACCEPT_ALL) --log-level $(LOG_LEVEL) --image-format igvm --output $(IGVM_FILE)
+
+generate-hash:
+	cargo hash --image $(IGVM_FILE)
+
+build-igvm-accept-all: pre-build build-igvm-accept generate-hash
+
+build-igvm-accept-all-tls:
+	cargo image --no-default-features --features $(IGVM_FEATURES_DISABLE_RA_AND_ACCEPT_ALL) --log-level $(LOG_LEVEL) --image-format igvm --output $(IGVM_FILE)
+
+generate-hash-accept-all-tls:
+	cargo hash --image $(IGVM_FILE) --test-disable-ra-and-accept-all
+
+build-igvm-accept-all-tls-all: pre-build build-igvm-accept-all-tls generate-hash-accept-all-tls
+
+build-igvm-reject:
+	cargo image --no-default-features --features $(IGVM_FEATURES_REJECT_ALL) --log-level $(LOG_LEVEL) --image-format igvm --output $(IGVM_FILE)
+
+build-igvm-reject-all: pre-build build-igvm-reject generate-hash
+
+build-igvm:
+	cargo image --no-default-features --features $(IGVM_FEATURES_BASE) --log-level $(LOG_LEVEL) --image-format igvm --output $(IGVM_FILE)
+
+build-igvm-all: pre-build build-igvm generate-hash
+
+build-igvm-get-quote:
+	cargo image --no-default-features --features $(IGVM_FEATURES_GET_QUOTE) --log-level $(LOG_LEVEL) --image-format igvm --output $(IGVM_FILE)
+
+build-igvm-get-quote-all: pre-build build-igvm-get-quote generate-hash

--- a/src/attestation/Cargo.toml
+++ b/src/attestation/Cargo.toml
@@ -11,6 +11,7 @@ der = { version = "0.7.9", features = ["oid", "alloc", "derive"] }
 spin = "0.9.2"
 tdx-tdcall = { path = "../../deps/td-shim/tdx-tdcall"}
 td-payload = { path = "../../deps/td-shim/td-payload", features = ["tdx"] }
+log = { version = "0.4.13" }
 
 # Use emulated versions for AzCVMEmu
 tdx-tdcall-emu = { path = "../../deps/td-shim-AzCVMEmu/tdx-tdcall", optional = true }
@@ -22,3 +23,4 @@ test = []
 AzCVMEmu = ["tdx-tdcall-emu", "td-payload-emu"]
 attest-lib-ext = []
 policy_v2=[]
+igvm-attest = []

--- a/src/attestation/src/binding.rs
+++ b/src/attestation/src/binding.rs
@@ -78,6 +78,7 @@ mod attest_lib_binding {
         ///      - MIGTD_ATTEST_ERROR_UNEXPECTED: An unexpected internal error occurred. E.g.
         ///          the parameter is incorrect, failed to get quote from QGS, heap memory allocation error,
         ///          the input (*p_quote_size) is not enough to place the real Quote, etc.
+        #[cfg(not(feature = "igvm-attest"))]
         pub fn get_quote(
             p_tdx_report: *const ::core::ffi::c_void,
             tdx_report_size: u32,

--- a/src/attestation/src/igvmattest.rs
+++ b/src/attestation/src/igvmattest.rs
@@ -1,0 +1,157 @@
+// Copyright (c) 2022 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use crate::{attest::TD_QUOTE_SIZE, Error};
+#[cfg(feature = "igvm-attest")]
+use alloc::{vec, vec::Vec};
+use core::ffi::c_void;
+
+extern "C" {
+    pub fn servtd_get_quote(tdquote_req_buf: *mut core::ffi::c_void, len: u64) -> i32;
+}
+
+#[repr(C)]
+#[derive(Debug)]
+struct ServtdTdxQuoteHdr {
+    /* Quote version, filled by TD */
+    version: u64,
+    /* Status code of Quote request, filled by VMM */
+    status: u64,
+    /* Length of TDREPORT, filled by TD */
+    in_len: u32,
+    /* Length of Quote, filled by VMM */
+    out_len: u32,
+    /* Actual Quote data or TDREPORT on input */
+    _data: [u64; 0],
+}
+
+const SERVTD_REQ_BUF_SIZE: usize = 16 * 4 * 1024; // 16 pages
+
+pub fn get_quote_igvm(td_report: &[u8]) -> Result<Vec<u8>, Error> {
+    let mut quote = vec![0u8; TD_QUOTE_SIZE];
+    let mut quote_size = TD_QUOTE_SIZE as u32;
+    let mut get_quote_blob = vec![0u8; SERVTD_REQ_BUF_SIZE];
+
+    // Copy the header to get_quote_blob
+    let hdr = ServtdTdxQuoteHdr {
+        version: 1,
+        status: 0,
+        in_len: td_report.len() as u32,
+        out_len: quote_size as u32,
+        _data: [],
+    };
+
+    let header_size = core::mem::size_of::<ServtdTdxQuoteHdr>();
+
+    // Validate buffer size
+    if header_size + td_report.len() > SERVTD_REQ_BUF_SIZE {
+        log::error!(
+            "Buffer too small: need {} bytes, have {} bytes\n",
+            header_size + td_report.len(),
+            SERVTD_REQ_BUF_SIZE
+        );
+        return Err(Error::GetQuote);
+    }
+
+    let hdr_bytes =
+        unsafe { core::slice::from_raw_parts(&hdr as *const _ as *const u8, header_size) };
+    get_quote_blob[..header_size].copy_from_slice(hdr_bytes);
+
+    log::debug!(
+        "Header size: {}, TD report size: {}\n",
+        header_size,
+        td_report.len()
+    );
+    log::debug!(
+        "ServtdTdxQuoteHdr values before calling servtd_get_quote: \n{:?}\n",
+        hdr
+    );
+    // Copy TD report at data offset (after header)
+    get_quote_blob[header_size..header_size + td_report.len()].copy_from_slice(td_report);
+
+    // Dump the first 64 bytes of the blob for debugging
+    let dump_len = core::cmp::min(64, get_quote_blob.len());
+    log::debug!(
+        "First {} bytes of get_quote_blob: {:02x?}\n",
+        dump_len,
+        &get_quote_blob[..dump_len]
+    );
+
+    // send the request to VMM via ghci
+    let get_quote_blob_ptr = get_quote_blob.as_mut_ptr() as *mut c_void;
+    let servtd_get_quote_ret =
+        unsafe { servtd_get_quote(get_quote_blob_ptr, SERVTD_REQ_BUF_SIZE as u64) };
+
+    if servtd_get_quote_ret != 0 {
+        unsafe {
+            let hdr = get_quote_blob_ptr as *mut ServtdTdxQuoteHdr;
+            log::error!(
+                "servtd_get_quote failed with error code: {} with header values:\n{:?}\n",
+                servtd_get_quote_ret,
+                (*hdr)
+            );
+        }
+        return Err(Error::GetQuote);
+    }
+
+    let hdr = get_quote_blob_ptr as *mut ServtdTdxQuoteHdr;
+
+    // Additional validation: ensure we can safely read the header
+    if (hdr as usize) < (get_quote_blob.as_ptr() as usize)
+        || (hdr as usize + header_size) > (get_quote_blob.as_ptr() as usize + get_quote_blob.len())
+    {
+        log::error!("Header pointer is outside of allocated buffer\n");
+        return Err(Error::GetQuote);
+    }
+
+    unsafe {
+        log::debug!(
+            "ServtdTdxQuoteHdr values after calling servtd_get_quote:\n {:?}\n",
+            (*hdr)
+        );
+    }
+
+    // Validate quote_size bounds
+    unsafe {
+        quote_size = (*hdr).out_len;
+    }
+    if quote_size > TD_QUOTE_SIZE as u32 {
+        log::error!(
+            "Quote size {} exceeds buffer size {}\n",
+            quote_size,
+            TD_QUOTE_SIZE
+        );
+        return Err(Error::GetQuote);
+    }
+
+    // Validate we have enough data in the buffer
+    if header_size + quote_size as usize > get_quote_blob.len() {
+        log::error!(
+            "Quote data extends beyond buffer: need {} bytes, have {} bytes\n",
+            header_size + quote_size as usize,
+            get_quote_blob.len()
+        );
+        return Err(Error::GetQuote);
+    }
+
+    // Validate output buffer size
+    if quote_size as usize > quote.len() {
+        log::error!(
+            "Quote size {} exceeds output buffer size {}\n",
+            quote_size,
+            quote.len()
+        );
+        return Err(Error::GetQuote);
+    }
+
+    quote[..quote_size as usize]
+        .copy_from_slice(&get_quote_blob[header_size..header_size + quote_size as usize]);
+
+    log::info!("get_quote_igvm returned quote_size = {}\n", quote_size);
+
+    log::debug!("quote = {:?}\n", &quote[..quote_size as usize]);
+
+    quote.truncate(quote_size as usize);
+    Ok(quote)
+}

--- a/src/attestation/src/lib.rs
+++ b/src/attestation/src/lib.rs
@@ -23,6 +23,9 @@ mod binding;
 mod ghci;
 pub mod root_ca;
 
+#[cfg(feature = "igvm-attest")]
+mod igvmattest;
+
 pub use attest::*;
 
 /// Supplemental data produced by quote verification, total serialized size is 774 bytes.

--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -95,6 +95,7 @@ AzCVMEmu = [
 	"env_logger",
 	"tokio",
 ]
+igvm-attest = ["attestation/igvm-attest"]
 
 [patch.crates-io]
 sys_time = { path = "src/std-support/sys_time" }


### PR DESCRIPTION
This change implements IGVM-based attestation quote retrieval for MigTD, providing a Rust implementation for obtaining TDX quotes through a Service TD (ServTD) interface when running in an IGVM (Isolated Guest Virtual Machine) environment. The implementation is specifically designed for Azure's virtualization stack, enabling secure communication with the VMM via GHCI to request and receive attestation quotes. This functionality is conditionally compiled with the igvm-attest feature flag, making it part of Azure's IGVM-specific deployment of TDX confidential computing capabilities.