### PR TITLE
fix(pre_session_data): add #[repr(C)] to HelloPacketPayload

### DIFF
--- a/src/migtd/src/migration/pre_session_data.rs
+++ b/src/migtd/src/migration/pre_session_data.rs
@@ -41,6 +41,7 @@ impl PreSessionMessage {
     }
 }
 
+#[repr(C)]
 pub(super) struct HelloPacketPayload {
     magic_word: [u8; 4],
     lowest_supported_version: u16,


### PR DESCRIPTION
HelloPacketPayload is serialized via as_bytes() (a raw pointer cast over the struct) and parsed via read_from_bytes() with hard-coded offsets, both of which assume C layout. Without #[repr(C)] the compiler is free to reorder fields, breaking the wire format.

Annotate the struct to match the sibling PreSessionMessage.