### PR TITLE
Pin the futures to the heap to reduce stack usage

### DIFF
--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -4,6 +4,8 @@
 
 #[cfg(feature = "vmcall-raw")]
 use crate::migration::event::VMCALL_MIG_REPORTSTATUS_FLAGS;
+#[cfg(any(feature = "policy_v2", feature = "spdm_attestation"))]
+use alloc::boxed::Box;
 use alloc::collections::BTreeSet;
 #[cfg(feature = "policy_v2")]
 use async_io::{AsyncRead, AsyncWrite};
@@ -760,7 +762,7 @@ pub async fn exchange_msk(info: &MigrationInformation) -> Result<()> {
 
     // Exchange policy firstly because of the message size limitation of TLS protocol
     #[cfg(feature = "policy_v2")]
-    let remote_policy = pre_session_data_exchange(&mut transport).await?;
+    let remote_policy = Box::pin(pre_session_data_exchange(&mut transport)).await?;
 
     #[cfg(not(feature = "spdm_attestation"))]
     {
@@ -851,13 +853,12 @@ pub async fn exchange_msk(info: &MigrationInformation) -> Result<()> {
     if info.is_src() {
         let mut spdm_requester =
             spdm::spdm_requester(transport).map_err(|_| MigrationResult::SecureSessionError)?;
-
-        spdm::spdm_requester_transfer_msk(
+        Box::pin(spdm::spdm_requester_transfer_msk(
             &mut spdm_requester,
             &info.mig_info,
             #[cfg(feature = "policy_v2")]
             remote_policy,
-        )
+        ))
         .await
         .map_err(|_| MigrationResult::MutualAttestationError)?;
         log::info!("MSK exchange completed\n");
@@ -865,12 +866,12 @@ pub async fn exchange_msk(info: &MigrationInformation) -> Result<()> {
         let mut spdm_responder =
             spdm::spdm_responder(transport).map_err(|_| MigrationResult::SecureSessionError)?;
 
-        spdm::spdm_responder_transfer_msk(
+        Box::pin(spdm::spdm_responder_transfer_msk(
             &mut spdm_responder,
             &info.mig_info,
             #[cfg(feature = "policy_v2")]
             remote_policy,
-        )
+        ))
         .await
         .map_err(|_| MigrationResult::MutualAttestationError)?;
         log::info!("MSK exchange completed\n");


### PR DESCRIPTION
Pin the futures to the heap to avoid potential stack usage to
  reduce stack memory consumption.

Reduce ~ 0xE_0000 stack memory consumption on current config. 
No influence on worst case of heap consumption.