### PR TITLE
MigTd: Use panic_with_guest_crash_reg_report()

### DIFF
--- a/src/migtd/src/bin/migtd/cvmemu.rs
+++ b/src/migtd/src/bin/migtd/cvmemu.rs
@@ -12,6 +12,7 @@ use std::process;
 
 use alloc::vec::Vec;
 use migtd;
+use migtd::driver::vmcall_raw::panic_with_guest_crash_reg_report;
 use migtd::migration::event;
 use migtd::migration::logging::{
     create_logarea, enable_logarea, init_vmm_logger, u8_to_levelfilter,
@@ -31,7 +32,10 @@ pub fn main() {
     // Initialize VMM logger (outputs to console via td-logger-emu in AzCVMEmu mode)
     let result = init_vmm_logger();
     if result.is_err() {
-        panic!("Failed to initialize VMM logger");
+        panic_with_guest_crash_reg_report(
+            MigrationResult::InitializationError as u64,
+            b"Failed to initialize VMM logger",
+        );
     }
 
     // Init internal heap

--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -16,6 +16,7 @@ use alloc::vec::Vec;
 use log::info;
 #[cfg(feature = "vmcall-raw")]
 use log::{debug, Level};
+use migtd::driver::vmcall_raw::panic_with_guest_crash_reg_report;
 use migtd::event_log::*;
 #[cfg(not(feature = "vmcall-raw"))]
 use migtd::migration::data::MigrationInformation;
@@ -109,7 +110,10 @@ pub fn runtime_main() {
     {
         let result = init_vmm_logger();
         if result.is_err() {
-            panic!("Failed to initialize VMM logger");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InitializationError as u64,
+                b"Failed to initialize VMM logger",
+            );
         }
         let _ = create_logarea();
     }
@@ -126,7 +130,10 @@ pub fn runtime_main() {
     #[cfg(not(feature = "vmcall-raw"))]
     {
         if query().is_err() {
-            panic!("Migration is not supported by VMM");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::Unsupported as u64,
+                b"Migration is not supported by VMM",
+            );
         }
     }
 
@@ -155,7 +162,10 @@ fn do_measurements() {
             log::error!(
                 "Failed to get the event log - firmware did not allocate event log buffer\n"
             );
-            panic!("Failed to get the event log");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InitializationError as u64,
+                b"Failed to get the event log",
+            );
         }
     };
 
@@ -180,7 +190,10 @@ fn do_measurements() {
             log::error!(
                 "Failed to get the event log - firmware did not allocate event log buffer\n"
             );
-            panic!("Failed to get the event log");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InitializationError as u64,
+                b"Failed to get the event log",
+            );
         }
     };
 
@@ -206,7 +219,10 @@ fn measure_test_feature(event_log: &mut [u8]) {
     )
     .map_err(|e| {
         log::error!("Failed to log migtd test feature: {:?}\n", e);
-        panic!("Failed to log migtd test feature");
+        panic_with_guest_crash_reg_report(
+            MigrationResult::InitializationError as u64,
+            b"Failed to log migtd test feature",
+        );
     });
 }
 
@@ -217,7 +233,10 @@ fn get_policy_and_measure(event_log: &mut [u8]) {
         Some(policy) => policy,
         None => {
             log::error!("Fail to get policy from CFV\n");
-            panic!("Fail to get policy from CFV");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InvalidPolicyError as u64,
+                b"Fail to get policy from CFV",
+            );
         }
     };
 
@@ -233,7 +252,10 @@ fn get_policy_and_measure(event_log: &mut [u8]) {
     )
     .map_err(|e| {
         log::error!("Failed to log migration policy: {:?}\n", e);
-        panic!("Failed to log migration policy");
+        panic_with_guest_crash_reg_report(
+            MigrationResult::InitializationError as u64,
+            b"Failed to log migration policy",
+        );
     });
 }
 
