### PR TITLE
Sanitize session logging.

### DIFF
--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -1179,7 +1179,7 @@ pub fn write_msk(mig_info: &MigtdMigrationInformation, msk: &MigrationSessionKey
             &mig_info.target_td_uuid,
         )
         .map_err(|e| {
-            log::error!(migration_request_id = mig_info.mig_request_id; "write_msk: tdcall_servtd_wr failed with error: {:?} for mig_info.binding_handle = {}, idx = {}, value = {}\n", e, mig_info.binding_handle, idx, msk.fields[idx]);
+            log::error!(migration_request_id = mig_info.mig_request_id; "write_msk: tdcall_servtd_wr failed with error: {:?} for mig_info.binding_handle = {}, idx = {}\n", e, mig_info.binding_handle, idx);
             MigrationResult::TdxModuleError
         })?;
     }


### PR DESCRIPTION
An internal tool has flagged this code. Even though the security reviewer doesn't think it exploitable, it violates the tool and hence have requested the fix.