### PR TITLE
Add alloc_shared_pages support for AzCVMEmu mode

### DIFF
--- a/deps/td-shim-AzCVMEmu/td-payload-emu/src/mm/shared/mod.rs
+++ b/deps/td-shim-AzCVMEmu/td-payload-emu/src/mm/shared/mod.rs
@@ -3,7 +3,10 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
+use alloc::boxed::Box;
 use alloc::vec::Vec;
+
+const PAGE_SIZE: usize = 0x1000;
 
 pub struct SharedMemory {
     buf: Vec<u8>,
@@ -35,4 +38,37 @@ impl SharedMemory {
         // actual shared/private memory conversion like in real TDX
         Some(&self.buf)
     }
+}
+
+/// Allocate shared pages in emulation mode using heap allocation
+/// # Safety
+/// The caller needs to explicitly call the `free_shared_pages` function after use
+pub unsafe fn alloc_shared_pages(num: usize) -> Option<usize> {
+    let size = PAGE_SIZE.checked_mul(num)?;
+    let buf = Vec::from_iter(core::iter::repeat(0u8).take(size)).into_boxed_slice();
+    let ptr = Box::into_raw(buf) as *mut u8;
+    Some(ptr as usize)
+}
+
+/// Allocate a single shared page in emulation mode
+/// # Safety
+/// The caller needs to explicitly call the `free_shared_page` function after use
+pub unsafe fn alloc_shared_page() -> Option<usize> {
+    alloc_shared_pages(1)
+}
+
+/// Free shared pages allocated in emulation mode
+/// # Safety
+/// The caller needs to ensure the correctness of the addr and page num
+pub unsafe fn free_shared_pages(addr: usize, num: usize) {
+    let size = PAGE_SIZE.checked_mul(num).expect("Invalid page num");
+    let ptr = addr as *mut u8;
+    let _ = Box::from_raw(core::slice::from_raw_parts_mut(ptr, size));
+}
+
+/// Free a single shared page allocated in emulation mode
+/// # Safety
+/// The caller needs to ensure the correctness of the addr
+pub unsafe fn free_shared_page(addr: usize) {
+    free_shared_pages(addr, 1)
 }


### PR DESCRIPTION
Implement `alloc_shared_pages`/`free_shared_pages` family of functions in td-payload-emu to support shared memory allocation in emulation mode. Uses heap allocation (Box/Vec) to emulate the shared memory allocator used in baremetal TDX environments.

PR#[528](https://github.com/intel/MigTD/pull/528) "Support Logging for vmcall-raw feature" utilizes `alloc_shared_pages` and  is blocked because of AzCVMEmu mode build failure. This PR should remove that hurdle. Once the logging feature is in, AzCVMEmu mode can be enhanced to exercise the `EnableLogArea` request and access the log area, with another PR. 