### PR TITLE
MigTD: correlate more error logs with request id

### DIFF
--- a/src/migtd/src/bin/migtd/cvmemu.rs
+++ b/src/migtd/src/bin/migtd/cvmemu.rs
@@ -457,10 +457,9 @@ fn handle_pre_mig_emu() -> i32 {
                         }
                         WaitForRequestResponse::StartMigration(req) => {
                             log::info!(migration_request_id = req.mig_info.mig_request_id; "Processing StartMigration request\n");
-                            let mut data = Vec::new();
 
                             // Call exchange_msk() and log its immediate outcome
-                            let res = exchange_msk(&req, &mut data).await;
+                            let res = exchange_msk(&req).await;
                             match &res {
                                 Ok(_) => log::info!(migration_request_id = req.mig_info.mig_request_id; "exchange_msk() returned Ok\n"),
                                 Err(e) => {

--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -403,7 +403,7 @@ fn handle_pre_mig() {
             async_runtime::add_task(async move {
                 #[cfg(not(feature = "vmcall-raw"))]
                 {
-                    let status = exchange_msk(&request, &mut data)
+                    let status = exchange_msk(&request)
                         .await
                         .map(|_| MigrationResult::Success)
                         .unwrap_or_else(|e| e);
@@ -422,7 +422,7 @@ fn handle_pre_mig() {
                 {
                     match request {
                         WaitForRequestResponse::StartMigration(wfr_info) => {
-                            let status = exchange_msk(&wfr_info, &mut data)
+                            let status = exchange_msk(&wfr_info)
                                 .await
                                 .map(|_| MigrationResult::Success)
                                 .unwrap_or_else(|e| e);

--- a/src/migtd/src/ratls/server_client.rs
+++ b/src/migtd/src/ratls/server_client.rs
@@ -81,10 +81,7 @@ pub fn server<T: AsyncRead + AsyncWrite + Unpin>(
 }
 
 #[cfg(not(feature = "policy_v2"))]
-pub fn client<T: AsyncRead + AsyncWrite + Unpin>(
-    stream: T,
-    #[cfg(feature = "vmcall-raw")] data: &mut Vec<u8>,
-) -> Result<SecureChannel<T>> {
+pub fn client<T: AsyncRead + AsyncWrite + Unpin>(stream: T) -> Result<SecureChannel<T>> {
     let signing_key = EcdsaPk::new().map_err(|e| {
         log::error!("client EcdsaPk::new() failed with error {:?}\n", e);
         e
@@ -101,14 +98,6 @@ pub fn client<T: AsyncRead + AsyncWrite + Unpin>(
         e
     })?;
     config.tls_client(stream).map_err(|e| {
-        #[cfg(feature = "vmcall-raw")]
-        data.extend_from_slice(
-            &format!(
-                "Error: server_client client(): Failure in tls_client() error: {:?}\n",
-                e
-            )
-            .into_bytes(),
-        );
         log::error!(
             "server_client client(): Failure in tls_client() error: {:?}\n",
             e
@@ -121,7 +110,6 @@ pub fn client<T: AsyncRead + AsyncWrite + Unpin>(
 pub fn client<T: AsyncRead + AsyncWrite + Unpin>(
     stream: T,
     remote_policy: Vec<u8>,
-    #[cfg(feature = "vmcall-raw")] data: &mut Vec<u8>,
 ) -> Result<SecureChannel<T>> {
     let signing_key = EcdsaPk::new().map_err(|e| {
         log::error!(
@@ -146,14 +134,6 @@ pub fn client<T: AsyncRead + AsyncWrite + Unpin>(
             e
         })?;
     config.tls_client(stream).map_err(|e| {
-        #[cfg(feature = "vmcall-raw")]
-        data.extend_from_slice(
-            &format!(
-                "Error: client policy_v2 client(): Failure in tls_client() error: {:?}\n",
-                e
-            )
-            .into_bytes(),
-        );
         log::error!("client policy_v2 tls_client() failed with error {:?}\n", e);
         e.into()
     })


### PR DESCRIPTION
- Add migration_request_id to all error logs in migration_src/dst_exchange_msk
- Capture actual RatlsError details instead of discarding with |_|
- Remove redundant data.extend_from_slice() error strings (now handled by VmmLoggerBackend)
- Remove unused 'data' parameter from ratls::client(), setup_transport(), shutdown_transport()
- Remove unnecessary #[cfg(feature = "vmcall-raw")] gates from error logs

This ensures all errors during TLS/ratls setup and I/O operations are properly logged with migration_request_id for correlation in the VMM logger backend.