### PR TITLE
fix(vmcall_raw): guard send-path buffer sizing against overflow

### DIFF
--- a/src/devices/vmcall_raw/src/lib.rs
+++ b/src/devices/vmcall_raw/src/lib.rs
@@ -142,6 +142,26 @@ pub enum State {
 }
 
 /// Align `size` up to a page.
-pub(crate) fn align_up(size: usize) -> usize {
-    (size & !(PAGE_SIZE - 1)) + if size % PAGE_SIZE != 0 { PAGE_SIZE } else { 0 }
+pub(crate) fn align_up(size: usize) -> Option<usize> {
+    size.checked_add(PAGE_SIZE - 1)
+        .map(|size| size & !(PAGE_SIZE - 1))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn align_up_handles_page_boundaries() {
+        assert_eq!(align_up(0), Some(0));
+        assert_eq!(align_up(1), Some(PAGE_SIZE));
+        assert_eq!(align_up(PAGE_SIZE - 1), Some(PAGE_SIZE));
+        assert_eq!(align_up(PAGE_SIZE), Some(PAGE_SIZE));
+        assert_eq!(align_up(PAGE_SIZE + 1), Some(PAGE_SIZE * 2));
+    }
+
+    #[test]
+    fn align_up_rejects_unrepresentable_size() {
+        assert_eq!(align_up(usize::MAX), None);
+    }
 }

--- a/src/devices/vmcall_raw/src/transport/vmcall.rs
+++ b/src/devices/vmcall_raw/src/transport/vmcall.rs
@@ -75,10 +75,13 @@ pub async fn vmcall_raw_transport_enqueue(
     buf: &[u8],
 ) -> Result<usize, VmcallRawError> {
     let data_status: u64 = 0;
-    let data_length: u32 = buf.len() as u32;
+    let data_length: u32 = buf.len().try_into().map_err(|_| VmcallRawError::Illegal)?;
 
-    let data_buffer_size = 8 + 4 + buf.len();
-    let data_buffer_page_count = align_up(data_buffer_size) / PAGE_SIZE;
+    let data_buffer_size = 12usize
+        .checked_add(buf.len())
+        .ok_or(VmcallRawError::Illegal)?;
+    let data_buffer_page_count =
+        align_up(data_buffer_size).ok_or(VmcallRawError::Illegal)? / PAGE_SIZE;
     let mut data_buffer =
         SharedMemory::new(data_buffer_page_count).ok_or(VmcallRawError::Illegal)?;
 


### PR DESCRIPTION
align_up() computed `(size & !(PAGE_SIZE - 1)) + PAGE_SIZE` for non-page-aligned input, which silently wraps to 0 near usize::MAX, and vmcall_raw_transport_enqueue() blindly downcast buf.len() to u32 and added the 12-byte header without overflow checks. A pathological caller could end up allocating a 0-page SharedMemory and writing past it.

Switch align_up() to checked_add and propagate None to the caller as VmcallRawError::Illegal; size the data buffer via checked_add(12) and reject buf.len() that does not fit a u32 data_length. Add unit tests for the boundary cases.