### PR TITLE
[Policy V2] Add tools to support key & policy auto generation and auto update td info into tcb_mapping.json

### DIFF
--- a/sh_script/build_policy_v2.sh
+++ b/sh_script/build_policy_v2.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+set -euo pipefail
+
+config_temp_dir="./config/templates"
+key_dir="./key"
+
+environment="${1:-pre-production}"
+case "$environment" in
+  pre-production|preprod)
+    collateral_file="collateral_pre_production_fmspc.json"
+    ;;
+  production|prod)
+    collateral_file="collateral_production_fmspc.json"
+    ;;
+  *)
+    echo "Usage: $0 <pre-production|production>"
+    exit 1
+    ;;
+esac
+
+echo "Selected collateral environment '$environment' using $collateral_file"
+
+# Build migtd-collateral-generator and generate collateral_pre_production_fmspc.json
+# cargo build -p migtd-collateral-generator
+# ./target/debug/migtd-collateral-generator \
+#   -o $config_temp_dir/collateral_pre_production_fmspc.json \
+#   --pre-production
+
+# Build json-signer and sign td_identity.json
+cargo build -p json-signer
+./target/debug/json-signer --sign \
+  --name tdIdentity \
+  --private-key $key_dir/issuer_pkcs8.key \
+  --input $config_temp_dir/td_identity.json \
+  --output $config_temp_dir/td_identity_signed.json
+
+# Sign tcb_mapping.json
+./target/debug/json-signer --sign \
+  --name tdTcbMapping \
+  --private-key $key_dir/issuer_pkcs8.key \
+  --input $config_temp_dir/tcb_mapping.json \
+  --output $config_temp_dir/tcb_mapping_signed.json
+
+# Build servtd-collateral-generator and generate servtd_collateral.json
+cargo build -p servtd-collateral-generator
+./target/debug/servtd-collateral-generator \
+  --identity $config_temp_dir/td_identity_signed.json \
+  --identity-chain $key_dir/migtd_issuer_chain.pem \
+  --mapping $config_temp_dir/tcb_mapping_signed.json \
+  --mapping-chain $key_dir/migtd_issuer_chain.pem \
+  -o $config_temp_dir/servtd_collateral.json
+
+# Build migtd-policy-generator and generate policy_v2.json
+cargo build -p migtd-policy-generator
+./target/debug/migtd-policy-generator v2 \
+  --policy-data $config_temp_dir/policy_v2.json \
+  --collaterals $config_temp_dir/../$collateral_file \
+  --servtd-collateral $config_temp_dir/servtd_collateral.json \
+  -o $config_temp_dir/policy_v2.json
+
+# Sign policy_v2.json
+./target/debug/json-signer --sign \
+  --name policyData \
+  --private-key $key_dir/issuer_pkcs8.key \
+  --input $config_temp_dir/policy_v2.json \
+  --output $config_temp_dir/policy_v2_signed.json

