### PR TITLE
fix(crypto): locate PEM_CERT_END after PEM_CERT_BEGIN in get_fmspc_from_quote

### DIFF
--- a/src/policy/src/v2/collaterals.rs
+++ b/src/policy/src/v2/collaterals.rs
@@ -16,7 +16,10 @@ pub fn get_fmspc_from_quote(quote: &[u8]) -> Result<[u8; 6], PolicyError> {
 
     let mid = String::from_utf8_lossy(quote);
     let start_index = mid.find(PEM_CERT_BEGIN).ok_or(PolicyError::InvalidQuote)?;
-    let end_index = mid.find(PEM_CERT_END).ok_or(PolicyError::InvalidQuote)? + PEM_CERT_END.len();
+    let end_index = mid[start_index..]
+        .find(PEM_CERT_END)
+        .map(|i| start_index + i + PEM_CERT_END.len())
+        .ok_or(PolicyError::InvalidQuote)?;
 
     let pck_cert = mid[start_index..end_index].as_bytes();
     let pck_der = crypto::pem_cert_to_der(pck_cert).map_err(|_| PolicyError::InvalidQuote)?;


### PR DESCRIPTION

find(PEM_CERT_END) searched from offset 0 of the lossy-decoded quote string, so if any byte sequence matching the END marker appeared before the BEGIN marker (or BEGIN was absent), end_index < start_index and the subsequent slice operation panicked.

Search for END strictly after the end of BEGIN, and return InvalidQuote on malformed input. Real hardware quotes never trigger the bug, but the parser should not panic on hostile input.