### PR TITLE
Wrap the pre-session v2 policy change with timeout

### DIFF
--- a/src/migtd/src/spdm/mod.rs
+++ b/src/migtd/src/spdm/mod.rs
@@ -16,7 +16,6 @@ use async_trait::async_trait;
 use codec::Codec;
 use codec::Reader;
 use codec::Writer;
-use core::time::Duration;
 use spdmlib::common::SpdmDeviceIo;
 use spdmlib::error::*;
 use spin::Mutex;
@@ -36,8 +35,6 @@ pub use spdm_vdm::*;
 use crate::migration::MigrationResult;
 use crate::migration::MigtdMigrationInformation;
 use crate::spdm::vmcall_msg::VMCALL_SPDM_MESSAGE_HEADER_SIZE;
-
-pub const SPDM_TIMEOUT: Duration = Duration::from_secs(60); // 60 seconds
 
 pub struct MigtdTransport<T: AsyncRead + AsyncWrite + Unpin> {
     pub transport: T,


### PR DESCRIPTION
Wrap the pre-session v2 policy change with a timeout to prevent potential
    hang during pre migration.
Fix problem 1 of issue: https://github.com/intel/MigTD/issues/603