### PR TITLE
MigTD: Add trace-level logs for request entry points

### DIFF
--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -422,6 +422,7 @@ fn handle_pre_mig() {
                 {
                     match request {
                         WaitForRequestResponse::StartMigration(wfr_info) => {
+                            log::trace!(migration_request_id = wfr_info.mig_info.mig_request_id; "Processing StartMigration request\n");
                             let status = exchange_msk(&wfr_info)
                                 .await
                                 .map(|_| MigrationResult::Success)
@@ -450,6 +451,7 @@ fn handle_pre_mig() {
                         WaitForRequestResponse::StartRebinding(rebinding_info) => {
                             use migtd::migration::rebinding::start_rebinding;
 
+                            log::trace!(migration_request_id = rebinding_info.mig_request_id; "Processing StartRebinding request\n");
                             let status = start_rebinding(&rebinding_info, &mut data)
                                 .await
                                 .map(|_| MigrationResult::Success)
@@ -480,6 +482,7 @@ fn handle_pre_mig() {
                             REQUESTS.lock().remove(&rebinding_info.mig_request_id);
                         }
                         WaitForRequestResponse::GetTdReport(wfr_info) => {
+                            log::trace!(migration_request_id = wfr_info.mig_request_id; "Processing GetTdReport request\n");
                             let status = get_tdreport(
                                 &wfr_info.reportdata,
                                 &mut data,
@@ -499,6 +502,7 @@ fn handle_pre_mig() {
                             REQUESTS.lock().remove(&wfr_info.mig_request_id);
                         }
                         WaitForRequestResponse::EnableLogArea(wfr_info) => {
+                            log::trace!(migration_request_id = wfr_info.mig_request_id; "Processing EnableLogArea request\n");
                             let status = enable_logarea(
                                 wfr_info.log_max_level,
                                 wfr_info.mig_request_id,
@@ -532,6 +536,7 @@ fn handle_pre_mig() {
                         }
                         #[cfg(feature = "policy_v2")]
                         WaitForRequestResponse::GetMigtdData(wfr_info) => {
+                            log::trace!(migration_request_id = wfr_info.mig_request_id; "Processing GetMigtdData request\n");
                             let status = get_migtd_data(
                                 &wfr_info.reportdata,
                                 &mut data,

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -298,6 +298,7 @@ pub async fn wait_for_request() -> Result<WaitForRequestResponse> {
         }
 
         let operation: u8 = data_status_bytes[1];
+        log::trace!("wait_for_request: Received operation {} with data length {}\n", operation, data_length);
         if operation == DataStatusOperation::StartMigration as u8 {
             // data_length should be MigtdMigrationInformation
             let expected_datalength = size_of::<MigtdMigrationInformation>();


### PR DESCRIPTION
Add trace logs for receiving WFR response and at entry of each request handler: StartMigration, StartRebinding, GetTdReport, EnableLogArea, GetMigtdData.