### PR TITLE
feat(migtd): verify SERVTD_ATTR on destination before MSK write

### DIFF
--- a/src/migtd/src/migration/servtd_ext.rs
+++ b/src/migtd/src/migration/servtd_ext.rs
@@ -127,9 +127,7 @@ pub fn read_servtd_ext(
     let actual_attr = u64::from_le_bytes(cur_servtd_attr);
     if actual_attr != EXPECTED_SERVTD_ATTR {
         log::error!(
-            "SERVTD_ATTR mismatch: expected {:#x}, got {:#x}",
-            EXPECTED_SERVTD_ATTR,
-            actual_attr
+            "SERVTD_ATTR mismatch: expected {EXPECTED_SERVTD_ATTR:#x}, got {actual_attr:#x}"
         );
         return Err(MigrationResult::InvalidParameter);
     }
@@ -146,6 +144,25 @@ pub fn read_servtd_ext(
         reserved: [0u8; 8],
         reserved2: [0u8; 104],
     })
+}
+
+/// Verify that CURR_SERVTD_ATTR of the target TD matches the hardcoded expected value.
+///
+/// Per GHCI 1.5: Both source and destination MigTDs must verify this before
+/// any TDG.SERVTD.WR operations (mig_dec_key, mig_version).
+pub fn verify_servtd_attr(
+    binding_handle: u64,
+    target_td_uuid: &[u64],
+) -> Result<(), MigrationResult> {
+    let result = tdcall_servtd_rd(binding_handle, TDCS_FIELD_SERVTD_ATTR, target_td_uuid)?;
+    let actual_attr = result.content;
+    if actual_attr != EXPECTED_SERVTD_ATTR {
+        log::error!(
+            "SERVTD_ATTR mismatch: expected {EXPECTED_SERVTD_ATTR:#x}, got {actual_attr:#x}"
+        );
+        return Err(MigrationResult::InvalidParameter);
+    }
+    Ok(())
 }
 
 pub fn write_approved_servtd_ext_hash(servtd_ext_hash: &[u8]) -> Result<(), MigrationResult> {

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -6,6 +6,8 @@
 use crate::migration::pre_session_data::pre_session_data_exchange;
 #[cfg(all(feature = "vmcall-raw", feature = "policy_v2"))]
 use crate::migration::rebinding::RebindingInfo;
+#[cfg(not(feature = "spdm_attestation"))]
+use crate::migration::servtd_ext::verify_servtd_attr;
 use crate::migration::transport::setup_transport;
 use crate::migration::transport::shutdown_transport;
 use crate::migration::transport::TransportType;
@@ -1092,6 +1094,14 @@ pub async fn exchange_msk(info: &MigrationInformation) -> Result<()> {
                 log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: cal_mig_version error: {:?}\n", e);
                 e
             })?;
+        verify_servtd_attr(
+            info.mig_info.binding_handle,
+            &info.mig_info.target_td_uuid,
+        )
+        .map_err(|e| {
+            log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: verify_servtd_attr error: {:?}\n", e);
+            e
+        })?;
         set_mig_version(&info.mig_info, mig_ver).map_err(|e| {
             log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: set_mig_version error: {:?}\n", e);
             e

--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -7,8 +7,10 @@ use crate::mig_policy;
 use crate::migration::rebinding::{
     write_rebinding_session_token, write_servtd_rebind_attr, RebindingInfo,
 };
+#[cfg(not(feature = "policy_v2"))]
+use crate::migration::servtd_ext::verify_servtd_attr;
 #[cfg(feature = "policy_v2")]
-use crate::migration::servtd_ext::{write_approved_servtd_ext_hash, ServtdExt};
+use crate::migration::servtd_ext::{verify_servtd_attr, write_approved_servtd_ext_hash, ServtdExt};
 use crate::{
     config::get_policy,
     event_log::get_event_log,
@@ -816,6 +818,11 @@ pub fn handle_exchange_mig_info_req(
     let responder_app_context =
         SpdmAppContextData::read(&mut reader).ok_or(SPDM_STATUS_INVALID_MSG_SIZE)?;
     let exchange_information = exchange_info(&responder_app_context.migration_info, false)?;
+
+    verify_servtd_attr(
+        responder_app_context.migration_info.binding_handle,
+        &responder_app_context.migration_info.target_td_uuid,
+    )?;
 
     let mig_ver = cal_mig_version(false, &exchange_information, &remote_information)?;
     set_mig_version(&responder_app_context.migration_info, mig_ver)?;


### PR DESCRIPTION
Add verify_servtd_attr() that reads CURR_SERVTD_ATTR via TDG.SERVTD.RD and compares it against the hardcoded EXPECTED_SERVTD_ATTR value. Call it on the SPDM responder (destination) path before set_mig_version/write_msk, and in the non-SPDM exchange_msk path for both source and destination.

Per GHCI 1.5, both source and destination MigTDs must verify CURR_SERVTD_ATTR matches the expected value before any TDG.SERVTD.WR operations (mig_dec_key, mig_version), since the field is written by untrusted VMM during PREBIND.

Closes #812