### PR TITLE
migtd: unify the memory layout for TLS and SPDM

### DIFF
--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -35,7 +35,9 @@ const MIGTD_VERSION: &str = env!("CARGO_PKG_VERSION");
 pub extern "C" fn main() {
     #[cfg(feature = "test_stack_size")]
     {
-        td_benchmark::StackProfiling::init(0x5a5a_5a5a_5a5a_5a5a, 0xd000);
+        use migtd::STACK_SIZE;
+
+        td_benchmark::StackProfiling::init(0x5a5a_5a5a_5a5a_5a5a, STACK_SIZE - 0x100000);
     }
     runtime_main()
 }
@@ -268,6 +270,8 @@ fn handle_pre_mig() {
                         }
                     }
                 }
+                #[cfg(any(feature = "test_stack_size", feature = "test_heap_size"))]
+                test_memory();
             });
         }
         sleep();
@@ -292,11 +296,11 @@ fn test_memory() {
     #[cfg(feature = "test_stack_size")]
     {
         let value = td_benchmark::StackProfiling::stack_usage().unwrap();
-        td_payload::println!("max stack usage: {}", value);
+        td_payload::println!("max stack usage: {:2x}", value);
     }
     #[cfg(feature = "test_heap_size")]
     {
         let value = td_benchmark::HeapProfiling::heap_usage().unwrap();
-        td_payload::println!("max heap usage: {}", value);
+        td_payload::println!("max heap usage: {:2x}", value);
     }
 }

--- a/src/migtd/src/lib.rs
+++ b/src/migtd/src/lib.rs
@@ -42,6 +42,9 @@ pub mod migration;
 pub mod ratls;
 pub mod spdm;
 
+pub const STACK_SIZE: usize = 0x30_0000;
+pub const HEAP_SIZE: usize = 0x70_0000;
+
 /// The entry point of MigTD-Core
 ///
 /// For the x86_64-unknown-none target, the entry point name is '_start'
@@ -52,18 +55,8 @@ pub extern "C" fn _start(hob: u64, payload: u64) -> ! {
     use td_payload::arch;
     use td_payload::mm::layout::*;
 
-    #[cfg(not(feature = "spdm_attestation"))]
-    const STACK_SIZE: usize = 0xA_2000;
-    #[cfg(not(feature = "spdm_attestation"))]
-    const HEAP_SIZE: usize = 0x6E_0000;
-
-    #[cfg(feature = "spdm_attestation")]
-    const STACK_SIZE: usize = 0x40_0000;
-    #[cfg(feature = "spdm_attestation")]
-    const HEAP_SIZE: usize = 0x40_0000;
-
     const PT_SIZE: usize = 0x8_0000;
-    const SHARED_MEMORY_SIZE: usize = 0x1E_0000;
+    const SHARED_MEMORY_SIZE: usize = 0xD_4000;
     const SHADOW_STACK_SIZE: usize = 0x10000;
 
     extern "C" {


### PR DESCRIPTION
Fix: https://github.com/intel/MigTD/issues/527
Fix: https://github.com/intel/MigTD/issues/543
Fix: https://github.com/intel/MigTD/issues/458

Tested spdm memory consumption data:
Stack: 0x18_0000
Heap: 0x12_0000 + 0x5_0000 * session_num

Proposed memory consumption calculation with buffers to avoid overflowing in worst cases,
The proposed spdm consumption equation also covers the ratls condition.
Stack: 0x30_0000
Heap: 0x10_0000 + 0x8_0000 * session_num