### PR TITLE
Change features

### DIFF
--- a/sh_script/Azure/Makefile
+++ b/sh_script/Azure/Makefile
@@ -3,9 +3,10 @@
 #
 
 IGVM_FILE ?= target/release/migtd.igvm
-LOG_LEVEL ?= debug
+LOG_LEVEL ?= trace
 # Common features for IGVM images
-IGVM_FEATURES_BASE ?= vmcall-raw,stack-guard,main,vmcall-interrupt,oneshot-apic,igvm-attest
+IGVM_FEATURES_BASE ?= vmcall-raw,stack-guard,main,vmcall-interrupt,oneshot-apic
+IGVM_FEATURES_GET_QUOTE ?= $(IGVM_FEATURES_BASE),igvm-attest
 # test_disable_ra_and_accept_all feature disables remote attestation and skips policy verification, bypassing RATLS security
 # test feature skips the compilation of attestation library when the remote attestation is not enabled or needed
 IGVM_FEATURES_DISABLE_RA_AND_ACCEPT_ALL ?= $(IGVM_FEATURES_BASE),test_disable_ra_and_accept_all
@@ -63,13 +64,13 @@ generate-hash:
 	cd ../../ &&  cargo run -p migtd-hash -- --image $(IGVM_FILE) --manifest $(IGVM_MANIFEST)
 
 build-igvm:
-	cd ../../ && cargo image --no-default-features --features $(IGVM_FEATURES_BASE) --log-level $(LOG_LEVEL) \
+	cd ../../ && cargo image --no-default-features --features $(IGVM_FEATURES_GET_QUOTE) --log-level $(LOG_LEVEL) \
 	 --image-format igvm --output $(IGVM_FILE)
 
 build-igvm-all: pre-build build-igvm generate-hash
 
 build-igvm-reject:
-	cd ../../ && cargo image --no-default-features --features $(IGVM_FEATURES_BASE) --log-level $(LOG_LEVEL) \
+	cd ../../ && cargo image --no-default-features --features $(IGVM_FEATURES_GET_QUOTE) --log-level $(LOG_LEVEL) \
 	 --image-format igvm --output $(IGVM_FILE) --debug
 
 build-igvm-reject-all: pre-build build-igvm-reject generate-hash
@@ -78,7 +79,7 @@ generate-hash-verbose:
 	cd ../../ && cargo run -p migtd-hash -- --image $(IGVM_FILE) --verbose --manifest $(IGVM_MANIFEST)
 
 build-igvm-get-quote:
-	cd ../../ && cargo image --no-default-features --features $(IGVM_FEATURES_BASE) --log-level $(LOG_LEVEL) \
+	cd ../../ && cargo image --no-default-features --features $(IGVM_FEATURES_GET_QUOTE) --log-level $(LOG_LEVEL) \
 	 --image-format igvm --output $(IGVM_FILE) --debug \
 	 --policy-v2 --policy config/templates/policy_v2_signed.json \
 	 --policy-issuer-chain config/templates/policy_issuer_chain.pem \


### PR DESCRIPTION
IGVM_FEATURES_BASE should not use have igvm-attest feature enabled. This is used only when a direct call needs to be made to GHCI for getting the quote from main.rs. 

We want to have the option in vmcall-raw to be able to go through the default path which uses servtd code path and calls GHCI from there.