--- a/sh_script/key_gen.sh
+++ b/sh_script/key_gen.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -e
+
+# Set output directory
+OUTPUT_DIR="key"
+mkdir -p "$OUTPUT_DIR"
+
+# 1. Create the Root CA Key and Certificate
+openssl ecparam -name secp384r1 -genkey -noout -out "$OUTPUT_DIR/ca.key"
+if [ ! -s "$OUTPUT_DIR/ca.key" ]; then
+	echo "Error: Root CA key ($OUTPUT_DIR/ca.key) was not generated successfully." >&2
+	exit 1
+fi
+openssl req -x509 -new -nodes -key "$OUTPUT_DIR/ca.key" -sha384 -days 3650 -out "$OUTPUT_DIR/root_ca.crt" -subj "/C=US/ST=CA/L=Santa Clara/O=MigTD Issuer/CN=MigTD Root CA"
+
+# 2. Create the Intermediate CA Key and Certificate
+openssl ecparam -name secp384r1 -genkey -noout -out "$OUTPUT_DIR/intermediate_ca.key"
+if [ ! -s "$OUTPUT_DIR/intermediate_ca.key" ]; then
+	echo "Error: Intermediate CA key ($OUTPUT_DIR/intermediate_ca.key) was not generated successfully." >&2
+	exit 1
+fi
+openssl req -new -nodes -key "$OUTPUT_DIR/intermediate_ca.key" -sha384 -out "$OUTPUT_DIR/intermediate_ca.csr" -subj "/C=US/ST=CA/L=Santa Clara/O=MigTD Intermediate Issuer/CN=MigTD Intermediate CA"
+openssl x509 -req -in "$OUTPUT_DIR/intermediate_ca.csr" -CA "$OUTPUT_DIR/root_ca.crt" -CAkey "$OUTPUT_DIR/ca.key" -CAcreateserial -sha384 -days 1825 -out "$OUTPUT_DIR/intermediate_ca.crt"
+
+# 3. Create the End-Entity (Server/Client) Key and Certificate
+openssl ecparam -name secp384r1 -genkey -noout -out "$OUTPUT_DIR/issuer.key"
+if [ ! -s "$OUTPUT_DIR/issuer.key" ]; then
+	echo "Error: End-Entity key ($OUTPUT_DIR/issuer.key) was not generated successfully." >&2
+	exit 1
+fi
+openssl req -new -nodes -key "$OUTPUT_DIR/issuer.key" -sha384 -out "$OUTPUT_DIR/issuer.csr" -subj "/C=US/ST=CA/L=Santa Clara/O=MigTD Issuer/CN=MigTD Info Issuer"
+openssl x509 -req -in "$OUTPUT_DIR/issuer.csr" -CA "$OUTPUT_DIR/intermediate_ca.crt" -CAkey "$OUTPUT_DIR/intermediate_ca.key" -CAcreateserial -sha384 -days 365 -out "$OUTPUT_DIR/issuer.crt"
+
+# 4. Concat them into cert chain
+cat "$OUTPUT_DIR/issuer.crt" "$OUTPUT_DIR/intermediate_ca.crt" "$OUTPUT_DIR/root_ca.crt" > "$OUTPUT_DIR/migtd_issuer_chain.pem"
+
+# 5. Convert issuer key to PKCS8
+openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in "$OUTPUT_DIR/issuer.key" -out "$OUTPUT_DIR/issuer_pkcs8.key"
+
+if [ ! -s "$OUTPUT_DIR/issuer_pkcs8.key" ]; then
+	echo "Error: PKCS8 key ($OUTPUT_DIR/issuer_pkcs8.key) was not generated successfully." >&2
+	exit 1
+fi
+echo "Certificate chain and keys generated successfully in $OUTPUT_DIR."

--- a/tools/migtd-hash/readme.md
+++ b/tools/migtd-hash/readme.md
@@ -32,6 +32,11 @@ popd
   ./target/debug/migtd-hash --manifest config/servtd_info.json --image <migtd.bin> --verbose
   ```
 
+  - Calculate migtd SERVTD_INFO_HASH and update tcb_mapping.json (For policy v2)
+  ```
+  ./target/debug/migtd-hash --manifest config/servtd_info.json --image <migtd.bin> --update-tcb-mapping <tcb_mapping.json> --policy-v2 --verbose
+  ```
+
   - Generate migtd SERVTD_HASH with debug infomation:
   ```
   ./target/debug/migtd-hash --manifest config/servtd_info.json --image <migtd.bin> --servtd-attr 0 --calc-servtd-hash --verbose

--- a/tools/migtd-hash/src/main.rs
+++ b/tools/migtd-hash/src/main.rs
@@ -2,21 +2,79 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
+use anyhow::{anyhow, Context};
 use clap::Parser;
 use log::debug;
 use migtd_hash::{
     build_td_info, calculate_servtd_hash, calculate_servtd_info_hash, SERVTD_TYPE_MIGTD,
 };
-use serde_json::json;
+use serde_json::{json, Value};
 use std::{
     fs::{self, File},
-    path::PathBuf,
+    path::{Path, PathBuf},
     process::exit,
 };
 
 const SERVTD_HASH_KEY: &str = "servtdHash";
 const SERVTD_INFO_HASH_KEY: &str = "servtdInfoHash";
 
