### PR TITLE
virtio-serial driver bugfixes

### DIFF
--- a/src/devices/virtio_serial/src/lib.rs
+++ b/src/devices/virtio_serial/src/lib.rs
@@ -482,7 +482,7 @@ impl VirtioSerial {
 
         self.timer.reset_timeout();
 
-        if self
+        while self
             .queues
             .index(CONTROL_RECEIVEQ as usize)
             .borrow_mut()
@@ -537,7 +537,6 @@ impl VirtioSerial {
             ControlEvent::DeviceAdd => {
                 self.fill_port_queue(port_id)?;
                 self.port_ready(port_id)?;
-                self.recv_control()?;
             }
             ControlEvent::DeviceRemove => {
                 self.connected_ports.remove(&port_id);

--- a/src/devices/virtio_serial/src/lib.rs
+++ b/src/devices/virtio_serial/src/lib.rs
@@ -467,6 +467,53 @@ impl VirtioSerial {
         Ok(())
     }
 
+    /// Non-blocking control-queue pump: drains any already-pending control
+    /// messages without waiting for new IRQ/events.
+    fn recv_control_nonblock(&mut self) -> Result<()> {
+        let vq = self.queues.index(CONTROL_RECEIVEQ as usize);
+        if !vq.borrow_mut().can_pop() {
+            return Ok(());
+        }
+
+        while self
+            .queues
+            .index(CONTROL_RECEIVEQ as usize)
+            .borrow_mut()
+            .can_pop()
+        {
+            let mut g2h = Vec::new();
+            let mut h2g = Vec::new();
+            let _ = self
+                .queues
+                .index(CONTROL_RECEIVEQ as usize)
+                .borrow_mut()
+                .pop_used(&mut g2h, &mut h2g)?;
+
+            for vq_buf in &h2g {
+                if let Some(record) = self.dma_allocation.get(&vq_buf.addr) {
+                    let safe_len = core::cmp::min(vq_buf.len as usize, record.dma_size);
+                    let control_msg =
+                        unsafe { core::slice::from_raw_parts(vq_buf.addr as *const u8, safe_len) };
+                    self.handle_control_msg(control_msg)?;
+                    self.free_dma_memory(vq_buf.addr)
+                        .ok_or(VirtioSerialError::OutOfResource)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Non-blocking control-queue pump to help consume late `PORT_OPEN` events.
+    /// Returns `Ok(true)` if at least one control message was drained.
+    pub fn try_poll_control() -> Result<()> {
+        SERIAL_DEVICE
+            .lock()
+            .get_mut()
+            .ok_or(VirtioSerialError::InvalidParameter)?
+            .recv_control_nonblock()
+    }
+
     fn recv_control(&mut self) -> Result<()> {
         let vq = self.queues.index(CONTROL_RECEIVEQ as usize);
 

--- a/src/migtd/src/migration/transport.rs
+++ b/src/migtd/src/migration/transport.rs
@@ -39,11 +39,41 @@ pub(super) async fn setup_transport(
 
     #[cfg(all(feature = "virtio-serial", not(feature = "vmcall-raw")))]
     {
-        use virtio_serial::VirtioSerialPort;
+        use crate::driver::ticks::Timer;
+        use core::time::Duration;
+        use virtio_serial::{VirtioSerial, VirtioSerialError, VirtioSerialPort};
         const VIRTIO_SERIAL_PORT_ID: u32 = 1;
+        const VIRTIO_SERIAL_OPEN_RETRY_TIMES: usize = 100;
+        const VIRTIO_SERIAL_OPEN_RETRY_DELAY: Duration = Duration::from_millis(10);
 
         let port = VirtioSerialPort::new(VIRTIO_SERIAL_PORT_ID);
-        port.open()?;
+        let mut opened = false;
+        for _ in 0..VIRTIO_SERIAL_OPEN_RETRY_TIMES {
+            match port.open() {
+                Ok(()) => {
+                    opened = true;
+                    break;
+                }
+                Err(VirtioSerialError::PortNotAvailable(_)) => {
+                    // `PORT_OPEN` can arrive after init_control; pump control queue during retry.
+                    // If we drained pending control msgs, try open again immediately to avoid
+                    // waiting for the next retry tick.
+                    Timer::after(VIRTIO_SERIAL_OPEN_RETRY_DELAY).await;
+                    VirtioSerial::try_poll_control()?;
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+        if !opened {
+            log::error!(
+                "virtio-serial port {} not available after {} retries ({}ms total)\n",
+                VIRTIO_SERIAL_PORT_ID,
+                VIRTIO_SERIAL_OPEN_RETRY_TIMES,
+                VIRTIO_SERIAL_OPEN_RETRY_TIMES
+                    * VIRTIO_SERIAL_OPEN_RETRY_DELAY.as_millis() as usize,
+            );
+            return Err(VirtioSerialError::PortNotAvailable(VIRTIO_SERIAL_PORT_ID).into());
+        }
         return Ok(port);
     }
 


### PR DESCRIPTION
Fix 2 migtd virtio-serial driver bugs:
- Missing control msgs since qemu may put multiple control msg but the driver pops one each time. 
- A late PORT_OPEN event may cause a PortNotAvailable when port.open(), try to drain control queue when PortNotAvailable and retry open.