### PR TITLE
Enable unified logging for Rust logging and memory logging for vmcall-raw.

### DIFF
--- a/sh_script/Azure/Makefile
+++ b/sh_script/Azure/Makefile
@@ -65,7 +65,7 @@ generate-hash:
 
 build-igvm:
 	cd ../../ && cargo image --no-default-features --features $(IGVM_FEATURES_GET_QUOTE) --log-level $(LOG_LEVEL) \
-	 --image-format igvm --output $(IGVM_FILE)
+	 --image-format igvm --output $(IGVM_FILE) --debug
 
 build-igvm-all: pre-build build-igvm generate-hash
 

--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -23,7 +23,7 @@ chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 crypto = { path = "../crypto" }
 futures-util = { version = "0.3.17", default-features = false }
 lazy_static = { version = "1.0", features = ["spin_no_std"] }
-log = { version = "0.4.29", features = ["kv", "release_max_level_off"] }
+log = { version = "0.4.29", features = ["kv"] }
 pci = { path="../devices/pci" }
 policy = {path = "../policy"}
 rust_std_stub = { path = "../std-support/rust-std-stub" }


### PR DESCRIPTION
This branch implements unified logging infrastructure for MigTD with support for structured, per-migration-request logging.

The PR addresses issues #571 and has the following changes -
1. Conditionally initializes td_logger OR vmm_logger based on feature flag
2. Ensures all subsequent logs are tagged with correct migration request ID
3. Support for key-value pairs in log messages
4. Existing log calls work as-is