+fn bytes_to_hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|byte| format!("{:02x}", byte)).collect()
+}
+
+fn update_tcb_mapping_file(
+    path: &Path,
+    mrtd: &[u8],
+    rtmr0: &[u8],
+    rtmr1: &[u8],
+) -> anyhow::Result<()> {
+    let manifest =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
+    let mut tcb_mapping: Value = serde_json::from_str(&manifest)
+        .with_context(|| format!("Failed to parse {}", path.display()))?;
+
+    let svn_mappings = tcb_mapping
+        .get_mut("svnMappings")
+        .and_then(Value::as_array_mut)
+        .ok_or_else(|| {
+            anyhow!(
+                "'svnMappings' missing or not an array in {}",
+                path.display()
+            )
+        })?;
+    let td_measurements = svn_mappings
+        .get_mut(0)
+        .ok_or_else(|| anyhow!("'svnMappings' array is empty in {}", path.display()))?
+        .get_mut("tdMeasurements")
+        .and_then(Value::as_object_mut)
+        .ok_or_else(|| {
+            anyhow!(
+                "'tdMeasurements' missing or not an object in {}",
+                path.display()
+            )
+        })?;
+
+    for (key, value) in [("mrtd", mrtd), ("rtmr0", rtmr0), ("rtmr1", rtmr1)] {
+        if !td_measurements.contains_key(key) {
+            eprintln!("Warning: '{}' not found in tdMeasurements, adding it.", key);
+        }
+        td_measurements.insert(
+            key.to_string(),
+            Value::String(bytes_to_hex(value).to_uppercase()),
+        );
+    }
+
+    let serialized = serde_json::to_string(&tcb_mapping).with_context(|| {
+        format!(
+            "Failed to serialize updated tcb mapping for {}",
+            path.display()
+        )
+    })?;
+    fs::write(path, serialized)
+        .with_context(|| format!("Failed to write updated tcb mapping to {}", path.display()))?;
+    println!("Updated {} successfully.", path.display());
+    Ok(())
+}
 #[derive(Clone, Parser)]
 struct Config {
     /// A json format manifest that contains values of TD info fields
@@ -49,6 +107,9 @@ struct Config {
     /// Enable verbose logging
     #[clap(short, long)]
     pub verbose: bool,
+    /// Update the provided tcb_mapping JSON with the generated TD measurements
+    #[clap(long)]
+    pub update_tcb_mapping: Option<PathBuf>,
 }
 
 fn main() {
@@ -157,11 +218,11 @@ fn main() {
     if let Some(output_td_info) = config.output_td_info {
         debug!("Writing TD Info to: {:?}", output_td_info);
         let td_info_json = json!({
-            "mrtd": td_info.mrtd.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
-            "rtmr0": td_info.rtmr0.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
-            "rtmr1": td_info.rtmr1.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
-            "rtmr2": td_info.rtmr2.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
-            "rtmr3": td_info.rtmr3.iter().map(|b| format!("{:02x}", b)).collect::<String>(),
+            "mrtd": bytes_to_hex(&td_info.mrtd),
+            "rtmr0": bytes_to_hex(&td_info.rtmr0),
+            "rtmr1": bytes_to_hex(&td_info.rtmr1),
+            "rtmr2": bytes_to_hex(&td_info.rtmr2),
+            "rtmr3": bytes_to_hex(&td_info.rtmr3),
         });
 
         fs::write(
@@ -172,6 +233,19 @@ fn main() {
             eprintln!("Failed to write output file: {}", e);
             exit(1);
         })
+    }
+
+    debug!("Updating tcb_mapping file...");
+    if let Some(tcb_mapping_path) = &config.update_tcb_mapping {
+        if let Err(e) = update_tcb_mapping_file(
+            tcb_mapping_path,
+            &td_info.mrtd,
+            &td_info.rtmr0,
+            &td_info.rtmr1,
+        ) {
+            eprintln!("Failed to update tcb_mapping file: {}", e);
+            exit(1);
+        }
     }
 
     debug!("Calculating servtd_info_hash...");


### PR DESCRIPTION
fix #598 

These tool can be used to automatically generate policy with corresponding td info measurement.

Example Usage:
# Generate new key pair for policy signing
bash sh_script/key_gen.sh
 
# build migtd with existing policy
cargo clean
cargo image --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain key/migtd_issuer_chain.pem --debug
 
# Build migtd-hash tool
pushd tools/migtd-hash
cargo build
popd
 
# Generate new measurement with updated TCB mapping
./target/debug/migtd-hash --manifest config/servtd_info.json --image target/debug/migtd.bin --policy-v2 --update-tcb-mapping config/templates/tcb_mapping.json
 
# Resign policy with generated keys
bash sh_script/build_policy_v2.sh preprod
 
# Rebuild migtd with new policy
cargo clean
cargo image --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain key/migtd_issuer_chain.pem --debug