### PR TITLE
feat(migtd): verify SERVTD_ATTR using SERVTD.RD api

### DIFF
--- a/src/migtd/src/mig_policy.rs
+++ b/src/migtd/src/mig_policy.rs
@@ -712,6 +712,121 @@ mod v2 {
         let iso_date = unix_to_iso8601(timestamp).unwrap();
         assert_eq!(iso_date, "2024-01-01T00:00:00Z");
     }
+
+    #[test]
+    fn test_verify_servtd_hash_valid() {
+        // Build a 512-byte TDINFO_STRUCT with known content
+        let mut tdinfo_bytes = [0u8; 512];
+        tdinfo_bytes[0..8].copy_from_slice(&[0x01; 8]); // attributes
+        tdinfo_bytes[8..16].copy_from_slice(&[0x02; 8]); // xfam
+
+        // Compute expected hash: SHA384(SHA384(tdinfo) || type(u16) || attr(u64))
+        let servtd_attr: u64 = 0;
+        let info_hash = digest_sha384(&tdinfo_bytes).unwrap();
+        let mut buffer = [0u8; SHA384_DIGEST_SIZE + size_of::<u16>() + size_of::<u64>()];
+        buffer[..SHA384_DIGEST_SIZE].copy_from_slice(&info_hash);
+        buffer[SHA384_DIGEST_SIZE..SHA384_DIGEST_SIZE + 2]
+            .copy_from_slice(&SERVTD_TYPE_MIGTD.to_le_bytes());
+        buffer[SHA384_DIGEST_SIZE + 2..SHA384_DIGEST_SIZE + 10]
+            .copy_from_slice(&servtd_attr.to_le_bytes());
+        let expected_hash = digest_sha384(&buffer).unwrap();
+
+        let result = verify_servtd_hash(&tdinfo_bytes, servtd_attr, &expected_hash);
+        assert!(result.is_ok());
+        let td_info = result.unwrap();
+        assert_eq!(td_info.attributes, [0x01; 8]);
+        assert_eq!(td_info.xfam, [0x02; 8]);
+    }
+
+    #[test]
+    fn test_verify_servtd_hash_wrong_hash() {
+        let tdinfo_bytes = [0u8; 512];
+        let wrong_hash = [0xFFu8; 48];
+        let result = verify_servtd_hash(&tdinfo_bytes, 0, &wrong_hash);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_verify_servtd_hash_short_input() {
+        let short = [0u8; 256]; // too small for TdInfo (512 bytes)
+        let result = verify_servtd_hash(&short, 0, &[0u8; 48]);
+        assert!(matches!(result, Err(PolicyError::InvalidParameter)));
+    }
+
+    #[test]
+    fn test_verify_servtd_hash_with_ignore_attributes() {
+        // Build TdInfo with non-zero attributes
+        let mut tdinfo_bytes = [0u8; 512];
+        tdinfo_bytes[0..8].copy_from_slice(&[0xFF; 8]); // attributes
+
+        // Compute hash with attributes zeroed (IGNORE_ATTRIBUTES flag)
+        let servtd_attr = SERVTD_ATTR_IGNORE_ATTRIBUTES;
+        let mut zeroed = tdinfo_bytes;
+        zeroed[0..8].fill(0); // zero attributes for hash computation
+        let info_hash = digest_sha384(&zeroed).unwrap();
+        let mut buffer = [0u8; SHA384_DIGEST_SIZE + size_of::<u16>() + size_of::<u64>()];
+        buffer[..SHA384_DIGEST_SIZE].copy_from_slice(&info_hash);
+        buffer[SHA384_DIGEST_SIZE..SHA384_DIGEST_SIZE + 2]
+            .copy_from_slice(&SERVTD_TYPE_MIGTD.to_le_bytes());
+        buffer[SHA384_DIGEST_SIZE + 2..SHA384_DIGEST_SIZE + 10]
+            .copy_from_slice(&servtd_attr.to_le_bytes());
+        let expected_hash = digest_sha384(&buffer).unwrap();
+
+        let result = verify_servtd_hash(&tdinfo_bytes, servtd_attr, &expected_hash);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_verify_servtd_hash_with_ignore_mrowner() {
+        // Build TdInfo with non-zero mrowner at offset 112..160
+        let mut tdinfo_bytes = [0u8; 512];
+        tdinfo_bytes[112..160].copy_from_slice(&[0xAA; 48]); // mrowner
+
+        // Compute hash with mrowner zeroed (IGNORE_MROWNER flag)
+        let servtd_attr = SERVTD_ATTR_IGNORE_MROWNER;
+        let mut zeroed = tdinfo_bytes;
+        zeroed[112..160].fill(0);
+        let info_hash = digest_sha384(&zeroed).unwrap();
+        let mut buffer = [0u8; SHA384_DIGEST_SIZE + size_of::<u16>() + size_of::<u64>()];
+        buffer[..SHA384_DIGEST_SIZE].copy_from_slice(&info_hash);
+        buffer[SHA384_DIGEST_SIZE..SHA384_DIGEST_SIZE + 2]
+            .copy_from_slice(&SERVTD_TYPE_MIGTD.to_le_bytes());
+        buffer[SHA384_DIGEST_SIZE + 2..SHA384_DIGEST_SIZE + 10]
+            .copy_from_slice(&servtd_attr.to_le_bytes());
+        let expected_hash = digest_sha384(&buffer).unwrap();
+
+        let result = verify_servtd_hash(&tdinfo_bytes, servtd_attr, &expected_hash);
+        assert!(result.is_ok());
+        // mrowner should be zeroed in the returned TdInfo
+        assert_eq!(result.unwrap().mrowner, [0u8; 48]);
+    }
+
+    #[test]
+    fn test_get_rtmrs_from_tdinfo() {
+        use tdx_tdcall::tdreport::TdInfo;
+        let mut tdinfo_bytes = [0u8; 512];
+        // RTMR offsets in TdInfo: rtmr0 at 208, rtmr1 at 256, rtmr2 at 304, rtmr3 at 352
+        tdinfo_bytes[208..256].copy_from_slice(&[0x01; 48]); // rtmr0
+        tdinfo_bytes[256..304].copy_from_slice(&[0x02; 48]); // rtmr1
+        tdinfo_bytes[304..352].copy_from_slice(&[0x03; 48]); // rtmr2
+        tdinfo_bytes[352..400].copy_from_slice(&[0x04; 48]); // rtmr3
+
+        let td_info = unsafe {
+            let mut uninit = core::mem::MaybeUninit::<TdInfo>::uninit();
+            core::ptr::copy_nonoverlapping(
+                tdinfo_bytes.as_ptr(),
+                uninit.as_mut_ptr() as *mut u8,
+                size_of::<TdInfo>(),
+            );
+            uninit.assume_init()
+        };
+
+        let rtmrs = get_rtmrs_from_tdinfo(&td_info).unwrap();
+        assert_eq!(rtmrs[0], [0x01; 48]);
+        assert_eq!(rtmrs[1], [0x02; 48]);
+        assert_eq!(rtmrs[2], [0x03; 48]);
+        assert_eq!(rtmrs[3], [0x04; 48]);
+    }
 }
 
 fn get_rtmrs_from_suppl_data(

--- a/src/migtd/src/migration/rebinding.rs
+++ b/src/migtd/src/migration/rebinding.rs
@@ -617,7 +617,6 @@ async fn rebinding_old_prepare(
 }
 
 #[cfg(not(feature = "spdm_attestation"))]
-
 async fn rebinding_new_prepare(
     transport: TransportType,
     info: &RebindingInfo,
@@ -811,4 +810,186 @@ async fn tls_session_read_exact(
         recvd += n;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use alloc::vec;
+
+    /// Build a minimal valid MIGTD_DATA blob containing one TDINFO_STRUCT entry.
+    fn build_migtd_data(tdinfo: &[u8]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(MIGTD_DATA_SIGNATURE); // "MIGTDATA"
+        buf.extend_from_slice(&0x00010000u32.to_le_bytes()); // version
+        buf.extend_from_slice(&0u32.to_le_bytes()); // length placeholder
+        buf.extend_from_slice(&1u32.to_le_bytes()); // num_entries = 1
+                                                    // Entry: type 0 (TDINFO)
+        buf.extend_from_slice(&MIGTD_DATA_TYPE_TDINFO.to_le_bytes());
+        buf.extend_from_slice(&(tdinfo.len() as u32).to_le_bytes());
+        buf.extend_from_slice(tdinfo);
+        // Patch length
+        let total = buf.len() as u32;
+        buf[12..16].copy_from_slice(&total.to_le_bytes());
+        buf
+    }
+
+    /// Create a 512-byte TDINFO_STRUCT with known mrowner and mrownerconfig.
+    fn make_tdinfo(mrowner: &[u8; 48], mrownerconfig: &[u8; 48]) -> Vec<u8> {
+        let mut tdinfo = vec![0u8; 512];
+        // mrowner at offset 112..160
+        tdinfo[112..160].copy_from_slice(mrowner);
+        // mrownerconfig at offset 160..208
+        tdinfo[160..208].copy_from_slice(mrownerconfig);
+        tdinfo
+    }
+
+    // --- InitData tests ---
+
+    #[test]
+    fn test_initdata_read_write_roundtrip() {
+        let mrowner = [0xAAu8; 48];
+        let mrownerconfig = [0xBBu8; 48];
+        let tdinfo = make_tdinfo(&mrowner, &mrownerconfig);
+
+        let data = build_migtd_data(&tdinfo);
+        let init = InitData::read_from_bytes(&data).expect("should parse valid MIGTD_DATA");
+
+        assert_eq!(init.init_tdinfo.len(), 512);
+        assert_eq!(init.init_tdinfo, tdinfo);
+
+        // Round-trip: write back and re-parse
+        let mut buf = Vec::new();
+        init.write_into_bytes(&mut buf);
+        let init2 = InitData::read_from_bytes(&buf).expect("round-trip should parse");
+        assert_eq!(init2.init_tdinfo, tdinfo);
+    }
+
+    #[test]
+    fn test_initdata_mrowner_mrownerconfig() {
+        let mrowner = [0x11u8; 48];
+        let mrownerconfig = [0x22u8; 48];
+        let tdinfo = make_tdinfo(&mrowner, &mrownerconfig);
+        let data = build_migtd_data(&tdinfo);
+
+        let init = InitData::read_from_bytes(&data).unwrap();
+        assert_eq!(init.mrowner(), &mrowner);
+        assert_eq!(init.mrownerconfig(), &mrownerconfig);
+    }
+
+    #[test]
+    fn test_initdata_rejects_bad_signature() {
+        let tdinfo = vec![0u8; 512];
+        let mut data = build_migtd_data(&tdinfo);
+        data[0] = b'X'; // corrupt signature
+        assert!(InitData::read_from_bytes(&data).is_none());
+    }
+
+    #[test]
+    fn test_initdata_rejects_bad_version() {
+        let tdinfo = vec![0u8; 512];
+        let mut data = build_migtd_data(&tdinfo);
+        data[8..12].copy_from_slice(&0x00020000u32.to_le_bytes()); // wrong version
+        assert!(InitData::read_from_bytes(&data).is_none());
+    }
+
+    #[test]
+    fn test_initdata_rejects_multiple_entries() {
+        let tdinfo = vec![0u8; 512];
+        let mut data = build_migtd_data(&tdinfo);
+        data[16..20].copy_from_slice(&2u32.to_le_bytes()); // num_entries = 2
+        assert!(InitData::read_from_bytes(&data).is_none());
+    }
+
+    #[test]
+    fn test_initdata_rejects_wrong_type() {
+        let tdinfo = vec![0u8; 512];
+        let mut data = build_migtd_data(&tdinfo);
+        data[20..24].copy_from_slice(&1u32.to_le_bytes()); // type 1 instead of 0
+        assert!(InitData::read_from_bytes(&data).is_none());
+    }
+
+    #[test]
+    fn test_initdata_rejects_short_tdinfo() {
+        let tdinfo = vec![0u8; 256]; // too small (< 512)
+        let data = build_migtd_data(&tdinfo);
+        assert!(InitData::read_from_bytes(&data).is_none());
+    }
+
+    #[test]
+    fn test_initdata_rejects_empty() {
+        assert!(InitData::read_from_bytes(&[]).is_none());
+        assert!(InitData::read_from_bytes(&[0u8; 10]).is_none());
+    }
+
+    // --- RebindingInfo tests ---
+
+    /// Build a minimal RebindingInfo byte buffer.
+    fn build_rebinding_info(
+        mig_request_id: u64,
+        rebinding_src: u8,
+        has_init_data: u8,
+        uuid: [u64; 4],
+        binding_handle: u64,
+        init_data: Option<&[u8]>,
+    ) -> Vec<u8> {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&mig_request_id.to_le_bytes()); // 0..8
+        buf.push(rebinding_src); // 8
+        buf.push(has_init_data); // 9
+        buf.extend_from_slice(&[0u8; 6]); // 10..16 reserved
+        for u in &uuid {
+            buf.extend_from_slice(&u.to_le_bytes()); // 16..48
+        }
+        buf.extend_from_slice(&binding_handle.to_le_bytes()); // 48..56
+        if let Some(data) = init_data {
+            buf.extend_from_slice(data);
+        }
+        buf
+    }
+
+    #[test]
+    fn test_rebinding_info_no_init_data() {
+        let buf = build_rebinding_info(42, 1, 0, [1, 2, 3, 4], 99, None);
+        let info = RebindingInfo::read_from_bytes(&buf).expect("should parse");
+        assert_eq!(info.mig_request_id, 42);
+        assert_eq!(info.rebinding_src, 1);
+        assert_eq!(info.has_init_data, 0);
+        assert_eq!(info.target_td_uuid, [1, 2, 3, 4]);
+        assert_eq!(info.binding_handle, 99);
+        assert!(info.init_migtd_data.is_none());
+    }
+
+    #[test]
+    fn test_rebinding_info_with_init_data() {
+        let tdinfo = make_tdinfo(&[0xCAu8; 48], &[0xFEu8; 48]);
+        let migtd_data = build_migtd_data(&tdinfo);
+        let buf = build_rebinding_info(7, 0, 1, [10, 20, 30, 40], 55, Some(&migtd_data));
+        let info = RebindingInfo::read_from_bytes(&buf).expect("should parse with init data");
+        assert_eq!(info.mig_request_id, 7);
+        assert_eq!(info.has_init_data, 1);
+        let init = info.init_migtd_data.as_ref().unwrap();
+        assert_eq!(init.mrowner(), &[0xCAu8; 48]);
+        assert_eq!(init.mrownerconfig(), &[0xFEu8; 48]);
+    }
+
+    #[test]
+    fn test_rebinding_info_rejects_short_buffer() {
+        assert!(RebindingInfo::read_from_bytes(&[0u8; 10]).is_none());
+        assert!(RebindingInfo::read_from_bytes(&[0u8; 55]).is_none()); // 55 < 56
+    }
+
+    #[test]
+    fn test_rebinding_info_rejects_nonzero_reserved() {
+        let mut buf = build_rebinding_info(1, 0, 0, [0; 4], 0, None);
+        buf[10] = 0xFF; // reserved byte not zero
+        assert!(RebindingInfo::read_from_bytes(&buf).is_none());
+    }
+
+    #[test]
+    fn test_rebinding_info_rejects_has_init_data_without_data() {
+        // has_init_data=1 but no data bytes following → InitData::read_from_bytes fails
+        let buf = build_rebinding_info(1, 0, 1, [0; 4], 0, None);
+        assert!(RebindingInfo::read_from_bytes(&buf).is_none());
+    }
 }

--- a/src/migtd/src/migration/servtd_ext.rs
+++ b/src/migtd/src/migration/servtd_ext.rs
@@ -24,6 +24,17 @@ pub const TDCS_FIELD_SERVTD_ATTR: u64 = 0x1910000300000202;
 pub const TDCS_FIELD_SERVTD_ACCEPT_SERVTD_EXT_HASH: u64 = 0x1910000300000214;
 const TDCS_FIELD_WRITE_MASK: u64 = u64::MAX;
 
+/// Hardcoded expected SERVTD_ATTR value.
+///
+/// Per MigTD Design Guide: "SERVTD_ATTR is written by untrusted VMM. In order
+/// to ensure VMM writes a right value, the MigTD MUST verify
+/// TDG.SERVTD.RD(CURR_SERVTD_ATTR) matching a hardcoded value in the MigTD
+/// reflecting the intended SERVTD_ATTR."
+///
+/// Bits 15:0  = SERVTD_TYPE (0 = MigTD)
+/// Bits 40:32 = IGNORE flags for SERVTD_HASH computation
+pub const EXPECTED_SERVTD_ATTR: u64 = 0;
+
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct ServtdExt {
@@ -111,6 +122,17 @@ pub fn read_servtd_ext(
     read_field(TDCS_FIELD_INIT_TEE_MODEL, 4, &mut init_tee_model)?;
     read_field(TDCS_FIELD_SERVTD_INFO_HASH, 8, &mut cur_servtd_info_hash)?;
     read_field(TDCS_FIELD_SERVTD_ATTR, 8, &mut cur_servtd_attr)?;
+
+    // Verify CURR_SERVTD_ATTR matches the hardcoded expected value per GHCI 1.5.
+    let actual_attr = u64::from_le_bytes(cur_servtd_attr);
+    if actual_attr != EXPECTED_SERVTD_ATTR {
+        log::error!(
+            "SERVTD_ATTR mismatch: expected {:#x}, got {:#x}",
+            EXPECTED_SERVTD_ATTR,
+            actual_attr
+        );
+        return Err(MigrationResult::InvalidParameter);
+    }
 
     Ok(ServtdExt {
         init_servtd_info_hash,


### PR DESCRIPTION
Add EXPECTED_SERVTD_ATTR constant and verify TDG.SERVTD.RD(CURR_SERVTD_ATTR)
matches the hardcoded value in read_servtd_ext(), per MigTD Design Guide and
GHCI 1.5 requirements. Reject with error on mismatch.