### PR TITLE
feat(migtd): support tdinfo_init in MigtdMigrationInformation

### DIFF
--- a/src/crypto/src/lib.rs
+++ b/src/crypto/src/lib.rs
@@ -97,6 +97,25 @@ pub fn pem_cert_to_der(cert: &[u8]) -> Result<CertificateDer<'static>> {
     CertificateDer::from_pem_slice(cert).map_err(|_| Error::DecodePemCert)
 }
 
+/// Returns the SHA-384 hash of the leaf certificate's public key from a PEM cert chain.
+/// Per GHCI 1.5: this hash is placed in tdinfo.MROWNER as the policy signing key identifier.
+pub fn get_policy_signer_key_hash(cert_chain_pem: &[u8]) -> Result<[u8; SHA384_DIGEST_SIZE]> {
+    let cert_chain = extract_cert_chain_from_pem(cert_chain_pem)?;
+    if cert_chain.is_empty() {
+        return Err(Error::CertChainVerification(
+            "No certificates found in chain".into(),
+        ));
+    }
+    let leaf_cert = &cert_chain[0];
+    let cert =
+        x509::Certificate::from_der(leaf_cert.as_ref()).map_err(|_| Error::ParseCertificate)?;
+    let public_key = extract_public_key_from_cert(&cert)?;
+    let hash_vec = hash::digest_sha384(&public_key).map_err(|_| Error::CalculateDigest)?;
+    let mut hash = [0u8; SHA384_DIGEST_SIZE];
+    hash.copy_from_slice(&hash_vec);
+    Ok(hash)
+}
+
 /// Verifies a certificate chain and then verifies a message signature
 pub fn verify_cert_chain_and_signature(
     cert_chain_pem: &[u8],

--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -275,6 +275,21 @@ fn get_policy_and_measure(event_log: &mut [u8]) {
 
     let version = initialize_policy();
 
+    // Per GHCI 1.5: Verify own TDINFO.MROWNER/MROWNERCONFIG matches policy key/SVN
+    // Skip in AzCVMEmu mode — emulator uses mock TD reports where VMM does not
+    // populate MROWNER/MROWNERCONFIG.
+    #[cfg(not(feature = "AzCVMEmu"))]
+    {
+        use migtd::mig_policy;
+        if let Err(e) = mig_policy::verify_own_tdinfo() {
+            log::error!("TDINFO policy binding verification failed: {:?}\n", e);
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InvalidPolicyError as u64,
+                b"TDINFO MROWNER/MROWNERCONFIG mismatch with policy",
+            );
+        }
+    }
+
     let event_data = version.as_bytes();
 
     // Measure and extend the migration policy to RTMR

--- a/src/migtd/src/mig_policy.rs
+++ b/src/migtd/src/mig_policy.rs
@@ -694,6 +694,73 @@ mod v2 {
         })
     }
 
