### PR TITLE
Add feature enable-vmm-logger to send log macros output to vmm log area.

### DIFF
--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -100,6 +100,7 @@ AzCVMEmu = [
 	"tokio",
 ]
 igvm-attest = ["attestation/igvm-attest"]
+enable-vmm-logger = []
 
 [patch.crates-io]
 sys_time = { path = "src/std-support/sys_time" }

--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -98,12 +98,15 @@ fn main() {
 }
 
 pub fn runtime_main() {
+    #[cfg(not(feature = "enable-vmm-logger"))]
     let _ = td_logger::init();
 
     // Create LogArea per vCPU
     #[cfg(feature = "vmcall-raw")]
     {
         let _ = create_logarea();
+        #[cfg(feature = "enable-vmm-logger")]
+        let _ = init_vmm_logger();
     }
 
     // Dump basic information of MigTD

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -32,7 +32,7 @@ use zerocopy::AsBytes;
 type Result<T> = core::result::Result<T, MigrationResult>;
 
 #[cfg(feature = "vmcall-raw")]
-use super::logging::entrylog;
+use super::logging::{entrylog, set_current_request_id};
 use super::{data::*, *};
 use crate::driver::ticks::with_timeout;
 #[cfg(not(feature = "spdm_attestation"))]
@@ -273,6 +273,7 @@ pub async fn wait_for_request() -> Result<WaitForRequestResponse> {
                 Poll::Pending
             } else {
                 REQUESTS.lock().insert(mig_request_id);
+                set_current_request_id(mig_request_id);
                 Poll::Ready(Ok(WaitForRequestResponse::StartMigration(wfr_info)))
             }
         } else if operation == DataStatusOperation::GetReportData as u8 {


### PR DESCRIPTION
This pull-request implements a custom logger backend that routes Rust's standard log macros log::info!, log::error!, etc. to MigTD's structured circular buffer logging system (log area) shared with the VMM.

init_vmm_logger will call log::set_logger, which is a global, one-time initialization function from the log crate that installs a logger implementation as the destination for all subsequent log!, info!, debug!, error!, etc. macros in the entire program.

VmmLoggerBackend will implement the Log trait, which has the following three functions -

impl Log for VmmLoggerBackend {
    fn enabled(&self, metadata: &Metadata) -> bool {
    }

    fn log(&self, record: &Record) {
    }

    fn flush(&self) {}
}

This is similar to what is implemented in td_logger. When info level is enabled and log::info! is called, it invokes the log function. The implementation in this function in VmmLoggerBackend does two things -
1. Calls entrylog(&msg.into_bytes(), record.level(), request_id); 
    The last parameter here is request_id, which is got from let request_id = CURRENT_REQUEST_ID.load(Ordering::SeqCst); and is set by the function set_current_request_id.
2. Calls td_logger::dbg_write_string(&format!("{} - {}\n", record.level(), record.args())); for backward compatibility to continue sending output to the serial port if it is not blocked.