@@ -244,7 +266,10 @@ fn get_policy_and_measure(event_log: &mut [u8]) {
         Some(policy) => policy,
         None => {
             log::error!("Fail to get policy from CFV\n");
-            panic!("Fail to get policy from CFV");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InvalidPolicyError as u64,
+                b"Fail to get policy from CFV",
+            );
         }
     };
 
@@ -262,7 +287,10 @@ fn get_policy_and_measure(event_log: &mut [u8]) {
     )
     .map_err(|e| {
         log::error!("Failed to log migration policy: {:?}\n", e);
-        panic!("Failed to log migration policy");
+        panic_with_guest_crash_reg_report(
+            MigrationResult::InitializationError as u64,
+            b"Failed to log migration policy",
+        );
     });
 }
 
@@ -273,7 +301,10 @@ fn get_policy_issuer_chain_and_measure(event_log: &mut [u8]) {
         Some(policy_issuer_chain) => policy_issuer_chain,
         None => {
             log::error!("Fail to get policy issuer chain from CFV\n");
-            panic!("Fail to get policy issuer chain from CFV");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InvalidPolicyError as u64,
+                b"Fail to get policy issuer chain from CFV",
+            );
         }
     };
 
@@ -287,7 +318,10 @@ fn get_policy_issuer_chain_and_measure(event_log: &mut [u8]) {
     )
     .map_err(|e| {
         log::error!("Failed to log policy issuer chain: {:?}\n", e);
-        panic!("Failed to log policy issuer chain");
+        panic_with_guest_crash_reg_report(
+            MigrationResult::InitializationError as u64,
+            b"Failed to log policy issuer chain",
+        );
     });
 }
 
@@ -297,7 +331,10 @@ fn get_ca_and_measure(event_log: &mut [u8]) {
         Some(policy_issuer_chain) => policy_issuer_chain,
         None => {
             log::error!("Fail to get root certificate chain from CFV\n");
-            panic!("Fail to get root certificate chain from CFV");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InvalidPolicyError as u64,
+                b"Fail to get root certificate chain from CFV",
+            );
         }
     };
 
@@ -311,14 +348,20 @@ fn get_ca_and_measure(event_log: &mut [u8]) {
     )
     .map_err(|e| {
         log::error!("Failed to log SGX root CA: {:?}\n", e);
-        panic!("Failed to log SGX root CA");
+        panic_with_guest_crash_reg_report(
+            MigrationResult::InitializationError as u64,
+            b"Failed to log SGX root CA",
+        );
     });
 
     match attestation::root_ca::set_ca(root_ca) {
         Ok(_) => (),
         Err(e) => {
             log::error!("Invalid root certificate: {:?}\n", e);
-            panic!("Invalid root certificate");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InvalidPolicyError as u64,
+                b"Invalid root certificate",
+            );
         }
     }
 }
@@ -331,26 +374,38 @@ fn initialize_policy() -> String {
         Some(policy) => policy,
         None => {
             log::error!("Fail to get policy from CFV\n");
-            panic!("Fail to get policy from CFV");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InvalidPolicyError as u64,
+                b"Fail to get policy from CFV",
+            );
         }
     };
     let policy_issuer_chain = match config::get_policy_issuer_chain() {
         Some(chain) => chain,
         None => {
             log::error!("Fail to get policy issuer chain from CFV\n");
-            panic!("Fail to get policy issuer chain from CFV");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InvalidPolicyError as u64,
+                b"Fail to get policy issuer chain from CFV",
+            );
         }
     };
     // Initialize and verify the migration policy
     let version = mig_policy::init_policy(policy, policy_issuer_chain).map_err(|e| {
         log::error!("Failed to initialize migration policy: {:?}\n", e);
-        panic!("Failed to initialize migration policy");
+        panic_with_guest_crash_reg_report(
+            MigrationResult::InvalidPolicyError as u64,
+            b"Failed to initialize migration policy",
+        );
     });
 
     // Initialize and verify the migration policy
     let _ = mig_policy::init_tcb_info().map_err(|e| {
         log::error!("Failed to initialize migration TCB info: {:?}\n", e);
-        panic!("Failed to initialize migration TCB info");
+        panic_with_guest_crash_reg_report(
+            MigrationResult::InvalidPolicyError as u64,
+            b"Failed to initialize migration TCB info",
+        );
     });
 
     version.expect("Failed to initialize migration policy")

