### PR TITLE
SPDM - enhance the payload size check upon receiving

### DIFF
--- a/src/migtd/src/spdm/mod.rs
+++ b/src/migtd/src/spdm/mod.rs
@@ -63,6 +63,10 @@ impl<T: AsyncRead + AsyncWrite + Unpin> SpdmDeviceIo for MigtdTransport<T> {
         _timeout: usize,
     ) -> Result<usize, usize> {
         let mut buffer = buffer.lock();
+        if buffer.len() < VMCALL_SPDM_MESSAGE_HEADER_SIZE {
+            return Err(0_usize);
+        }
+
         let mut recvd = 0;
         while recvd < VMCALL_SPDM_MESSAGE_HEADER_SIZE {
             let n = self
@@ -78,7 +82,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin> SpdmDeviceIo for MigtdTransport<T> {
             vmcall_msg::VmCallMessageHeader::read(&mut reader).ok_or(0_usize)?;
         let payload_size = vmcall_msg_header.length as usize;
 
-        if buffer.len() < payload_size + VMCALL_SPDM_MESSAGE_HEADER_SIZE {
+        if payload_size > buffer.len().saturating_sub(VMCALL_SPDM_MESSAGE_HEADER_SIZE) {
             return Err(0_usize);
         }
 


### PR DESCRIPTION
Enhance the payload size check in SPDM receive function to prevent
  buffer overflow and interger overflow.

Fix problem 2 of issue https://github.com/intel/MigTD/issues/603