### PR TITLE
build(migtd): bump version to 0.7.0 and update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,53 @@
 
 ### License
 
-<PROJECT NAME> is licensed under the terms in [LICENSE]<link to license file in repo>. By contributing to the project, you agree to the license and copyright terms therein and release your contribution under these terms.
+MigTD is licensed under the terms in [LICENSE](LICENSE.md). By contributing to the project, you agree to the license and copyright terms therein and release your contribution under these terms.
+
+## Commit messages
+
+When you create a commit, please write a clear and concise commit message that describes the change.
+A good commit message should explain the "what" and "why" of the change, not just the "how".
+This helps other contributors understand the purpose of the change and makes it easier to review and maintain the codebase.
+
+## Commit titles
+
+All commit titles should follow the format (all fields are required):
+
+    <type>(<crate/module>): <subject>
+
+    body (required)
+
+Where:
+
+- `<type>` is a noun describing the type of change (e.g., `fix`, `feat`, `docs`, `refactor`, etc.),
+- `<crate/module>` is the name of the crate / module affected by the change (e.g., `migtd/spdm`), `crate` is required, `module` is optional.
+- `<subject>` is a brief description of the change
+
+For example:
+
+```
+feat(migtd): verify SERVTD_ATTR using SERVTD.RD API
+
+This change adds verification of SERVTD_ATTR fields using the
+SERVTD.RD API, ensuring attributes are validated during the
+migration and rebinding flows.
+```
+
+This is a common convention used in many open-source projects and helps maintain a consistent commit history. See [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for more details and examples.
+
+### Repository-scoped changes
+
+When a change affects the repository as a whole rather than a specific crate or module (e.g., changes to CI configuration, build scripts, documentation at the root level, or tooling), use `migtd` as the crate name. For example:
+
+```
+docs(migtd): add commit message and title conventions
+
+Add sections describing the required commit message format,
+including the conventional commit title structure and the
+mandatory body field. This aligns contribution guidelines with
+the project's existing commit history and the Conventional
+Commits specification.
+```
 
 ### Sign your work
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -368,7 +368,7 @@ name = "cc-measurement"
 version = "0.1.0"
 dependencies = [
  "sha2 0.10.8",
- "zerocopy 0.7.32",
+ "zerocopy 0.8.27",
 ]
 
 [[package]]
@@ -2297,7 +2297,6 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_json",
- "spin 0.10.0",
  "spin 0.9.8",
  "sys_time 0.1.0",
  "untrusted",
@@ -2526,7 +2525,7 @@ dependencies = [
  "tdx-tdcall",
  "x86",
  "x86_64 0.14.9",
- "zerocopy 0.7.32",
+ "zerocopy 0.8.27",
 ]
 
 [[package]]
@@ -2556,7 +2555,7 @@ dependencies = [
  "td-shim-interface",
  "tdx-tdcall",
  "which",
- "zerocopy 0.7.32",
+ "zerocopy 0.8.27",
 ]
 
 [[package]]
@@ -2574,7 +2573,7 @@ dependencies = [
  "log",
  "r-efi 3.2.0",
  "scroll",
- "zerocopy 0.7.32",
+ "zerocopy 0.8.27",
 ]
 
 [[package]]

--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "migtd"
-version = "0.6.0"
+version = "0.7.0"
 license = "BSD-2-Clause-Patent"
 edition = "2021"
 


### PR DESCRIPTION
Release preparation for v0.7.0.

Changes:
- Bump migtd crate version from 0.6.0 to 0.7.0
- Update CONTRIBUTING.md with commit message conventions (conventional commits format, repository-scoped changes guidance) and fix license placeholder