### PR TITLE
Policy v2: skip global types for rebinding

### DIFF
--- a/src/migtd/src/mig_policy.rs
+++ b/src/migtd/src/mig_policy.rs
@@ -188,12 +188,16 @@ mod v2 {
         let relative_reference = get_local_tcb_evaluation_info()?;
         let policy = get_verified_policy().ok_or(PolicyError::InvalidParameter)?;
 
-        policy
-            .policy_data
-            .evaluate_policy_common(&evaluation_data_dst, &relative_reference)?;
-        policy
-            .policy_data
-            .evaluate_policy_forward(&evaluation_data_dst, &relative_reference)?;
+        policy.policy_data.evaluate_policy_common(
+            &evaluation_data_dst,
+            &relative_reference,
+            false,
+        )?;
+        policy.policy_data.evaluate_policy_forward(
+            &evaluation_data_dst,
+            &relative_reference,
+            false,
+        )?;
 
         // Verify the destination's policy against local policy
         verified_policy_dst
@@ -218,9 +222,11 @@ mod v2 {
         let relative_reference = get_local_tcb_evaluation_info()?;
         let policy = get_verified_policy().ok_or(PolicyError::InvalidParameter)?;
 
-        policy
-            .policy_data
-            .evaluate_policy_backward(&evaluation_data_src, &relative_reference)?;
+        policy.policy_data.evaluate_policy_backward(
+            &evaluation_data_src,
+            &relative_reference,
+            false,
+        )?;
 
         Ok(suppl_data)
     }
@@ -242,9 +248,11 @@ mod v2 {
         let relative_reference = get_local_tcb_evaluation_info()?;
         let policy = get_verified_policy().ok_or(PolicyError::InvalidParameter)?;
 
-        policy
-            .policy_data
-            .evaluate_policy_forward(&evaluation_data_dst, &relative_reference)?;
+        policy.policy_data.evaluate_policy_forward(
+            &evaluation_data_dst,
+            &relative_reference,
+            true,
+        )?;
 
         // Verify the destination's policy against local policy
         verified_policy_dst
@@ -299,15 +307,19 @@ mod v2 {
 
         let relative_reference =
             get_init_tcb_evaluation_info(&init_tdreport, &verified_policy_init)?;
-        policy
-            .policy_data
-            .evaluate_policy_common(&evaluation_data_src, &relative_reference)?;
+        policy.policy_data.evaluate_policy_common(
+            &evaluation_data_src,
+            &relative_reference,
+            true,
+        )?;
 
         // If backward policy exists, evaluate the migration src based on it.
         let relative_reference = get_local_tcb_evaluation_info()?;
-        policy
-            .policy_data
-            .evaluate_policy_backward(&evaluation_data_src, &relative_reference)?;
+        policy.policy_data.evaluate_policy_backward(
+            &evaluation_data_src,
+            &relative_reference,
+            true,
+        )?;
 
         Ok(tdx_report.as_bytes().to_vec())
     }

--- a/src/policy/src/v2/policy.rs
+++ b/src/policy/src/v2/policy.rs
@@ -298,9 +298,12 @@ impl<'a> PolicyData<'a> {
         &self,
         value: &PolicyEvaluationInfo,
         relative_reference: &PolicyEvaluationInfo,
+        skip_global: bool,
     ) -> Result<(), PolicyError> {
         match self.forward_policy.as_ref() {
-            Some(policy) => Self::evaluate_policy_block(policy, value, relative_reference),
+            Some(policy) => {
+                Self::evaluate_policy_block(policy, value, relative_reference, skip_global)
+            }
             None => Ok(()),
         }
     }
@@ -309,9 +312,12 @@ impl<'a> PolicyData<'a> {
         &self,
         value: &PolicyEvaluationInfo,
         relative_reference: &PolicyEvaluationInfo,
+        skip_global: bool,
     ) -> Result<(), PolicyError> {
         match self.backward_policy.as_ref() {
-            Some(policy) => Self::evaluate_policy_block(policy, value, relative_reference),
+            Some(policy) => {
+                Self::evaluate_policy_block(policy, value, relative_reference, skip_global)
+            }
             None => Ok(()),
         }
     }
@@ -320,9 +326,12 @@ impl<'a> PolicyData<'a> {
         &self,
         value: &PolicyEvaluationInfo,
         relative_reference: &PolicyEvaluationInfo,
+        skip_global: bool,
     ) -> Result<(), PolicyError> {
         match self.policy.as_ref() {
-            Some(policy) => Self::evaluate_policy_block(policy, value, relative_reference),
+            Some(policy) => {
+                Self::evaluate_policy_block(policy, value, relative_reference, skip_global)
+            }
             None => Ok(()),
         }
     }
@@ -331,11 +340,15 @@ impl<'a> PolicyData<'a> {
         block: &Vec<PolicyTypes>,
         value: &PolicyEvaluationInfo,
         relative_reference: &PolicyEvaluationInfo,
+        skip_global: bool,
     ) -> Result<(), PolicyError> {
         for policy_type in block {
             match policy_type {
-                PolicyTypes::Global(global) => global.evaluate(value, relative_reference)?,
+                PolicyTypes::Global(global) if !skip_global => {
+                    global.evaluate(value, relative_reference)?
+                }
                 PolicyTypes::Servtd(migtd) => migtd.evaluate(value, relative_reference)?,
+                _ => {}
             }
         }
         Ok(())


### PR DESCRIPTION
Rebinding uses TD reports instead of DCAP quotes, so platform-level TCB data (tcb_date, tcb_status, fmspc, CRL numbers) is not available. Add a skip_global parameter to evaluate_policy_* methods so rebinding callers can skip Global (TCB/platform/CRL) rules while still enforcing ServTD (MigTD identity) checks.