### PR TITLE
Add VmmLoggerBackend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,9 +1233,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.20"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e6163cb8c49088c2c36f57875e58ccd8c87c7427f7fbd50ea6710b2f3f2e8f"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "maybe-async"

--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 crypto = { path = "../crypto" }
 futures-util = { version = "0.3.17", default-features = false }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
-log = { version = "0.4.13", features = ["release_max_level_off"] }
+log = { version = "0.4.29", features = ["kv", "release_max_level_off"] }
 pci = { path="../devices/pci" }
 policy = {path = "../policy"}
 rust_std_stub = { path = "../std-support/rust-std-stub" }


### PR DESCRIPTION
This pull-request is related to a new feature extension to existing VMM logging mechanism (connecting it to RUST log crate) and also resolves the request: [https://github.com/https://github.com/intel/MigTD/issues/571]

Instead of using entrylog wherever logs need to be added to the vmm log area, the existing logging macros log::info!, log::error!, etc can be routed to the vmm log area. 

1. init_vmm_logger will call log::set_logger, which is a global, one-time initialization function from the log crate that installs a logger implementation as the destination for all subsequent log!, info!, debug!, error!, etc. macros in the entire program.

2. VmmLoggerBackend will implement the Log trait, which has the following three functions -

       impl Log for VmmLoggerBackend {
              fn enabled(&self, metadata: &Metadata) -> bool {
              }

              fn log(&self, record: &Record) {
              }

              fn flush(&self) {}
       }
       
This is similar to what is implemented in td_logger. When info level is enabled and log::info! is called, it invokes the log function. The implementation in this function in VmmLoggerBackend does two things -

-  Calls entrylog(&msg.into_bytes(), record.level(), request_id);
    The last parameter here is request_id, which is got from let request_id = CURRENT_REQUEST_ID.load(Ordering::SeqCst); and is set by the function set_current_request_id.

- Calls td_logger::dbg_write_string(&format!("{} - {}\n", record.level(), record.args())); for backward compatibility to continue sending output to the serial port if it is not blocked.