### PR TITLE
MigTd/spdm: fall back to local init data for rebind

### DIFF
--- a/src/migtd/src/spdm/spdm_req.rs
+++ b/src/migtd/src/spdm/spdm_req.rs
@@ -877,11 +877,9 @@ pub async fn send_and_receive_sdm_rebind_attest_info(
     //SERVTD_EXT
     let binding_handle = rebind_info.binding_handle;
     let target_td_uuid = &rebind_info.target_td_uuid;
-    if rebind_info.init_migtd_data.is_none() {
-        error!("RebindingInfo.init_migtd_data is None!\n");
-        return Err(SPDM_STATUS_INVALID_STATE_LOCAL);
-    }
-    let init_migtd_data = rebind_info.init_migtd_data.as_ref().unwrap();
+    let local_data = crate::migration::rebinding::InitData::get_from_local(&[0u8; 64])
+        .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
+    let init_migtd_data = rebind_info.init_migtd_data.as_ref().unwrap_or(&local_data);
 
     let servtd_ext = read_servtd_ext(binding_handle, target_td_uuid)
         .map_err(|_| SPDM_STATUS_INVALID_STATE_LOCAL)?;


### PR DESCRIPTION
In send_and_receive_sdm_rebind_attest_info(), the code previously returned an error when RebindingInfo.init_migtd_data was None. This is inconsistent with the RA-TLS rebinding path which falls back to InitData::get_from_local(). Apply the same fallback pattern so SPDM rebind-prepare works when init_migtd_data is not provided.