### PR TITLE
fix(migtd): include TD_INFO in default metadata

### DIFF
--- a/config/image_layout.json
+++ b/config/image_layout.json
@@ -4,7 +4,8 @@
     "TempStack": "0x010000",
     "TempHeap": "0x010000",
     "Metadata": "0x001000",
-    "Payload": "0xEE6000",
+    "TdInfo": "0x001000",
+    "Payload": "0xEE5000",
     "Ipl": "0x50000",
     "ResetVector": "0x008000"
 }

--- a/config/metadata.json
+++ b/config/metadata.json
@@ -1,18 +1,26 @@
 {
     "Sections": [
         {
-            "DataOffset": "0xFA7000",
-            "RawDataSize": "0x59000",
-            "MemoryAddress": "0xFFFA7000",
-            "MemoryDataSize": "0x59000",
+            "DataOffset": "0xFA6000",
+            "RawDataSize": "0x5A000",
+            "MemoryAddress": "0xFFFA6000",
+            "MemoryDataSize": "0x5A000",
             "Type": "BFV",
             "Attributes": "0x1"
         },
         {
+            "DataOffset": "0xFA6000",
+            "RawDataSize": "0x1000",
+            "MemoryAddress": "0x0",
+            "MemoryDataSize": "0x0",
+            "Type": "TdInfo",
+            "Attributes": "0x0"
+        },
+        {
             "DataOffset": "0xC1000",
-            "RawDataSize": "0xEE6000",
+            "RawDataSize": "0xEE5000",
             "MemoryAddress": "0xFF0C1000",
-            "MemoryDataSize": "0xEE6000",
+            "MemoryDataSize": "0xEE5000",
             "Type": "Payload",
             "Attributes": "0x1"
         },


### PR DESCRIPTION
Reserve a TdInfo slot in the image layout and add a TdInfo section to the default metadata JSON so the generated MigTD image satisfies the spec's TD_INFO requirement.

Fixes #619 