### PR TITLE
attestation: fix UB in FFI return type for servtd_attest functions

### DIFF
--- a/src/attestation/src/attest.rs
+++ b/src/attestation/src/attest.rs
@@ -9,7 +9,7 @@ use crate::binding::verify_quote_integrity_ex;
 use crate::binding::get_quote as get_quote_inner;
 
 use crate::{
-    binding::{init_heap, verify_quote_integrity, AttestLibError, QveCollateral},
+    binding::{init_heap, verify_quote_integrity, QveCollateral},
     root_ca::ROOT_CA_PUBLIC_KEY,
     Error, TD_VERIFIED_REPORT_SIZE,
 };
@@ -91,8 +91,8 @@ pub fn get_quote(td_report: &[u8]) -> Result<Vec<u8>, Error> {
                 quote.as_mut_ptr() as *mut c_void,
                 &mut quote_size as *mut u32,
             );
-            if result != AttestLibError::Success {
-                log::error!("get_quote_inner failed with error: {:?}\n", result);
+            if result != 0 {
+                log::error!("get_quote_inner failed with error: {:#x}\n", result);
                 return Err(Error::GetQuote);
             }
         }
@@ -118,8 +118,8 @@ pub fn verify_quote(quote: &[u8]) -> Result<Vec<u8>, Error> {
             td_report_verify.as_mut_ptr() as *mut c_void,
             &mut report_verify_size as *mut u32,
         );
-        if result != AttestLibError::Success {
-            log::error!("verify_quote_integrity failed with error: {:?}\n", result);
+        if result != 0 {
+            log::error!("verify_quote_integrity failed with error: {:#x}\n", result);
             return Err(Error::VerifyQuote);
         }
     }
@@ -160,9 +160,9 @@ pub fn verify_quote_with_collaterals(
             td_report_verify.as_mut_ptr() as *mut c_void,
             &mut report_verify_size as *mut u32,
         );
-        if result != AttestLibError::Success {
+        if result != 0 {
             log::error!(
-                "verify_quote_integrity_ex failed with error: {:?}\n",
+                "verify_quote_integrity_ex failed with error: {:#x}\n",
                 result
             );
             return Err(Error::VerifyQuote);

--- a/src/attestation/src/binding.rs
+++ b/src/attestation/src/binding.rs
@@ -84,7 +84,7 @@ mod attest_lib_binding {
             tdx_report_size: u32,
             p_quote: *mut ::core::ffi::c_void,
             p_quote_size: *mut u32,
-        ) -> AttestLibError;
+        ) -> i32;
 
         /// Verify the integrity of MigTD's Quote and return td report of MigTD
         /// Note: all IN/OUT memory should be managed by Caller
@@ -106,7 +106,7 @@ mod attest_lib_binding {
             root_pub_key_size: u32,
             p_tdx_report_verify: *mut ::core::ffi::c_void,
             p_tdx_report_verify_size: *mut u32,
-        ) -> AttestLibError;
+        ) -> i32;
 
         #[cfg(feature = "attest-lib-ext")]
         pub fn verify_quote_integrity_ex(
@@ -117,7 +117,7 @@ mod attest_lib_binding {
             p_collateral: *const QveCollateral,
             p_tdx_report_verify: *mut ::core::ffi::c_void,
             p_tdx_report_verify_size: *mut u32,
-        ) -> AttestLibError;
+        ) -> i32;
 
         /// Allocate heap space for MigTD Attestation library internal use,
         /// Must be called only once by MigTD before other attestation lib APIs
@@ -127,10 +127,7 @@ mod attest_lib_binding {
         ///
         /// @return true: Successfully init heap for internal use.
         /// @return false: Failed to init heap for internal use. E.g. the parameter is incorrect, etc.
-        pub fn init_heap(
-            p_td_heap_base: *const ::core::ffi::c_void,
-            td_heap_size: u32,
-        ) -> AttestLibError;
+        pub fn init_heap(p_td_heap_base: *const ::core::ffi::c_void, td_heap_size: u32) -> i32;
     }
 }
 
@@ -145,9 +142,9 @@ mod null_binding {
         _tdx_report_size: u32,
         _p_quote: *mut ::core::ffi::c_void,
         _p_quote_size: *mut u32,
-    ) -> AttestLibError {
+    ) -> i32 {
         *_p_quote_size = TD_VERIFIED_REPORT_SIZE as u32;
-        AttestLibError::Success
+        0
     }
 
     #[no_mangle]
@@ -158,8 +155,8 @@ mod null_binding {
         _root_pub_key_size: u32,
         _p_tdx_report_verify: *mut ::core::ffi::c_void,
         _p_tdx_report_verify_size: *mut u32,
-    ) -> AttestLibError {
-        AttestLibError::Success
+    ) -> i32 {
+        0
     }
 
     #[cfg(feature = "attest-lib-ext")]
@@ -172,15 +169,15 @@ mod null_binding {
         p_collateral: *const QveCollateral,
         p_tdx_report_verify: *mut ::core::ffi::c_void,
         p_tdx_report_verify_size: *mut u32,
-    ) -> AttestLibError {
-        AttestLibError::Success
+    ) -> i32 {
+        0
     }
 
     #[no_mangle]
     pub unsafe extern "C" fn init_heap(
         _p_td_heap_base: *const ::core::ffi::c_void,
         _td_heap_size: u32,
-    ) -> AttestLibError {
-        AttestLibError::Success
+    ) -> i32 {
+        0
     }
 }


### PR DESCRIPTION
The C library libservtd_attest.a uses servtd_attest_error_t values (e.g. SERVTD_ATTEST_ERROR_QUOTE_FAILURE = 0x0070), but the Rust FFI declarations used the AttestLibError enum whose discriminants match the internal TDX_ATTEST_ERROR_* range (e.g. QuoteFailure = 0x0008).

When the C code returned a value outside the Rust enum's discriminant set, this created an invalid enum value — undefined behavior in Rust. In Release builds the UB was silent, but in Debug builds (Rust 1.88 with ub_checks enabled) it triggered a panic:

  "unsafe precondition(s) violated: hint::unreachable_unchecked
   must never be reached"

Fix by changing FFI return types from AttestLibError to i32 and comparing against 0 (success) instead of AttestLibError::Success. This matches the C API contract where 0 means success and any non-zero value is an error code. Error codes are now logged in hex for easier cross-reference with the C header.

Affected functions: get_quote, verify_quote_integrity, verify_quote_integrity_ex, init_heap.