### PR TITLE
fix(servtd_ext): verify SERVTD_ATTR against INIT_ATTR from TDINFO

### DIFF
--- a/src/migtd/src/migration/servtd_ext.rs
+++ b/src/migtd/src/migration/servtd_ext.rs
@@ -123,11 +123,19 @@ pub fn read_servtd_ext(
     read_field(TDCS_FIELD_SERVTD_INFO_HASH, 8, &mut cur_servtd_info_hash)?;
     read_field(TDCS_FIELD_SERVTD_ATTR, 8, &mut cur_servtd_attr)?;
 
-    // Verify CURR_SERVTD_ATTR matches the hardcoded expected value per GHCI 1.5.
+    // Verify CURR_SERVTD_ATTR matches both the hardcoded expected value and the
+    // INIT_ATTR from MigTDData's TDINFO per GHCI 1.5.
     let actual_attr = u64::from_le_bytes(cur_servtd_attr);
+    let expected_init_attr = u64::from_le_bytes(init_attr);
     if actual_attr != EXPECTED_SERVTD_ATTR {
         log::error!(
-            "SERVTD_ATTR mismatch: expected {EXPECTED_SERVTD_ATTR:#x}, got {actual_attr:#x}"
+            "SERVTD_ATTR mismatch vs hardcoded: expected {EXPECTED_SERVTD_ATTR:#x}, got {actual_attr:#x}"
+        );
+        return Err(MigrationResult::InvalidParameter);
+    }
+    if actual_attr != expected_init_attr {
+        log::error!(
+            "SERVTD_ATTR mismatch vs INIT_ATTR: expected {expected_init_attr:#x}, got {actual_attr:#x}"
         );
         return Err(MigrationResult::InvalidParameter);
     }
@@ -146,7 +154,8 @@ pub fn read_servtd_ext(
     })
 }
 
-/// Verify that CURR_SERVTD_ATTR of the target TD matches the hardcoded expected value.
+/// Verify that CURR_SERVTD_ATTR of the target TD matches both the hardcoded
+/// expected value and the INIT_ATTR from MigTDData's TDINFO.
 ///
 /// Per GHCI 1.5: Both source and destination MigTDs must verify this before
 /// any TDG.SERVTD.WR operations (mig_dec_key, mig_version).
@@ -158,7 +167,17 @@ pub fn verify_servtd_attr(
     let actual_attr = result.content;
     if actual_attr != EXPECTED_SERVTD_ATTR {
         log::error!(
-            "SERVTD_ATTR mismatch: expected {EXPECTED_SERVTD_ATTR:#x}, got {actual_attr:#x}"
+            "SERVTD_ATTR mismatch vs hardcoded: expected {EXPECTED_SERVTD_ATTR:#x}, got {actual_attr:#x}"
+        );
+        return Err(MigrationResult::InvalidParameter);
+    }
+
+    let init_result =
+        tdcall_servtd_rd(binding_handle, TDCS_FIELD_SERVTD_INIT_ATTR, target_td_uuid)?;
+    let expected_init_attr = init_result.content;
+    if actual_attr != expected_init_attr {
+        log::error!(
+            "SERVTD_ATTR mismatch vs INIT_ATTR: expected {expected_init_attr:#x}, got {actual_attr:#x}"
         );
         return Err(MigrationResult::InvalidParameter);
     }


### PR DESCRIPTION
## Summary

Per GHCI 1.5, `CURR_SERVTD_ATTR` must match the `SERVTD_ATTR` value provided in MigTDData's TDINFO during migrate or rebind operations.

Previously, both `verify_servtd_attr()` and `read_servtd_ext()` only compared against the hardcoded `EXPECTED_SERVTD_ATTR` constant (`0`). While all bits are currently fixed-0, this will break if IGNORE flags (bits 40:32) or future attribute bits become non-zero.

## Changes

- `read_servtd_ext()`: after reading both `init_attr` and `cur_servtd_attr`, now verifies `cur_servtd_attr` matches `init_attr` (in addition to the hardcoded check)
- `verify_servtd_attr()`: adds a second `TDG.SERVTD.RD` call to read `TDCS_FIELD_SERVTD_INIT_ATTR` and verifies `CURR_SERVTD_ATTR` matches it

This ensures forward-compatibility with non-zero `SERVTD_ATTR` values per the spec requirement.

## References

- GHCI 1.5 §TDG.SERVTD.RD / SERVTD_ATTR verification
- MigTD Design Guide Rev 0.9.3 §SERVTD_ATTR

Closes: #831