### PR TITLE
Refactor wait_for_request() to catch all errors to report

### DIFF
--- a/deps/td-shim-AzCVMEmu/tdx-tdcall/src/tdx_emu.rs
+++ b/deps/td-shim-AzCVMEmu/tdx-tdcall/src/tdx_emu.rs
@@ -70,7 +70,7 @@ pub enum EmuMigRequest {
         target_td_uuid: [u64; 4],
         binding_handle: u64,
     },
-    GetReportData {
+    GetTDReport {
         request_id: u64,
         reportdata: [u8; 64],
     },
@@ -100,10 +100,10 @@ pub fn set_emulated_mig_request(req: EmuMigRequest) {
     MIG_REQUEST.lock().push(req);
 }
 
-/// Helper: Set a complete migration flow with EnableLogArea, GetReportData, and StartMigration
+/// Helper: Set a complete migration flow with EnableLogArea, GetTDReport, and StartMigration
 /// Automatically queues all three requests in sequence
 /// Uses request_id for migration, request_id | 0x8000_0000_0000_0000 for EnableLogArea,
-/// and request_id | 0x4000_0000_0000_0000 for GetReportData
+/// and request_id | 0x4000_0000_0000_0000 for GetTDReport
 pub fn set_emulated_start_migration(
     request_id: u64,
     migration_source: u8,
@@ -112,7 +112,7 @@ pub fn set_emulated_start_migration(
 ) {
     // Use different bit markers to distinguish each request type
     let enable_log_request_id = request_id | 0x8000_0000_0000_0000; // High bit for EnableLogArea
-    let get_report_request_id = request_id | 0x4000_0000_0000_0000; // Second-high bit for GetReportData
+    let get_report_request_id = request_id | 0x4000_0000_0000_0000; // Second-high bit for GetTDReport
 
     // Step 1: Queue EnableLogArea with Info level (3)
     set_emulated_mig_request(EmuMigRequest::EnableLogArea {
@@ -120,12 +120,12 @@ pub fn set_emulated_start_migration(
         log_max_level: 3,
     });
 
-    // Step 2: Queue GetReportData with default reportdata
+    // Step 2: Queue GetTDReport with default reportdata
     let mut reportdata = [0u8; 64];
     reportdata[0..8].copy_from_slice(&request_id.to_le_bytes());
     reportdata[8..23].copy_from_slice(b"MIGTD_MIGRATION"); // 15 bytes
     reportdata[23] = 0; // Null terminator
-    set_emulated_mig_request(EmuMigRequest::GetReportData {
+    set_emulated_mig_request(EmuMigRequest::GetTDReport {
         request_id: get_report_request_id,
         reportdata,
     });
@@ -139,7 +139,7 @@ pub fn set_emulated_start_migration(
     });
 }
 
-/// Helper: Set a GetReportData request
+/// Helper: Set a GetTDReport request
 /// Automatically queues EnableLogArea request first, then the report request
 /// Uses request_id for report, and request_id | 0x8000_0000_0000_0000 for EnableLogArea
 pub fn set_emulated_get_report_data(request_id: u64, reportdata: [u8; 64]) {
@@ -152,8 +152,8 @@ pub fn set_emulated_get_report_data(request_id: u64, reportdata: [u8; 64]) {
         log_max_level: 3,
     });
 
-    // Then queue the GetReportData request with original request_id
-    set_emulated_mig_request(EmuMigRequest::GetReportData {
+    // Then queue the GetTDReport request with original request_id
+    set_emulated_mig_request(EmuMigRequest::GetTDReport {
         request_id,
         reportdata,
     });
@@ -563,7 +563,7 @@ pub fn tdvmcall_migtd_waitforrequest(
     // data_buffer uses the GHCI 1.5 buffer format:
     // Bytes 0-7: status (u64) - filled by VMM/emulation
     //   byte[0] = 1 (TDX_VMCALL_VMM_SUCCESS)
-    //   byte[1] = operation type (1=StartMigration, 3=GetReportData, 4=EnableLogArea)
+    //   byte[1] = operation type (1=StartMigration, 3=GetTDReport, 4=EnableLogArea)
     // Bytes 8-11: length (u32) - filled by VMM/emulation
     // Bytes 12+: Request-specific payload
 
@@ -633,17 +633,17 @@ pub fn tdvmcall_migtd_waitforrequest(
                     migration_source
                 );
             }
-            EmuMigRequest::GetReportData {
+            EmuMigRequest::GetTDReport {
                 request_id,
                 reportdata,
             } => {
-                // DataStatusOperation::GetReportData = 3
-                let status = 0x0000_0000_0000_0301u64; // byte[0]=1 (success), byte[1]=3 (GetReportData)
+                // DataStatusOperation::GetTDReport = 3
+                let status = 0x0000_0000_0000_0301u64; // byte[0]=1 (success), byte[1]=3 (GetTDReport)
                 let length = REPORT_DATA_PAYLOAD_LEN as u32;
 
                 if data_buffer.len() < HEADER_LEN + REPORT_DATA_PAYLOAD_LEN {
                     error!(
-                        "waitforrequest buffer too small for GetReportData: have={} need={}",
+                        "waitforrequest buffer too small for GetTDReport: have={} need={}",
                         data_buffer.len(),
                         HEADER_LEN + REPORT_DATA_PAYLOAD_LEN
                     );
@@ -662,7 +662,7 @@ pub fn tdvmcall_migtd_waitforrequest(
                 payload[8..72].copy_from_slice(&reportdata);
 
                 log::info!(
-                    "tdvmcall_migtd_waitforrequest: GetReportData request_id={} reportdata[0..8]={:02x?}",
+                    "tdvmcall_migtd_waitforrequest: GetTDReport request_id={} reportdata[0..8]={:02x?}",
                     request_id, &reportdata[0..8]
                 );
             }
@@ -882,9 +882,9 @@ pub fn tdvmcall_migtd_reportstatus(
                 );
             }
         } else if (mig_request_id & 0x4000_0000_0000_0000) != 0 {
-            // This is a GetReportData response (second-high bit set)
+            // This is a GetTDReport response (second-high bit set)
             log::info!(
-                "tdvmcall_migtd_reportstatus: GetReportData response detected (request_id has second-high bit set)"
+                "tdvmcall_migtd_reportstatus: GetTDReport response detected (request_id has second-high bit set)"
             );
 
             // If it looks like a TD report (1024 bytes), show some key fields

--- a/migtdemu.sh
+++ b/migtdemu.sh
@@ -83,7 +83,7 @@ show_usage() {
     echo "    example files in config/AzCVMEmu. Some reference values in those files for the ServTD may become"
     echo "    outdated over time. Use ./sh_script/build_AzCVMEmu_policy_and_test.sh to generate updated policy"
     echo "    and issuer chain files."
-    echo "  - Migration flow automatically includes EnableLogArea and GetReportData requests before"
+    echo "  - Migration flow automatically includes EnableLogArea and GetTDReport requests before"
     echo "    the actual migration, ensuring logging is enabled and a TD report is generated."
     echo "  - CPU affinity is controlled via taskset. Use --num-cpus to specify the number of CPUs"
     echo "    (e.g., 2 means CPUs 0-1, 4 means CPUs 0-3). Default is 1 CPU for single-threaded behavior."
@@ -93,7 +93,7 @@ show_usage() {
     echo "    token exchange, and approval). 'rebind-finalize' clears the session token."
     echo
     echo "Examples:"
-    echo "  # Migration testing (includes EnableLogArea → GetReportData → StartMigration)"
+    echo "  # Migration testing (includes EnableLogArea → GetTDReport → StartMigration)"
     echo "  $0                                    # Build release and run as source with defaults"
     echo "  $0 --role destination                # Build release and run as destination"
     echo "  $0 --debug --role source             # Build debug and run as source"

--- a/src/migtd/src/bin/migtd/cvmemu.rs
+++ b/src/migtd/src/bin/migtd/cvmemu.rs
@@ -383,7 +383,7 @@ fn parse_commandline_args() {
     match operation {
         "migration" => {
             log::info!(
-                "Setting up migration flow (EnableLogArea → GetReportData → StartMigration)\n"
+                "Setting up migration flow (EnableLogArea → GetTDReport → StartMigration)\n"
             );
             set_emulated_start_migration(mig_request_id, rebinding_src, td_uuid, binding_handle);
         }
@@ -441,7 +441,7 @@ fn print_usage() {
     println!("  export MIGTD_POLICY_FILE=config/policy.json");
     println!("  export MIGTD_ROOT_CA_FILE=config/Intel_SGX_Provisioning_Certification_RootCA.cer");
     println!();
-    println!("  # Migration (automatically includes EnableLogArea and GetReportData):");
+    println!("  # Migration (automatically includes EnableLogArea and GetTDReport):");
     println!("  ./migtd --role source --request-id 42");
     println!("  ./migtd -m destination -r 42 -b 0x5678");
     println!("  ./migtd --role source --dest-ip 192.168.1.100 --dest-port 8001");
@@ -456,7 +456,7 @@ fn handle_pre_mig_emu() -> i32 {
     // For AzCVMEmu, create an async runtime and run the standard flow
     let rt = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
 
-    // Process requests in sequence: EnableLogArea → GetReportData → StartMigration
+    // Process requests in sequence: EnableLogArea → GetTDReport → StartMigration
     let exit_code: i32 = rt.block_on(async move {
         loop {
             match migtd::migration::session::wait_for_request().await {
@@ -554,7 +554,7 @@ fn handle_pre_mig_emu() -> i32 {
                             }
                         }
                         WaitForRequestResponse::GetTdReport(report_info) => {
-                            log::info!(migration_request_id = report_info.mig_request_id; "Processing GetReportData request\n");
+                            log::info!(migration_request_id = report_info.mig_request_id; "Processing GetTDReport request\n");
                             log::debug!(migration_request_id = report_info.mig_request_id;
                                 "ReportData (first 32 bytes): {:02x?}\n",
                                 &report_info.reportdata[0..32]

--- a/src/migtd/src/migration/logging.rs
+++ b/src/migtd/src/migration/logging.rs
@@ -280,6 +280,9 @@ pub async fn enable_logarea(log_max_level: u8, request_id: u64, data: &mut Vec<u
         #[cfg(test)]
         {
             let logareavector = LOGAREAPTR.lock();
+            if logareavector.is_empty() {
+                return Err(MigrationResult::OutOfResource);
+            }
             let data_buffer = logareavector[0] as *mut u8;
             let data_buffer = unsafe { core::slice::from_raw_parts_mut(data_buffer, PAGE_SIZE) };
 
@@ -460,6 +463,9 @@ pub fn entrylog(msg: &Vec<u8>, loglevel: Level, request_id: u64) {
                 logareavector = PROVISIONAL_LOGAREAPTR.lock();
             } else {
                 logareavector = LOGAREAPTR.lock();
+            }
+            if logareavector.is_empty() {
+                return;
             }
             let data_buffer = logareavector[0] as *mut u8;
             let data_buffer =
@@ -654,8 +660,14 @@ pub fn init_vmm_logger() -> core::result::Result<(), SetLoggerError> {
 mod test {
     use super::*;
 
+    /// All logging tests share global state (LOGAREAPTR, LOGGING_INFORMATION, the
+    /// installed logger). Serialize them to prevent data races where one test
+    /// clears LOGAREAPTR while another test's logger callback reads from it.
+    static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     #[test]
     fn test_create_logarea() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // Reset the global state for testing
         LOGGING_INFORMATION.num_vcpus.store(0, Ordering::SeqCst);
         LOGGING_INFORMATION
@@ -706,6 +718,7 @@ mod test {
 
     #[tokio::test]
     async fn test_enable_logarea() {
+        let _guard = TEST_LOCK.lock().unwrap();
         let mut data: Vec<u8> = Vec::new();
         let log_max_level: u8 = 5;
 
@@ -750,6 +763,7 @@ mod test {
 
     #[tokio::test]
     async fn test_provisional_entrylog() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // Reset the global state for testing
         LOGGING_INFORMATION.num_vcpus.store(0, Ordering::SeqCst);
         LOGGING_INFORMATION
@@ -832,6 +846,7 @@ mod test {
 
     #[tokio::test]
     async fn test_entrylog() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // Reset the global state for testing
         LOGGING_INFORMATION.num_vcpus.store(0, Ordering::SeqCst);
         LOGGING_INFORMATION
@@ -920,6 +935,7 @@ mod test {
 
     #[tokio::test]
     async fn test_provisional_and_entrylog_combined() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // Reset the global state for testing
         LOGGING_INFORMATION.num_vcpus.store(0, Ordering::SeqCst);
         LOGGING_INFORMATION
@@ -1064,6 +1080,7 @@ mod test {
 
     #[tokio::test]
     async fn test_entrylog_message_max_buffersize() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // Reset the global state for testing
         LOGGING_INFORMATION.num_vcpus.store(0, Ordering::SeqCst);
         LOGGING_INFORMATION
@@ -1124,6 +1141,7 @@ mod test {
 
     #[tokio::test]
     async fn test_entrylog_message_greaterthan_buffersize() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // Reset the global state for testing
         LOGGING_INFORMATION.num_vcpus.store(0, Ordering::SeqCst);
         LOGGING_INFORMATION
@@ -1166,6 +1184,7 @@ mod test {
 
     #[tokio::test]
     async fn test_entrylog_message_with_headerlen_left_at_bottom() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // Reset the global state for testing
         LOGGING_INFORMATION.num_vcpus.store(0, Ordering::SeqCst);
         LOGGING_INFORMATION
@@ -1264,6 +1283,7 @@ mod test {
 
     #[tokio::test]
     async fn test_entrylog_message_with_lessthan_headerlen_at_bottom() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // Reset the global state for testing
         LOGGING_INFORMATION.num_vcpus.store(0, Ordering::SeqCst);
         LOGGING_INFORMATION
@@ -1361,6 +1381,7 @@ mod test {
 
     #[tokio::test]
     async fn test_entrylog_message_with_startoffset_at_invalid_message() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // Reset the global state for testing
         LOGGING_INFORMATION.num_vcpus.store(0, Ordering::SeqCst);
         LOGGING_INFORMATION
@@ -1458,6 +1479,7 @@ mod test {
 
     #[tokio::test]
     async fn test_log_info() {
+        let _guard = TEST_LOCK.lock().unwrap();
         // cargo test --features vmcall-raw --lib migration::logging::test::test_log_info -- --nocapture
 
         // Reset the global state for testing

--- a/src/migtd/src/migration/mod.rs
+++ b/src/migtd/src/migration/mod.rs
@@ -26,6 +26,71 @@ use crypto::Error as CryptoError;
 use r_efi::efi::Guid;
 use rust_std_stub::io;
 use scroll::{Pread, Pwrite};
+
+/// Implement `read_from_bytes(data_length, payload)` for a fixed-size
+/// `#[derive(Pread)]` struct. Validates `data_length == size_of::<Self>()`
+/// and rejects payloads with trailing bytes.
+#[cfg(feature = "vmcall-raw")]
+macro_rules! impl_read_from_bytes {
+    ($t:ty) => {
+        #[cfg(feature = "vmcall-raw")]
+        impl $t {
+            pub fn read_from_bytes(
+                data_length: u32,
+                payload: &[u8],
+            ) -> core::result::Result<Self, MigrationResult> {
+                if data_length != core::mem::size_of::<Self>() as u32 {
+                    return Err(MigrationResult::InvalidParameter);
+                }
+                payload
+                    .pread(0)
+                    .map_err(|_| MigrationResult::InvalidParameter)
+            }
+        }
+    };
+}
+
+/// Implement `read_from_bytes(data_length, payload)` for a struct whose layout
+/// starts with `mig_request_id: u64` followed by optional data bytes.
+/// Accepts either the full struct or just the `mig_request_id` (with the
+/// optional field set to its default).
+///
+/// Usage: `impl_read_from_bytes_with_optional!(Type, field_name, default_value)`
+///
+/// Example:
+///   `impl_read_from_bytes_with_optional!(ReportInfo, reportdata, [0u8; 64])`
+#[cfg(feature = "vmcall-raw")]
+macro_rules! impl_read_from_bytes_with_optional {
+    ($t:ty, $field:ident, $default:expr) => {
+        #[cfg(feature = "vmcall-raw")]
+        impl $t {
+            pub fn read_from_bytes(
+                data_length: u32,
+                payload: &[u8],
+            ) -> core::result::Result<Self, MigrationResult> {
+                let request_id_only = core::mem::size_of::<u64>() as u32;
+                let full_size = core::mem::size_of::<Self>() as u32;
+                if data_length != request_id_only && data_length != full_size {
+                    return Err(MigrationResult::InvalidParameter);
+                }
+                if data_length == full_size {
+                    payload
+                        .pread(0)
+                        .map_err(|_| MigrationResult::InvalidParameter)
+                } else {
+                    let mig_request_id: u64 = payload
+                        .pread(0)
+                        .map_err(|_| MigrationResult::InvalidParameter)?;
+                    Ok(Self {
+                        mig_request_id,
+                        $field: $default,
+                    })
+                }
+            }
+        }
+    };
+}
+
 use tdx_tdcall::TdCallError;
 use tdx_tdcall::TdVmcallError;
 #[cfg(feature = "virtio-serial")]
@@ -105,6 +170,9 @@ pub struct MigtdMigrationInformation {
     pub communication_id: u64,
 }
 
+#[cfg(feature = "vmcall-raw")]
+impl_read_from_bytes!(MigtdMigrationInformation);
+
 #[repr(C)]
 #[derive(Debug, Pread, Pwrite)]
 #[cfg(feature = "vmcall-raw")]
@@ -114,6 +182,9 @@ pub struct ReportInfo {
     pub mig_request_id: u64,
     pub reportdata: [u8; 64],
 }
+
+#[cfg(feature = "vmcall-raw")]
+impl_read_from_bytes_with_optional!(ReportInfo, reportdata, [0u8; 64]);
 
 #[repr(C)]
 #[derive(Debug, Pread, Pwrite)]
@@ -125,6 +196,9 @@ pub struct MigtdDataInfo {
     pub reportdata: [u8; 64],
 }
 
+#[cfg(all(feature = "vmcall-raw", feature = "policy_v2"))]
+impl_read_from_bytes_with_optional!(MigtdDataInfo, reportdata, [0u8; 64]);
+
 #[repr(C)]
 #[derive(Debug, Pread, Pwrite)]
 #[cfg(feature = "vmcall-raw")]
@@ -135,6 +209,9 @@ pub struct EnableLogAreaInfo {
     pub log_max_level: u8,
     pub reserved: [u8; 7],
 }
+
+#[cfg(feature = "vmcall-raw")]
+impl_read_from_bytes!(EnableLogAreaInfo);
 
 #[repr(C)]
 #[derive(Debug, Pread, Pwrite)]

--- a/src/migtd/src/migration/rebinding.rs
+++ b/src/migtd/src/migration/rebinding.rs
@@ -90,10 +90,15 @@ pub struct RebindingInfo {
 }
 
 impl RebindingInfo {
-    pub fn read_from_bytes(b: &[u8]) -> Option<Self> {
-        // Check the length of input and the reserved fields (bytes 10-15 per GHCI 1.5)
-        if b.len() < 56 || b[10..16] != [0; 6] {
-            return None;
+    pub fn read_from_bytes(
+        data_length: u32,
+        payload: &[u8],
+    ) -> core::result::Result<Self, crate::migration::MigrationResult> {
+        use crate::migration::MigrationResult;
+        let b = payload;
+        // Check the length of input and the reserved fields
+        if b.len() < 56 || (data_length as usize) < 56 || b[11..16] != [0; 5] {
+            return Err(MigrationResult::InvalidParameter);
         }
         let mig_request_id = u64::from_le_bytes(b[..8].try_into().unwrap());
         let rebinding_src = b[8];
@@ -107,11 +112,11 @@ impl RebindingInfo {
 
         let mut init_migtd_data = None;
         if has_init_data == 1 {
-            // Returns None if `has_init_data` is set but reading initialization data from the input buffer fails.
-            init_migtd_data = Some(InitData::read_from_bytes(&b[56..])?);
+            init_migtd_data =
+                Some(InitData::read_from_bytes(&b[56..]).ok_or(MigrationResult::InvalidParameter)?);
         }
 
-        Some(Self {
+        Ok(Self {
             mig_request_id,
             rebinding_src,
             has_init_data,
@@ -951,7 +956,7 @@ mod test {
     #[test]
     fn test_rebinding_info_no_init_data() {
         let buf = build_rebinding_info(42, 1, 0, [1, 2, 3, 4], 99, None);
-        let info = RebindingInfo::read_from_bytes(&buf).expect("should parse");
+        let info = RebindingInfo::read_from_bytes(buf.len() as u32, &buf).expect("should parse");
         assert_eq!(info.mig_request_id, 42);
         assert_eq!(info.rebinding_src, 1);
         assert_eq!(info.has_init_data, 0);
@@ -965,7 +970,8 @@ mod test {
         let tdinfo = make_tdinfo(&[0xCAu8; 48], &[0xFEu8; 48]);
         let migtd_data = build_migtd_data(&tdinfo);
         let buf = build_rebinding_info(7, 0, 1, [10, 20, 30, 40], 55, Some(&migtd_data));
-        let info = RebindingInfo::read_from_bytes(&buf).expect("should parse with init data");
+        let info = RebindingInfo::read_from_bytes(buf.len() as u32, &buf)
+            .expect("should parse with init data");
         assert_eq!(info.mig_request_id, 7);
         assert_eq!(info.has_init_data, 1);
         let init = info.init_migtd_data.as_ref().unwrap();
@@ -975,21 +981,21 @@ mod test {
 
     #[test]
     fn test_rebinding_info_rejects_short_buffer() {
-        assert!(RebindingInfo::read_from_bytes(&[0u8; 10]).is_none());
-        assert!(RebindingInfo::read_from_bytes(&[0u8; 55]).is_none()); // 55 < 56
+        assert!(RebindingInfo::read_from_bytes(10, &[0u8; 10]).is_err());
+        assert!(RebindingInfo::read_from_bytes(55, &[0u8; 55]).is_err()); // 55 < 56
     }
 
     #[test]
     fn test_rebinding_info_rejects_nonzero_reserved() {
         let mut buf = build_rebinding_info(1, 0, 0, [0; 4], 0, None);
         buf[10] = 0xFF; // reserved byte not zero
-        assert!(RebindingInfo::read_from_bytes(&buf).is_none());
+        assert!(RebindingInfo::read_from_bytes(buf.len() as u32, &buf).is_err());
     }
 
     #[test]
     fn test_rebinding_info_rejects_has_init_data_without_data() {
         // has_init_data=1 but no data bytes following → InitData::read_from_bytes fails
         let buf = build_rebinding_info(1, 0, 1, [0; 4], 0, None);
-        assert!(RebindingInfo::read_from_bytes(&buf).is_none());
+        assert!(RebindingInfo::read_from_bytes(buf.len() as u32, &buf).is_err());
     }
 }

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -76,13 +76,18 @@ pub enum DataStatusOperation {
 }
 
 #[cfg(feature = "vmcall-raw")]
-fn parse_uuid(buf: &[u8]) -> [u64; 4] {
-    [
-        u64::from_le_bytes(buf[0..8].try_into().unwrap()),
-        u64::from_le_bytes(buf[8..16].try_into().unwrap()),
-        u64::from_le_bytes(buf[16..24].try_into().unwrap()),
-        u64::from_le_bytes(buf[24..32].try_into().unwrap()),
-    ]
+impl TryFrom<u8> for DataStatusOperation {
+    type Error = u8;
+    fn try_from(value: u8) -> core::result::Result<Self, u8> {
+        match value {
+            1 => Ok(Self::StartMigration),
+            2 => Ok(Self::StartRebinding),
+            3 => Ok(Self::GetTDReport),
+            4 => Ok(Self::EnableLogArea),
+            5 => Ok(Self::GetMigtdData),
+            unknown => Err(unknown),
+        }
+    }
 }
 
 lazy_static! {
@@ -254,6 +259,202 @@ fn try_accept_request(
 }
 
 #[cfg(feature = "vmcall-raw")]
+fn get_request_payload<'a>(
+    data_buffer: &'a [u8],
+    reqbufferhdrlen: usize,
+    data_length: u32,
+) -> Result<&'a [u8]> {
+    let end = reqbufferhdrlen
+        .checked_add(data_length as usize)
+        .ok_or(MigrationResult::InvalidParameter)?;
+    data_buffer
+        .get(reqbufferhdrlen..end)
+        .ok_or(MigrationResult::InvalidParameter)
+}
+
+#[cfg(feature = "vmcall-raw")]
+fn read_request_id(data_buffer: &[u8], reqbufferhdrlen: usize) -> Option<u64> {
+    let end = reqbufferhdrlen.checked_add(size_of::<u64>())?;
+    let bytes: [u8; 8] = data_buffer.get(reqbufferhdrlen..end)?.try_into().ok()?;
+    Some(u64::from_le_bytes(bytes))
+}
+
+#[cfg(feature = "vmcall-raw")]
+fn reject_request(
+    pending_error_report: &mut Option<(u64, MigrationResult)>,
+    request_id: Option<u64>,
+    status: MigrationResult,
+) -> Poll<Result<WaitForRequestResponse>> {
+    if let Some(request_id) = request_id {
+        *pending_error_report = Some((request_id, status));
+    }
+    Poll::Ready(Err(status))
+}
+
+/// Log an error with an optional `migration_request_id` structured field.
+macro_rules! log_request_error {
+    ($request_id:expr, $($arg:tt)*) => {
+        if let Some(mig_request_id) = $request_id {
+            log::error!(migration_request_id = mig_request_id; $($arg)*);
+        } else {
+            log::error!($($arg)*);
+        }
+    };
+}
+
+#[cfg(feature = "vmcall-raw")]
+async fn report_wait_for_request_error(request_id: u64, status: MigrationResult) {
+    let data = Vec::new();
+    if let Err(e) = report_status(status as u8, request_id, &data).await {
+        log::error!(migration_request_id = request_id;
+            "wait_for_request: failed to report error status {:?} to host: {:?}\n",
+            status,
+            e
+        );
+    }
+}
+
+/// Parse a raw request buffer into a typed WaitForRequestResponse.
+///
+#[cfg(feature = "vmcall-raw")]
+fn parse_request(
+    data_buffer: &[u8],
+    reqbufferhdrlen: usize,
+    pending_error_report: &mut Option<(u64, MigrationResult)>,
+) -> Poll<Result<WaitForRequestResponse>> {
+    let reqbufferhdr = process_buffer(data_buffer);
+    let data_status = reqbufferhdr.datastatus;
+    let data_length = reqbufferhdr.length;
+    if (data_status == 0) && (data_length == 0) {
+        return Poll::Pending;
+    }
+
+    let data_status_bytes = &data_status.to_le_bytes();
+    let request_id = read_request_id(data_buffer, reqbufferhdrlen);
+    if data_status_bytes[0] != TDX_VMCALL_VMM_SUCCESS {
+        log_request_error!(
+            request_id,
+            "wait_for_request: data_status byte[0] failure, data_status = {:x}\n",
+            data_status
+        );
+        return reject_request(
+            pending_error_report,
+            request_id,
+            MigrationResult::VmmInternalError,
+        );
+    }
+
+    let operation: u8 = data_status_bytes[1];
+    log::trace!(
+        "wait_for_request: Received operation {} with data length {}\n",
+        operation,
+        data_length
+    );
+
+    // Step 1: Convert operation byte to typed enum, reject unknown immediately
+    let op = match DataStatusOperation::try_from(operation).map_err(|unknown| {
+        log_request_error!(
+            request_id,
+            "wait_for_request: unknown operation {} received\n",
+            unknown
+        );
+        reject_request(
+            pending_error_report,
+            request_id,
+            MigrationResult::UnsupportedOperationError,
+        )
+    }) {
+        Ok(op) => op,
+        Err(poll) => return poll,
+    };
+
+    // Step 2: Extract payload bytes based on data_length
+    let slice = match get_request_payload(data_buffer, reqbufferhdrlen, data_length) {
+        Ok(s) => s,
+        Err(status) => {
+            log::error!("wait_for_request: {:?} payload out of bounds\n", op);
+            return reject_request(pending_error_report, request_id, status);
+        }
+    };
+
+    // Step 3: Decode payload into operation-specific data and dispatch
+    // Each read_from_bytes() validates data_length == expected size.
+    macro_rules! decode_and_dispatch {
+        ($type:ty, |$info:ident| $response:expr) => {
+            match <$type>::read_from_bytes(data_length, slice) {
+                Ok($info) => try_accept_request($info.mig_request_id, $response),
+                Err(status) => {
+                    log_request_error!(
+                        request_id,
+                        "wait_for_request: {:?} failed to decode payload\n",
+                        op
+                    );
+                    reject_request(pending_error_report, request_id, status)
+                }
+            }
+        };
+    }
+
+    match op {
+        DataStatusOperation::StartMigration => {
+            decode_and_dispatch!(MigtdMigrationInformation, |mig_info| {
+                WaitForRequestResponse::StartMigration(MigrationInformation { mig_info })
+            })
+        }
+        DataStatusOperation::StartRebinding => {
+            #[cfg(all(feature = "vmcall-raw", feature = "policy_v2"))]
+            {
+                decode_and_dispatch!(RebindingInfo, |info| {
+                    WaitForRequestResponse::StartRebinding(info)
+                })
+            }
+            #[cfg(not(all(feature = "vmcall-raw", feature = "policy_v2")))]
+            {
+                log_request_error!(
+                    request_id,
+                    "wait_for_request: unsupported operation {:?} received\n",
+                    op
+                );
+                reject_request(
+                    pending_error_report,
+                    request_id,
+                    MigrationResult::UnsupportedOperationError,
+                )
+            }
+        }
+        DataStatusOperation::GetTDReport => {
+            decode_and_dispatch!(ReportInfo, |info| WaitForRequestResponse::GetTdReport(info))
+        }
+        DataStatusOperation::EnableLogArea => {
+            decode_and_dispatch!(EnableLogAreaInfo, |info| {
+                WaitForRequestResponse::EnableLogArea(info)
+            })
+        }
+        DataStatusOperation::GetMigtdData => {
+            #[cfg(all(feature = "vmcall-raw", feature = "policy_v2"))]
+            {
+                decode_and_dispatch!(MigtdDataInfo, |info| WaitForRequestResponse::GetMigtdData(
+                    info
+                ))
+            }
+            #[cfg(not(all(feature = "vmcall-raw", feature = "policy_v2")))]
+            {
+                log_request_error!(
+                    request_id,
+                    "wait_for_request: unsupported operation {:?} received\n",
+                    op
+                );
+                reject_request(
+                    pending_error_report,
+                    request_id,
+                    MigrationResult::UnsupportedOperationError,
+                )
+            }
+        }
+    }
+}
+
+#[cfg(feature = "vmcall-raw")]
 pub async fn wait_for_request() -> Result<WaitForRequestResponse> {
     let mut reqbufferhdr = RequestDataBufferHeader {
         datastatus: 0,
@@ -281,7 +482,8 @@ pub async fn wait_for_request() -> Result<WaitForRequestResponse> {
         },
     )?;
 
-    poll_fn(|_cx| {
+    let mut pending_error_report: Option<(u64, MigrationResult)> = None;
+    let result = poll_fn(|_cx| {
         if VMCALL_SERVICE_FLAG.load(Ordering::SeqCst) {
             VMCALL_SERVICE_FLAG.store(false, Ordering::SeqCst);
         } else {
@@ -292,169 +494,21 @@ pub async fn wait_for_request() -> Result<WaitForRequestResponse> {
             private_buffer
         } else {
             log::error!("wait_for_request: copy_to_private_shadow failure\n");
-            return Poll::Pending
+            return Poll::Ready(Err(MigrationResult::OutOfResource));
         };
 
-        reqbufferhdr = process_buffer(data_buffer);
-        let data_status = reqbufferhdr.datastatus;
-        let data_length = reqbufferhdr.length;
-        if (data_status == 0) && (data_length == 0) {
-            return Poll::Pending;
-        }
-        let data_status_bytes = &data_status.to_le_bytes();
-        if data_status_bytes[0] != TDX_VMCALL_VMM_SUCCESS {
-            log::error!("wait_for_request: data_status byte[0] failure\n");
-            return Poll::Pending;
-        }
-
-        let operation: u8 = data_status_bytes[1];
-        log::trace!("wait_for_request: Received operation {} with data length {}\n", operation, data_length);
-        if operation == DataStatusOperation::StartMigration as u8 {
-            // data_length should be MigtdMigrationInformation
-            let expected_datalength = size_of::<MigtdMigrationInformation>();
-            if data_length != expected_datalength as u32 {
-                if data_length >= size_of::<u64>() as u32 {
-                    let slice = &data_buffer[reqbufferhdrlen..reqbufferhdrlen + data_length as usize];
-                    let mig_request_id = u64::from_le_bytes(slice[0..8].try_into().unwrap());
-                    log::error!(migration_request_id = mig_request_id; "wait_for_request: StartMigration operation incorrect data length - expected {} actual {}\n", expected_datalength, data_length);
-                } else {
-                    log::error!("wait_for_request: StartMigration operation incorrect data length - expected {} actual {}\n", expected_datalength, data_length);
-                }
-                return Poll::Pending;
-            }
-            let slice = &data_buffer[reqbufferhdrlen..reqbufferhdrlen + data_length as usize];
-            let mig_request_id = u64::from_le_bytes(slice[0..8].try_into().unwrap());
-
-            let wfr_info = MigtdMigrationInformation {
-                mig_request_id,
-                migration_source: slice[8],
-                _pad: slice[9..16].try_into().unwrap(),
-                target_td_uuid: parse_uuid(&slice[16..48]),
-                binding_handle: u64::from_le_bytes(slice[48..56].try_into().unwrap()),
-            };
-
-            let wfr_info = MigrationInformation { mig_info: wfr_info };
-
-            try_accept_request(mig_request_id, WaitForRequestResponse::StartMigration(wfr_info))
-        } else if operation == DataStatusOperation::StartRebinding as u8 {
-            #[cfg(all(feature = "vmcall-raw", feature = "policy_v2"))]
-            match RebindingInfo::read_from_bytes(&data_buffer[reqbufferhdrlen..]) {
-                Some(rebinding_info) => {
-                    let req_id = rebinding_info.mig_request_id;
-                    try_accept_request(req_id, WaitForRequestResponse::StartRebinding(rebinding_info))
-                }
-                None => {
-                    if data_length >= size_of::<u64>() as u32 {
-                        let slice = &data_buffer[reqbufferhdrlen..reqbufferhdrlen + data_length as usize];
-                        let mig_request_id = u64::from_le_bytes(slice[0..8].try_into().unwrap());
-                        log::error!(migration_request_id = mig_request_id; "wait_for_request: StartRebinding operation incorrect data received\n");
-                    } else {
-                        log::error!("wait_for_request: StartRebinding operation incorrect data received\n");
-                    }
-                    Poll::Pending
-                }
-            }
-            #[cfg(not(all(feature = "vmcall-raw", feature = "policy_v2")))]
-            {
-                log::debug!("wait_for_request: invalid operation StartRebinding received\n");
-                Poll::Pending
-            }
-        } else if operation == DataStatusOperation::GetTDReport as u8 {
-            let mut reportdata: [u8; 64] = [0; 64];
-            let mut mig_request_id: u64 = 0;
-            // data length should MigRequestID (+ optional REPORTDATA)
-            if data_length != size_of_val(&mig_request_id) as u32
-                && data_length
-                    != size_of::<ReportInfo>() as u32
-            {
-                if data_length >= size_of::<u64>() as u32 {
-                    let slice = &data_buffer[reqbufferhdrlen..reqbufferhdrlen + data_length as usize];
-                    let mig_request_id = u64::from_le_bytes(slice[0..8].try_into().unwrap());
-                    log::error!(migration_request_id = mig_request_id; "wait_for_request: GetReportData operation incorrect data length - expected {} actual {}\n", size_of::<ReportInfo>(), data_length);
-                } else {
-                    log::error!("wait_for_request: GetReportData operation incorrect data length - expected {} actual {}\n", size_of::<ReportInfo>(), data_length);
-                }
-                return Poll::Pending;
-            }
-            let slice = &data_buffer[reqbufferhdrlen..reqbufferhdrlen + data_length as usize];
-            mig_request_id = u64::from_le_bytes(slice[0..8].try_into().unwrap());
-
-            if data_length == (size_of_val(&mig_request_id) + TD_REPORT_ADDITIONAL_DATA_SIZE) as u32
-            {
-                reportdata = slice[8..72].try_into().unwrap();
-            }
-
-            let wfr_info = ReportInfo {
-                mig_request_id,
-                reportdata,
-            };
-
-            try_accept_request(mig_request_id, WaitForRequestResponse::GetTdReport(wfr_info))
-        } else if operation == DataStatusOperation::EnableLogArea as u8 {
-            let expected_datalength = size_of::<EnableLogAreaInfo>();
-            if data_length != expected_datalength as u32 {
-                if data_length >= size_of::<u64>() as u32 {
-                    let slice = &data_buffer[reqbufferhdrlen..reqbufferhdrlen + data_length as usize];
-                    let mig_request_id = u64::from_le_bytes(slice[0..8].try_into().unwrap());
-                    log::error!(migration_request_id = mig_request_id; "wait_for_request: EnableLogArea operation incorrect data length - expected {} actual {}\n", expected_datalength, data_length);
-                } else {
-                    log::error!("wait_for_request: EnableLogArea operation incorrect data length - expected {} actual {}\n", expected_datalength, data_length);
-                }
-                return Poll::Pending;
-            }
-
-            let slice = &data_buffer[reqbufferhdrlen..reqbufferhdrlen + data_length as usize];
-            let mig_request_id = u64::from_le_bytes(slice[0..8].try_into().unwrap());
-
-            let wfr_info = EnableLogAreaInfo {
-                mig_request_id,
-                log_max_level: slice[8],
-                reserved: slice[9..16].try_into().unwrap(),
-            };
-
-            try_accept_request(mig_request_id, WaitForRequestResponse::EnableLogArea(wfr_info))
-        } else if operation == DataStatusOperation::GetMigtdData as u8 {
-            #[cfg(all(feature = "vmcall-raw", feature = "policy_v2"))]
-            {
-                let mut reportdata: [u8; 64] = [0; 64];
-                let mut mig_request_id: u64 = 0;
-                // data length should MigRequestID (+ optional REPORTDATA)
-                if data_length != size_of::<MigtdDataInfo>() as u32 && data_length != size_of_val(&mig_request_id) as u32
-                {
-                    if data_length >= size_of::<u64>() as u32 {
-                        let slice = &data_buffer[reqbufferhdrlen..reqbufferhdrlen + data_length as usize];
-                        let mig_request_id = u64::from_le_bytes(slice[0..8].try_into().unwrap());
-                        log::error!(migration_request_id = mig_request_id; "wait_for_request: GetMigtdData operation incorrect data length - expected {} actual {}\n", size_of::<ReportInfo>(), data_length);
-                    } else {
-                        log::error!("wait_for_request: GetMigtdData operation incorrect data length - expected {} actual {}\n", size_of::<ReportInfo>(), data_length);
-                    }
-                    return Poll::Pending;
-                }
-                let slice = &data_buffer[reqbufferhdrlen..reqbufferhdrlen + data_length as usize];
-                mig_request_id = u64::from_le_bytes(slice[0..8].try_into().unwrap());
-
-                if data_length == (size_of_val(&mig_request_id) + TD_REPORT_ADDITIONAL_DATA_SIZE) as u32
-                {
-                    reportdata = slice[8..72].try_into().unwrap();
-                }
-
-                let wfr_info = MigtdDataInfo {
-                    mig_request_id,
-                    reportdata,
-                };
-
-                try_accept_request(mig_request_id, WaitForRequestResponse::GetMigtdData(wfr_info))
-            }
-            #[cfg(not(all(feature = "vmcall-raw", feature = "policy_v2")))]
-            {
-                log::debug!("wait_for_request: invalid operation GetMigtdData received\n");
-                Poll::Pending
-            }
-        } else {
-            Poll::Pending
-        }
+        parse_request(data_buffer, reqbufferhdrlen, &mut pending_error_report)
     })
-    .await
+    .await;
+
+    if let Err(status) = result {
+        if let Some((request_id, report_status_code)) = pending_error_report.take() {
+            report_wait_for_request_error(request_id, report_status_code).await;
+        }
+        return Err(status);
+    }
+
+    result
 }
 
 #[cfg(not(feature = "vmcall-raw"))]

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -1340,4 +1340,245 @@ mod test {
         let result = cal_mig_version(true, &local_info, &remote_info);
         assert!(matches!(result, Ok(6)));
     }
+
+    // ---- parse_request-level tests: simulate host data buffers ----
+
+    #[cfg(feature = "vmcall-raw")]
+    mod parse_request_tests {
+        use super::super::{parse_request, REQUESTS};
+        use crate::migration::{
+            data::{RequestDataBufferHeader, WaitForRequestResponse},
+            EnableLogAreaInfo, MigrationResult, MigtdMigrationInformation, ReportInfo,
+        };
+        use core::mem::size_of;
+        use core::task::Poll;
+
+        const HDR_LEN: usize = size_of::<RequestDataBufferHeader>();
+
+        /// Build a raw request buffer: header (datastatus + length) + payload.
+        fn build_request_buffer(operation: u8, payload: &[u8]) -> Vec<u8> {
+            let mut datastatus = [0u8; 8];
+            datastatus[0] = super::super::TDX_VMCALL_VMM_SUCCESS;
+            datastatus[1] = operation;
+            let length = payload.len() as u32;
+            let mut buf = Vec::with_capacity(HDR_LEN + payload.len());
+            buf.extend_from_slice(&datastatus);
+            buf.extend_from_slice(&length.to_le_bytes());
+            buf.extend_from_slice(payload);
+            buf
+        }
+
+        fn build_raw_buffer(datastatus: u64, length: u32, payload: &[u8]) -> Vec<u8> {
+            let mut buf = Vec::with_capacity(HDR_LEN + payload.len());
+            buf.extend_from_slice(&datastatus.to_le_bytes());
+            buf.extend_from_slice(&length.to_le_bytes());
+            buf.extend_from_slice(payload);
+            buf
+        }
+
+        fn build_migration_payload(request_id: u64, is_source: u8) -> Vec<u8> {
+            let mut payload = vec![0u8; size_of::<MigtdMigrationInformation>()];
+            payload[0..8].copy_from_slice(&request_id.to_le_bytes());
+            payload[8] = is_source;
+            payload
+        }
+
+        fn cleanup_request(request_id: u64) {
+            REQUESTS.lock().remove(&request_id);
+        }
+
+        #[test]
+        fn test_parse_empty_buffer_returns_pending() {
+            let buf = build_raw_buffer(0, 0, &[]);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            assert!(matches!(result, Poll::Pending));
+        }
+
+        #[test]
+        fn test_parse_vmm_failure_status() {
+            let mut buf = vec![0u8; HDR_LEN + 8];
+            buf[0] = 0; // NOT success
+            buf[1] = 1;
+            let length = 8u32;
+            buf[8..12].copy_from_slice(&length.to_le_bytes());
+            buf[12..20].copy_from_slice(&42u64.to_le_bytes());
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::VmmInternalError))
+            ));
+            assert_eq!(pending, Some((42, MigrationResult::VmmInternalError)));
+        }
+
+        #[test]
+        fn test_parse_unknown_operation() {
+            let payload = 99u64.to_le_bytes();
+            let buf = build_request_buffer(255, &payload);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::UnsupportedOperationError))
+            ));
+        }
+
+        #[test]
+        fn test_parse_start_migration_success() {
+            let request_id: u64 = 0xAA00_0000_0000_0001;
+            let payload = build_migration_payload(request_id, 1);
+            let buf = build_request_buffer(1, &payload);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            match result {
+                Poll::Ready(Ok(WaitForRequestResponse::StartMigration(info))) => {
+                    assert_eq!(info.mig_info.mig_request_id, request_id);
+                    assert_eq!(info.mig_info.migration_source, 1);
+                }
+                _ => panic!("Expected StartMigration, got unexpected variant"),
+            }
+            assert!(pending.is_none());
+            cleanup_request(request_id);
+        }
+
+        #[test]
+        fn test_parse_start_migration_truncated_payload() {
+            // Payload is too short and data_length != expected size
+            let buf = build_request_buffer(1, &[0u8; 8]);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::InvalidParameter))
+            ));
+        }
+
+        #[test]
+        fn test_parse_start_migration_trailing_bytes_rejected() {
+            // Payload has correct data but data_length is too large (trailing bytes)
+            let request_id: u64 = 0xAA00_0000_0000_0099;
+            let mut payload = build_migration_payload(request_id, 1);
+            payload.extend_from_slice(&[0xFF; 8]); // trailing garbage
+            let buf = build_request_buffer(1, &payload);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            // read_from_bytes rejects because data_length != size_of::<MigtdMigrationInformation>()
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::InvalidParameter))
+            ));
+        }
+
+        #[test]
+        fn test_parse_get_td_report_full() {
+            let request_id: u64 = 0xBB00_0000_0000_0002;
+            let mut payload = vec![0u8; size_of::<ReportInfo>()];
+            payload[0..8].copy_from_slice(&request_id.to_le_bytes());
+            payload[8..72].fill(0xCC);
+            let buf = build_request_buffer(3, &payload);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            match result {
+                Poll::Ready(Ok(WaitForRequestResponse::GetTdReport(info))) => {
+                    assert_eq!(info.mig_request_id, request_id);
+                    assert_eq!(info.reportdata[0], 0xCC);
+                }
+                _ => panic!("Expected GetTdReport, got unexpected variant"),
+            }
+            cleanup_request(request_id);
+        }
+
+        #[test]
+        fn test_parse_get_td_report_request_id_only() {
+            let request_id: u64 = 0xCC00_0000_0000_0003;
+            let payload = request_id.to_le_bytes();
+            let buf = build_request_buffer(3, &payload);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            match result {
+                Poll::Ready(Ok(WaitForRequestResponse::GetTdReport(info))) => {
+                    assert_eq!(info.mig_request_id, request_id);
+                    assert_eq!(info.reportdata, [0u8; 64]);
+                }
+                _ => panic!("Expected GetTdReport with zero reportdata, got unexpected variant"),
+            }
+            cleanup_request(request_id);
+        }
+
+        #[test]
+        fn test_parse_get_td_report_wrong_size_rejected() {
+            // 16 bytes is neither 8 nor 72 → read_from_bytes rejects
+            let buf = build_request_buffer(3, &[0u8; 16]);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::InvalidParameter))
+            ));
+        }
+
+        #[test]
+        fn test_parse_enable_log_area_success() {
+            let request_id: u64 = 0xDD00_0000_0000_0004;
+            let mut payload = vec![0u8; size_of::<EnableLogAreaInfo>()];
+            payload[0..8].copy_from_slice(&request_id.to_le_bytes());
+            payload[8] = 4;
+            let buf = build_request_buffer(4, &payload);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            match result {
+                Poll::Ready(Ok(WaitForRequestResponse::EnableLogArea(info))) => {
+                    assert_eq!(info.mig_request_id, request_id);
+                    assert_eq!(info.log_max_level, 4);
+                }
+                _ => panic!("Expected EnableLogArea, got unexpected variant"),
+            }
+            cleanup_request(request_id);
+        }
+
+        #[test]
+        fn test_parse_enable_log_area_truncated() {
+            let buf = build_request_buffer(4, &[0u8; 4]);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::InvalidParameter))
+            ));
+        }
+
+        #[test]
+        fn test_parse_duplicate_request_returns_pending() {
+            let request_id: u64 = 0xEE00_0000_0000_0005;
+            let payload = build_migration_payload(request_id, 0);
+            let buf = build_request_buffer(1, &payload);
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            assert!(matches!(
+                result,
+                Poll::Ready(Ok(WaitForRequestResponse::StartMigration(_)))
+            ));
+            // Second call: duplicate → Pending
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            assert!(matches!(result, Poll::Pending));
+            cleanup_request(request_id);
+        }
+
+        #[test]
+        fn test_parse_payload_out_of_bounds() {
+            let mut buf = vec![0u8; HDR_LEN + 8];
+            buf[0] = super::super::TDX_VMCALL_VMM_SUCCESS;
+            buf[1] = 1;
+            let fake_length = 100u32;
+            buf[8..12].copy_from_slice(&fake_length.to_le_bytes());
+            buf[12..20].copy_from_slice(&42u64.to_le_bytes());
+            let mut pending = None;
+            let result = parse_request(&buf, HDR_LEN, &mut pending);
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::InvalidParameter))
+            ));
+        }
+    }
 }

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -70,7 +70,7 @@ const TDX_VMCALL_VMM_SUCCESS: u8 = 1;
 pub enum DataStatusOperation {
     StartMigration = 1,
     StartRebinding = 2,
-    GetReportData = 3,
+    GetTDReport = 3,
     EnableLogArea = 4,
     GetMigtdData = 5,
 }
@@ -359,7 +359,7 @@ pub async fn wait_for_request() -> Result<WaitForRequestResponse> {
                 log::debug!("wait_for_request: invalid operation StartRebinding received\n");
                 Poll::Pending
             }
-        } else if operation == DataStatusOperation::GetReportData as u8 {
+        } else if operation == DataStatusOperation::GetTDReport as u8 {
             let mut reportdata: [u8; 64] = [0; 64];
             let mut mig_request_id: u64 = 0;
             // data length should MigRequestID (+ optional REPORTDATA)


### PR DESCRIPTION
Also in separate commits:
- renamed GetReportData to GetTDReport to align with TDX terminology used in documents
- added more unit tests and fixed unsafe logging unit tests
