### PR TITLE
ci: make TDX Integration Test optional (workflow_dispatch only)

### DIFF
--- a/.github/workflows/integration-tdx.yml
+++ b/.github/workflows/integration-tdx.yml
@@ -1,13 +1,7 @@
 on:
-  push:
-    paths-ignore:
-      - "**.md"
-  pull_request:
-    paths-ignore:
-      - "**.md"
   workflow_dispatch:
 
-name: Integration Test on TDX Server
+name: Integration Test on TDX Server (Optional/Broken)
 
 env:
   AS: nasm


### PR DESCRIPTION
Since the CI integration server broke and we need more time to bring it up, make the TDX Integration Test optional.

Contributes to #805 