--- a/src/migtd/src/driver/timer.rs
+++ b/src/migtd/src/driver/timer.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use super::vmcall_raw::panic_with_guest_crash_reg_report;
+use crate::migration::MigrationResult;
 use core::sync::atomic::{AtomicBool, Ordering};
 use spin::Once;
 use td_payload::arch::apic::*;
@@ -42,7 +43,10 @@ pub fn init_timer() {
         TSC_DEADLINE_ENABLED.store(false, Ordering::SeqCst);
         #[cfg(not(feature = "oneshot-apic"))]
         {
-            panic!("Please enable TSC deadline mode for TD");
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InitializationError as u64,
+                b"Please enable TSC deadline mode for TD",
+            );
         }
     }
 
@@ -122,7 +126,10 @@ fn set_timer_notification(vector: u8) {
     // Setup interrupt handler
     if register_interrupt_callback(vector as usize, InterruptCallback::new(timer_handler)).is_err()
     {
-        panic_with_guest_crash_reg_report(0xFF, b"Failed to set interrupt callback for timer");
+        panic_with_guest_crash_reg_report(
+            MigrationResult::InitializationError as u64,
+            b"Failed to set interrupt callback for timer",
+        );
     }
 }
 

--- a/src/migtd/src/driver/vmcall_raw.rs
+++ b/src/migtd/src/driver/vmcall_raw.rs
@@ -15,7 +15,7 @@ pub fn vmcall_raw_device_init() {
 }
 
 #[track_caller]
-pub fn panic_with_guest_crash_reg_report(errorcode: u64, msg: &[u8]) {
+pub fn panic_with_guest_crash_reg_report(errorcode: u64, msg: &[u8]) -> ! {
     #[cfg(not(feature = "vmcall-raw"))]
     let _ = errorcode;
     let location = core::panic::Location::caller();

--- a/src/migtd/src/migration/event.rs
+++ b/src/migtd/src/migration/event.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use crate::driver::vmcall_raw::panic_with_guest_crash_reg_report;
+use crate::migration::MigrationResult;
 use core::sync::atomic::{AtomicBool, Ordering};
 use td_payload::arch::apic::*;
 use td_payload::arch::idt::{register_interrupt_callback, InterruptCallback, InterruptStack};
@@ -22,7 +23,7 @@ pub fn register_callback() {
     .is_err()
     {
         panic_with_guest_crash_reg_report(
-            0xFF,
+            MigrationResult::InitializationError as u64,
             b"Failed to set interrupt callback for VMCALL_SERVICE",
         );
     }

--- a/src/migtd/src/migration/mod.rs
+++ b/src/migtd/src/migration/mod.rs
@@ -188,6 +188,7 @@ pub enum MigrationResult {
     VmmCanceled = 10,
     VmmInternalError = 11,
     UnsupportedOperationError = 12,
+    InitializationError = 0xFF,
 }
 
 impl TryFrom<u8> for MigrationResult {
@@ -208,6 +209,7 @@ impl TryFrom<u8> for MigrationResult {
             10 => Ok(MigrationResult::VmmCanceled),
             11 => Ok(MigrationResult::VmmInternalError),
             12 => Ok(MigrationResult::UnsupportedOperationError),
+            0xFF => Ok(MigrationResult::InitializationError),
             _ => Err(()),
         }
     }


### PR DESCRIPTION
Replace hard-coded 0xFF error code with proper MigrationResult variants

Fixes:https://github.com/intel/MigTD/issues/765