+    /// Per GHCI 1.5: Verify that own TDINFO.MROWNER matches policy signing key hash
+    /// and TDINFO.MROWNERCONFIG matches policy SVN.
+    /// Must be called at MigTD startup to ensure VMM correctly provisioned the TD.
+    pub fn verify_own_tdinfo() -> Result<(), PolicyError> {
+        use crate::config::get_policy_issuer_chain;
+
+        let policy = get_verified_policy().ok_or(PolicyError::InvalidParameter)?;
+        let policy_svn = policy.policy_data.get_policy_svn();
+
+        // Get own TDINFO from TDReport
+        let tdx_report = tdx_tdcall::tdreport::tdcall_report(&[0u8; 64])
+            .map_err(|_| PolicyError::GetTdxReport)?;
+        let td_info = &tdx_report.td_info;
+
+        // Verify MROWNERCONFIG == policy_svn (stored as little-endian u32 in first 4 bytes,
+        // remaining 44 bytes must be zero)
+        let mut expected_mrownerconfig = [0u8; SHA384_DIGEST_SIZE];
+        expected_mrownerconfig[..4].copy_from_slice(&policy_svn.to_le_bytes());
+        if td_info.mrownerconfig != expected_mrownerconfig {
+            return Err(PolicyError::SvnMismatch);
+        }
+
+        // Verify MROWNER == SHA384(policy signing public key)
+        let policy_issuer_chain = get_policy_issuer_chain().ok_or(PolicyError::InvalidParameter)?;
+        let policy_key_hash = crypto::get_policy_signer_key_hash(policy_issuer_chain)
+            .map_err(|_| PolicyError::InvalidCollateral)?;
+        if td_info.mrowner != policy_key_hash {
+            return Err(PolicyError::PolicyHashMismatch);
+        }
+
+        Ok(())
+    }
+
+    /// Per GHCI 1.5: Verify initMigtdData.MROWNER matches own policy signer key hash
+    /// and initMigtdData.MROWNERCONFIG <= own policy SVN.
+    pub fn verify_init_migtd_data_policy_binding(
+        init_data: &crate::migration::init_data::InitData,
+    ) -> Result<(), PolicyError> {
+        use crate::config::get_policy_issuer_chain;
+
+        let policy = get_verified_policy().ok_or(PolicyError::InvalidParameter)?;
+        let my_policy_svn = policy.policy_data.get_policy_svn();
+
+        // Check MROWNER == own policy signer key hash
+        let policy_issuer_chain = get_policy_issuer_chain().ok_or(PolicyError::InvalidParameter)?;
+        let policy_key_hash = crypto::get_policy_signer_key_hash(policy_issuer_chain)
+            .map_err(|_| PolicyError::InvalidCollateral)?;
+        if init_data.mrowner() != policy_key_hash {
+            return Err(PolicyError::PolicyHashMismatch);
+        }
+
+        // Check MROWNERCONFIG (init policy_svn) <= my policy_svn
+        let init_mrownerconfig = init_data.mrownerconfig();
+        let mut init_svn_bytes = [0u8; 4];
+        init_svn_bytes.copy_from_slice(&init_mrownerconfig[..4]);
+        let init_policy_svn = u32::from_le_bytes(init_svn_bytes);
+        // Remaining 44 bytes should be zero
+        if init_mrownerconfig[4..] != [0u8; SHA384_DIGEST_SIZE - 4] {
+            return Err(PolicyError::InvalidParameter);
+        }
+        if init_policy_svn > my_policy_svn {
+            return Err(PolicyError::SvnMismatch);
+        }
+
+        Ok(())
+    }
+
     #[test]
     fn test_unix_to_iso8601() {
         let timestamp = 1704067200; // Corresponds to 2024-01-01T00:00:00Z

--- a/src/migtd/src/migration/data.rs
+++ b/src/migtd/src/migration/data.rs
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
+#[cfg(feature = "policy_v2")]
+use crate::migration::init_data::InitData;
 #[cfg(all(feature = "main", feature = "vmcall-raw", feature = "policy_v2"))]
 use crate::migration::rebinding::RebindingInfo;
 
@@ -267,6 +269,8 @@ pub enum WaitForRequestResponse {
 
 pub struct MigrationInformation {
     pub mig_info: MigtdMigrationInformation,
+    #[cfg(feature = "policy_v2")]
+    pub init_migtd_data: Option<InitData>,
     #[cfg(all(
         not(feature = "vmcall-raw"),
         any(feature = "vmcall-vsock", feature = "virtio-vsock")
@@ -356,9 +360,17 @@ fn create_migration_information(
     mig_socket_hob: Option<&[u8]>,
     policy_info_hob: Option<&[u8]>,
 ) -> Option<MigrationInformation> {
-    let mig_info = hob_lib::get_guid_data(mig_info_hob?)?
-        .pread::<MigtdMigrationInformation>(0)
-        .ok()?;
+    let mig_info_data = hob_lib::get_guid_data(mig_info_hob?)?;
+    let mig_info = mig_info_data.pread::<MigtdMigrationInformation>(0).ok()?;
+
+    // Per GHCI 1.5: if has_init_data == 1, InitData blob follows MigtdMigrationInformation
+    #[cfg(feature = "policy_v2")]
+    let init_migtd_data = if mig_info.has_init_data == 1 {
+        let offset = size_of::<MigtdMigrationInformation>();
+        InitData::read_from_bytes(mig_info_data.get(offset..)?)
+    } else {
+        None
+    };
 
     #[cfg(any(feature = "vmcall-vsock", feature = "virtio-vsock"))]
     let mig_socket_info = hob_lib::get_guid_data(mig_socket_hob?)?
@@ -380,6 +392,8 @@ fn create_migration_information(
 
     Some(MigrationInformation {
         mig_info,
+        #[cfg(feature = "policy_v2")]
+        init_migtd_data,
         #[cfg(any(feature = "vmcall-vsock", feature = "virtio-vsock"))]
         mig_socket_info,
         mig_policy,
@@ -730,7 +744,8 @@ mod test {
         let mig_info = MigtdMigrationInformation {
             mig_request_id: 0,
             migration_source: 1,
-            _pad: [0, 0, 0, 0, 0, 0, 0],
+            has_init_data: 0,
+            _reserved: [0; 6],
             target_td_uuid: [0, 0, 0, 0],
             binding_handle: 0,
             mig_policy_id: 0,

--- a/src/migtd/src/migration/init_data.rs
+++ b/src/migtd/src/migration/init_data.rs
@@ -1,0 +1,120 @@
+// Copyright (c) 2025 Intel Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use alloc::vec::Vec;
+use crypto::SHA384_DIGEST_SIZE;
+
+pub(crate) const MIGTD_DATA_SIGNATURE: &[u8] = b"MIGTDATA";
+pub(crate) const MIGTD_DATA_TYPE_TDINFO: u32 = 0;
+
+pub struct InitData {
+    /// The TDINFO_STRUCT of the initial MigTD (per GHCI 1.5, MIGTD_DATA type 0).
+    pub init_tdinfo: Vec<u8>,
+}
+
+impl InitData {
+    /// TDINFO_STRUCT field offsets and sizes (per TDX Module ABI).
+    const TDINFO_MROWNER_OFFSET: usize = 112; // attributes(8) + xfam(8) + mrtd(48) + mrconfig_id(48)
+    const TDINFO_MROWNERCONFIG_OFFSET: usize = 160; // MROWNER_OFFSET + 48
+    const TDINFO_FIELD_SIZE: usize = SHA384_DIGEST_SIZE;
+    const TDINFO_MIN_SIZE: usize = 512;
+
+    /// Extract mrowner from the TDINFO_STRUCT.
+    /// Per GHCI 1.5: VMM puts migpolicy.policy_key in tdinfo.mrowner.
+    pub fn mrowner(&self) -> &[u8] {
+        &self.init_tdinfo
+            [Self::TDINFO_MROWNER_OFFSET..Self::TDINFO_MROWNER_OFFSET + Self::TDINFO_FIELD_SIZE]
+    }
+
+    /// Extract mrownerconfig from the TDINFO_STRUCT.
+    /// Per GHCI 1.5: VMM puts migpolicy.policy_svn in tdinfo.mrownerconfig.
+    pub fn mrownerconfig(&self) -> &[u8] {
+        &self.init_tdinfo[Self::TDINFO_MROWNERCONFIG_OFFSET
+            ..Self::TDINFO_MROWNERCONFIG_OFFSET + Self::TDINFO_FIELD_SIZE]
+    }
+
+    pub fn read_from_bytes(b: &[u8]) -> Option<Self> {
+        if b.len() < 20 || &b[..8] != MIGTD_DATA_SIGNATURE {
+            return None;
+        }
+
+        let version = u32::from_le_bytes(b[8..12].try_into().unwrap());
+        let length = u32::from_le_bytes(b[12..16].try_into().unwrap());
+        let num_entries = u32::from_le_bytes(b[16..20].try_into().unwrap());
+
+        // Per GHCI 1.5: version must be 0x00010000, numberOfEntry must be 1 (tdinfo)
+        if version != 0x00010000 || b.len() < length as usize || num_entries != 1 {
+            return None;
+        }
+
+        let entry = MigtdDataEntry::read_from_bytes(&b[20..])?;
+        if entry.r#type != MIGTD_DATA_TYPE_TDINFO {
+            return None;
+        }
+
+        if entry.value.len() < Self::TDINFO_MIN_SIZE {
+            return None;
+        }
+
+        Some(Self {
+            init_tdinfo: entry.value.to_vec(),
+        })
+    }
+
+    pub fn write_into_bytes(&self, buf: &mut Vec<u8>) {
+        let start_len = buf.len();
+        buf.extend_from_slice(MIGTD_DATA_SIGNATURE);
+        buf.extend_from_slice(&0x00010000u32.to_le_bytes()); // Version
+
+        // Placeholder for length.
+        buf.extend_from_slice(&0u32.to_le_bytes());
+
+        // Per GHCI 1.5: numberOfEntry = 1, entry type 0 = tdinfo
+        buf.extend_from_slice(&1u32.to_le_bytes()); // num_entries
+
+        buf.extend_from_slice(&MIGTD_DATA_TYPE_TDINFO.to_le_bytes());
+        buf.extend_from_slice(&(self.init_tdinfo.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&self.init_tdinfo);
+
+        let total_size = (buf.len() - start_len) as u32;
+
+        // Update length field
+        let length_offset = start_len + 12;
+        buf[length_offset..length_offset + 4].copy_from_slice(&total_size.to_le_bytes());
+    }
+
+    pub fn get_from_local(report_data: &[u8; 64]) -> Option<Self> {
+        let report = tdx_tdcall::tdreport::tdcall_report(report_data).ok()?;
+        Some(Self {
+            init_tdinfo: report.td_info.as_bytes().to_vec(),
+        })
+    }
+}
+
+pub struct MigtdDataEntry<'a> {
+    pub r#type: u32,
+    pub length: u32,
+    pub value: &'a [u8],
+}
+
+impl<'a> MigtdDataEntry<'a> {
+    pub fn read_from_bytes(b: &'a [u8]) -> Option<Self> {
+        if b.len() < 8 {
+            return None;
+        }
+
+        let r#type = u32::from_le_bytes(b[0..4].try_into().unwrap());
+        let length = u32::from_le_bytes(b[4..8].try_into().unwrap());
+
+        if b.len() < length as usize + 8 {
+            return None;
+        }
+
+        Some(Self {
+            r#type,
+            length,
+            value: &b[8..8 + length as usize],
+        })
+    }
+}

--- a/src/migtd/src/migration/mod.rs
+++ b/src/migtd/src/migration/mod.rs
@@ -4,6 +4,8 @@
 
 pub mod data;
 pub mod event;
+#[cfg(feature = "policy_v2")]
+pub mod init_data;
 pub mod logging;
 #[cfg(feature = "policy_v2")]
 pub mod pre_session_data;
@@ -152,7 +154,11 @@ pub struct MigtdMigrationInformation {
 
     // If set, current MigTD is MigTD-s else current MigTD is MigTD-d
     pub migration_source: u8,
-    _pad: [u8; 7],
+
+    // Per GHCI 1.5: hasInitMigtdData — true if initMigtdData follows at offset 56
+    pub has_init_data: u8,
+
+    _reserved: [u8; 6],
 
     // UUID of target TD
     pub target_td_uuid: [u64; 4],
@@ -171,7 +177,29 @@ pub struct MigtdMigrationInformation {
 }
 
 #[cfg(feature = "vmcall-raw")]
-impl_read_from_bytes!(MigtdMigrationInformation);
+impl MigtdMigrationInformation {
+    pub fn read_from_bytes(
+        data_length: u32,
+        payload: &[u8],
+    ) -> core::result::Result<Self, MigrationResult> {
+        let fixed_size = core::mem::size_of::<Self>() as u32;
+        if (data_length as usize) < fixed_size as usize {
+            return Err(MigrationResult::InvalidParameter);
+        }
+        let info: Self = payload
+            .pread(0)
+            .map_err(|_| MigrationResult::InvalidParameter)?;
+        // Reject trailing bytes unless has_init_data is set
+        if data_length > fixed_size && info.has_init_data != 1 {
+            return Err(MigrationResult::InvalidParameter);
+        }
+        // Reject reserved fields that must be zero
+        if info._reserved != [0; 6] {
+            return Err(MigrationResult::InvalidParameter);
+        }
+        Ok(info)
+    }
+}
 
 #[repr(C)]
 #[derive(Debug, Pread, Pwrite)]

--- a/src/migtd/src/migration/rebinding.rs
+++ b/src/migtd/src/migration/rebinding.rs
@@ -8,7 +8,6 @@ use core::time::Duration;
 use crypto::{
     tls::SecureChannel,
     x509::{Certificate, Decode},
-    SHA384_DIGEST_SIZE,
 };
 use ring::rand::{SecureRandom, SystemRandom};
 use tdx_tdcall::tdx::{tdcall_servtd_rebind_approve, tdcall_vm_write};
@@ -45,8 +44,8 @@ const TDCS_FIELD_WRITE_MASK: u64 = u64::MAX;
 
 const TLS_TIMEOUT: Duration = Duration::from_secs(60); // 60 seconds
                                                        // FIXME: Need VMM provide socket information
-const MIGTD_DATA_SIGNATURE: &[u8] = b"MIGTDATA";
-const MIGTD_DATA_TYPE_TDINFO: u32 = 0;
+pub use super::init_data::{InitData, MigtdDataEntry};
+pub(crate) use super::init_data::{MIGTD_DATA_SIGNATURE, MIGTD_DATA_TYPE_TDINFO};
 
 #[repr(C)]
 pub struct RebindingToken {
@@ -123,117 +122,6 @@ impl RebindingInfo {
             target_td_uuid,
             binding_handle,
             init_migtd_data,
-        })
-    }
-}
-
-pub struct InitData {
-    /// The TDINFO_STRUCT of the initial MigTD (per GHCI 1.5, MIGTD_DATA type 0).
-    pub init_tdinfo: Vec<u8>,
-}
-
-impl InitData {
-    /// TDINFO_STRUCT field offsets and sizes (per TDX Module ABI).
-    const TDINFO_MROWNER_OFFSET: usize = 112; // attributes(8) + xfam(8) + mrtd(48) + mrconfig_id(48)
-    const TDINFO_MROWNERCONFIG_OFFSET: usize = 160; // MROWNER_OFFSET + 48
-    const TDINFO_FIELD_SIZE: usize = SHA384_DIGEST_SIZE;
-    const TDINFO_MIN_SIZE: usize = 512;
-
-    /// Extract mrowner from the TDINFO_STRUCT.
-    /// Per GHCI 1.5: VMM puts migpolicy.policy_key in tdinfo.mrowner.
-    pub fn mrowner(&self) -> &[u8] {
-        &self.init_tdinfo
-            [Self::TDINFO_MROWNER_OFFSET..Self::TDINFO_MROWNER_OFFSET + Self::TDINFO_FIELD_SIZE]
-    }
-
-    /// Extract mrownerconfig from the TDINFO_STRUCT.
-    /// Per GHCI 1.5: VMM puts migpolicy.policy_svn in tdinfo.mrownerconfig.
-    pub fn mrownerconfig(&self) -> &[u8] {
-        &self.init_tdinfo[Self::TDINFO_MROWNERCONFIG_OFFSET
-            ..Self::TDINFO_MROWNERCONFIG_OFFSET + Self::TDINFO_FIELD_SIZE]
-    }
-
-    pub fn read_from_bytes(b: &[u8]) -> Option<Self> {
-        if b.len() < 20 || &b[..8] != MIGTD_DATA_SIGNATURE {
-            return None;
-        }
-
-        let version = u32::from_le_bytes(b[8..12].try_into().unwrap());
-        let length = u32::from_le_bytes(b[12..16].try_into().unwrap());
-        let num_entries = u32::from_le_bytes(b[16..20].try_into().unwrap());
-
-        // Per GHCI 1.5: version must be 0x00010000, numberOfEntry must be 1 (tdinfo)
-        if version != 0x00010000 || b.len() < length as usize || num_entries != 1 {
-            return None;
-        }
-
-        let entry = MigtdDataEntry::read_from_bytes(&b[20..])?;
-        if entry.r#type != MIGTD_DATA_TYPE_TDINFO {
-            return None;
-        }
-
-        if entry.value.len() < Self::TDINFO_MIN_SIZE {
-            return None;
-        }
-
-        Some(Self {
-            init_tdinfo: entry.value.to_vec(),
-        })
-    }
-
-    pub fn write_into_bytes(&self, buf: &mut Vec<u8>) {
-        let start_len = buf.len();
-        buf.extend_from_slice(MIGTD_DATA_SIGNATURE);
-        buf.extend_from_slice(&0x00010000u32.to_le_bytes()); // Version
-
-        // Placeholder for length.
-        buf.extend_from_slice(&0u32.to_le_bytes());
-
-        // Per GHCI 1.5: numberOfEntry = 1, entry type 0 = tdinfo
-        buf.extend_from_slice(&1u32.to_le_bytes()); // num_entries
-
-        buf.extend_from_slice(&MIGTD_DATA_TYPE_TDINFO.to_le_bytes());
-        buf.extend_from_slice(&(self.init_tdinfo.len() as u32).to_le_bytes());
-        buf.extend_from_slice(&self.init_tdinfo);
-
-        let total_size = (buf.len() - start_len) as u32;
-
-        // Update length field
-        let length_offset = start_len + 12;
-        buf[length_offset..length_offset + 4].copy_from_slice(&total_size.to_le_bytes());
-    }
-
-    pub fn get_from_local(report_data: &[u8; 64]) -> Option<Self> {
-        let report = tdx_tdcall::tdreport::tdcall_report(report_data).ok()?;
-        Some(Self {
-            init_tdinfo: report.td_info.as_bytes().to_vec(),
-        })
-    }
-}
-
-pub struct MigtdDataEntry<'a> {
-    pub r#type: u32,
-    pub length: u32,
-    pub value: &'a [u8],
-}
-
-impl<'a> MigtdDataEntry<'a> {
-    pub fn read_from_bytes(b: &'a [u8]) -> Option<Self> {
-        if b.len() < 8 {
-            return None;
-        }
-
-        let r#type = u32::from_le_bytes(b[0..4].try_into().unwrap());
-        let length = u32::from_le_bytes(b[4..8].try_into().unwrap());
-
-        if b.len() < length as usize + 8 {
-            return None;
-        }
-
-        Some(Self {
-            r#type,
-            length,
-            value: &b[8..8 + length as usize],
         })
     }
 }

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -397,9 +397,50 @@ fn parse_request(
 
     match op {
         DataStatusOperation::StartMigration => {
-            decode_and_dispatch!(MigtdMigrationInformation, |mig_info| {
-                WaitForRequestResponse::StartMigration(MigrationInformation { mig_info })
-            })
+            #[cfg(feature = "policy_v2")]
+            {
+                match MigtdMigrationInformation::read_from_bytes(data_length, slice) {
+                    Ok(mig_info) => {
+                        use crate::migration::init_data::InitData;
+                        let init_migtd_data = if mig_info.has_init_data == 1 {
+                            let fixed_size = core::mem::size_of::<MigtdMigrationInformation>();
+                            Some(
+                                InitData::read_from_bytes(&slice[fixed_size..])
+                                    .ok_or(MigrationResult::InvalidParameter)
+                                    .map_err(|status| {
+                                        log_request_error!(
+                                            request_id,
+                                            "wait_for_request: StartMigration failed to decode init_migtd_data\n"
+                                        );
+                                        status
+                                    })?,
+                            )
+                        } else {
+                            None
+                        };
+                        try_accept_request(
+                            mig_info.mig_request_id,
+                            WaitForRequestResponse::StartMigration(MigrationInformation {
+                                mig_info,
+                                init_migtd_data,
+                            }),
+                        )
+                    }
+                    Err(status) => {
+                        log_request_error!(
+                            request_id,
+                            "wait_for_request: StartMigration failed to decode payload\n"
+                        );
+                        reject_request(pending_error_report, request_id, status)
+                    }
+                }
+            }
+            #[cfg(not(feature = "policy_v2"))]
+            {
+                decode_and_dispatch!(MigtdMigrationInformation, |mig_info| {
+                    WaitForRequestResponse::StartMigration(MigrationInformation { mig_info })
+                })
+            }
         }
         DataStatusOperation::StartRebinding => {
             #[cfg(all(feature = "vmcall-raw", feature = "policy_v2"))]
@@ -672,7 +713,7 @@ pub async fn get_migtd_data(
     data: &mut Vec<u8>,
     request_id: u64,
 ) -> Result<()> {
-    use crate::migration::rebinding::InitData;
+    use crate::migration::init_data::InitData;
 
     let init_data = InitData::get_from_local(additional_data).ok_or_else(|| {
         log::error!( migration_request_id = request_id;
@@ -948,6 +989,8 @@ async fn migration_src_exchange_msk(
             &mut spdm_requester,
             &info.mig_info,
             #[cfg(feature = "policy_v2")]
+            info.init_migtd_data.as_ref(),
+            #[cfg(feature = "policy_v2")]
             remote_policy,
         ),
     )
@@ -1019,6 +1062,18 @@ async fn migration_dst_exchange_msk(
 
 #[cfg(feature = "main")]
 pub async fn exchange_msk(info: &MigrationInformation) -> Result<()> {
+    // Per GHCI 1.5: if VMM provided initMigtdData, verify policy binding
+    #[cfg(feature = "policy_v2")]
+    if let Some(ref init_data) = info.init_migtd_data {
+        crate::mig_policy::verify_init_migtd_data_policy_binding(init_data).map_err(|e| {
+            log::error!(
+                migration_request_id = info.mig_info.mig_request_id;
+                "exchange_msk: initMigtdData policy binding verification failed: {:?}\n", e
+            );
+            MigrationResult::PolicyUnsatisfiedError
+        })?;
+    }
+
     let mut transport = setup_transport(
         info.mig_info.mig_request_id,
         #[cfg(any(feature = "vmcall-vsock", feature = "virtio-vsock"))]

--- a/src/migtd/src/spdm/spdm_req.rs
+++ b/src/migtd/src/spdm/spdm_req.rs
@@ -90,6 +90,7 @@ pub fn spdm_requester<T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static>
 pub async fn spdm_requester_transfer_msk(
     spdm_requester: &mut RequesterContext,
     mig_info: &MigtdMigrationInformation,
+    #[cfg(feature = "policy_v2")] init_migtd_data: Option<&crate::migration::init_data::InitData>,
     #[cfg(feature = "policy_v2")] remote_policy: Vec<u8>,
 ) -> Result<(), SpdmStatus> {
     Box::pin(spdm_requester.send_receive_spdm_version()).await?;
@@ -107,6 +108,8 @@ pub async fn spdm_requester_transfer_msk(
         spdm_requester,
         mig_info,
         session_id,
+        #[cfg(feature = "policy_v2")]
+        init_migtd_data,
         #[cfg(feature = "policy_v2")]
         remote_policy,
     ))
@@ -296,6 +299,7 @@ pub async fn send_and_receive_sdm_migration_attest_info(
     spdm_requester: &mut RequesterContext,
     mig_info: &MigtdMigrationInformation,
     session_id: u32,
+    #[cfg(feature = "policy_v2")] init_migtd_data: Option<&crate::migration::init_data::InitData>,
     #[cfg(feature = "policy_v2")] remote_policy: Vec<u8>,
 ) -> SpdmResult {
     if spdm_requester.common.provision_info.my_pub_key.is_none()
@@ -412,11 +416,27 @@ pub async fn send_and_receive_sdm_migration_attest_info(
             .ok_or(SPDM_STATUS_BUFFER_FULL)?;
     }
 
-    // Init TDINFO: local MigTD TDINFO_STRUCT for SERVTD_HASH verification by peer
+    // Init TDINFO: use VMM-provided initMigtdData if available, otherwise local
     {
-        let report = tdx_tdcall::tdreport::tdcall_report(&[0u8; 64])
-            .map_err(|_| SPDM_STATUS_INVALID_STATE_LOCAL)?;
-        let tdinfo_init = report.td_info.as_bytes();
+        #[cfg(feature = "policy_v2")]
+        let tdinfo_init_vec;
+        #[cfg(feature = "policy_v2")]
+        let tdinfo_init: &[u8] = if let Some(init_data) = init_migtd_data {
+            &init_data.init_tdinfo
+        } else {
+            let report = tdx_tdcall::tdreport::tdcall_report(&[0u8; 64])
+                .map_err(|_| SPDM_STATUS_INVALID_STATE_LOCAL)?;
+            tdinfo_init_vec = report.td_info.as_bytes().to_vec();
+            &tdinfo_init_vec
+        };
+        #[cfg(not(feature = "policy_v2"))]
+        let tdinfo_init = {
+            let report = tdx_tdcall::tdreport::tdcall_report(&[0u8; 64])
+                .map_err(|_| SPDM_STATUS_INVALID_STATE_LOCAL)?;
+            report.td_info.as_bytes().to_vec()
+        };
+        #[cfg(not(feature = "policy_v2"))]
+        let tdinfo_init: &[u8] = &tdinfo_init;
         let tdinfo_init_element = VdmMessageElement {
             element_type: VdmMessageElementType::TdReportInit,
             length: tdinfo_init.len() as u32,
@@ -983,7 +1003,7 @@ pub async fn send_and_receive_sdm_rebind_attest_info(
     //SERVTD_EXT
     let binding_handle = rebind_info.binding_handle;
     let target_td_uuid = &rebind_info.target_td_uuid;
-    let local_data = crate::migration::rebinding::InitData::get_from_local(&[0u8; 64])
+    let local_data = crate::migration::init_data::InitData::get_from_local(&[0u8; 64])
         .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
     let init_migtd_data = rebind_info.init_migtd_data.as_ref().unwrap_or(&local_data);
 

--- a/src/policy/src/v2/policy.rs
+++ b/src/policy/src/v2/policy.rs
@@ -294,6 +294,10 @@ impl<'a> PolicyData<'a> {
         !self.id.is_empty() && self.version == "2.0"
     }
 
+    pub fn get_policy_svn(&self) -> u32 {
+        self.policy_svn
+    }
+
     pub fn evaluate_policy_forward(
         &self,
         value: &PolicyEvaluationInfo,


### PR DESCRIPTION
Per GHCI 1.5, the VMM must put migpolicy.policy_key and migpolicy.policy_svn in TDINFO.MROWNER and TDINFO.MROWNERCONFIG respectively, and may provide initMigtdData in the StartMigration request for subsequent migrations.

This change implements:

a) Allow VMM to pass initMigtdData via the StartMigration request.
   MigtdMigrationInformation now has has_init_data field at offset 9
   and the parser accepts variable-length payload with init data.

b) MigTD startup self-check: verify that own TDINFO.MROWNER equals
   SHA384(policy signing public key) and TDINFO.MROWNERCONFIG equals
   own policy_svn. Reject with InvalidPolicyError on mismatch.

c) Migration flow verification: when VMM provides initMigtdData,
   verify that initMigtdData.MROWNER matches own policy signer key
   hash and initMigtdData.MROWNERCONFIG <= own policy_svn before
   proceeding with key exchange.

d) SPDM requester for migration uses VMM-provided initMigtdData
   (when available) instead of always generating local TDINFO,
   enabling correct attestation for non-initial migrations.

Closes: #822  #823 