### PR TITLE
ghci/igvm_attest: handle quote error in notification path

### DIFF
--- a/src/attestation/src/ghci.rs
+++ b/src/attestation/src/ghci.rs
@@ -49,11 +49,13 @@ pub extern "C" fn servtd_get_quote(tdquote_req_buf: *mut c_void, len: u64) -> i3
         return AttestLibError::QuoteFailure as i32;
     }
 
-    if let Err(err) = wait_for_quote_completion(notify_registered, shared.as_bytes()) {
+    let wait_result = wait_for_quote_completion(notify_registered, shared.as_bytes());
+    input.copy_from_slice(&shared.as_bytes()[..len as usize]);
+
+    if let Err(err) = wait_result {
         log::error!("wait_for_quote_completion failed: {:?}\n", err);
         return err as i32;
     }
-    input.copy_from_slice(&shared.as_bytes()[..len as usize]);
 
     // Success
     0
@@ -87,19 +89,32 @@ fn wait_for_quote_completion(notify_registered: bool, buffer: &[u8]) -> Result<(
     // If the VMM notification is successfully registered, wait for VMM injecting the interrupt.
     if notify_registered {
         wait_for_vmm_notification();
-        return Ok(());
+        //GetQuote state transitioned out of in-flight, now check the status code in the buffer.
     }
 
-    let mut status_code = GET_QUOTE_STATUS_IN_FLIGHT;
-    while status_code == GET_QUOTE_STATUS_IN_FLIGHT {
-        status_code = match buffer.get(GET_QUOTE_STATUS_FIELD) {
+    let status_code = loop {
+        let status = match buffer.get(GET_QUOTE_STATUS_FIELD) {
             Some(bytes) => u64::from_le_bytes(bytes.try_into().unwrap()),
             None => {
                 log::error!("Failed to get quote status from buffer\n");
                 return Err(AttestLibError::InvalidParameter);
             }
         };
-    }
+
+        if notify_registered {
+            if status == GET_QUOTE_STATUS_IN_FLIGHT {
+                log::warn!(
+                    "UNEXPECTED Error: Quote status remains IN_FLIGHT after VMM notification\n"
+                );
+                // upper layer should retry.
+            }
+            break status;
+        }
+
+        if status != GET_QUOTE_STATUS_IN_FLIGHT {
+            break status;
+        }
+    };
 
     if status_code == GET_QUOTE_STATUS_SUCCESS {
         Ok(())

--- a/src/attestation/src/igvmattest.rs
+++ b/src/attestation/src/igvmattest.rs
@@ -125,6 +125,11 @@ pub fn get_quote_igvm(td_report: &[u8]) -> Result<Vec<u8>, Error> {
         return Err(Error::GetQuote);
     }
 
+    if quote_size == 0 {
+        log::error!("Unexpected quote size: 0\n");
+        return Err(Error::GetQuote);
+    }
+
     // Validate we have enough data in the buffer
     if header_size + quote_size as usize > get_quote_blob.len() {
         log::error!(


### PR DESCRIPTION
When MigTD registers for VMM notification of quote completion, ghci returns Ok without checking the status code in the GetQuote buffer. Remove the early return so the status code is checked after the notification is received.

Also log an unexpected error when ghci returns success but quote size is zero.