### PR TITLE
Fix Transport Layer for SPDM Messages Receiving

### DIFF
--- a/src/migtd/src/spdm/vmcall_msg.rs
+++ b/src/migtd/src/spdm/vmcall_msg.rs
@@ -13,6 +13,7 @@ use spdmlib::{
 };
 use spin::Mutex;
 
+pub const VMCALL_SPDM_MESSAGE_HEADER_SIZE: usize = 12;
 pub const VMCALL_SPDM_SIGNATURE: u32 = 0x4D445053; // 'SPDM'
 pub const VMCALL_SPDM_VERSION: u16 = 0x0100; // Version 1.0
 pub const VMCALL_SPDM_MESSAGE_TYPE_SPDM_MESSAGE: u8 = 0x1; // 1 – DSP0274 SPDM message


### PR DESCRIPTION
Add length check when receiving SPDM messages to ensure complete message retrieval.
Fix: https://github.com/intel/MigTD/issues/548