### PR TITLE
fix(servtd_ext): remove broken init_attr == curr_attr check

### DIFF
--- a/src/migtd/src/migration/servtd_ext.rs
+++ b/src/migtd/src/migration/servtd_ext.rs
@@ -123,19 +123,11 @@ pub fn read_servtd_ext(
     read_field(TDCS_FIELD_SERVTD_INFO_HASH, 8, &mut cur_servtd_info_hash)?;
     read_field(TDCS_FIELD_SERVTD_ATTR, 8, &mut cur_servtd_attr)?;
 
-    // Verify CURR_SERVTD_ATTR matches both the hardcoded expected value and the
-    // INIT_ATTR from MigTDData's TDINFO per GHCI 1.5.
+    // Verify CURR_SERVTD_ATTR matches the hardcoded expected value.
     let actual_attr = u64::from_le_bytes(cur_servtd_attr);
-    let expected_init_attr = u64::from_le_bytes(init_attr);
     if actual_attr != EXPECTED_SERVTD_ATTR {
         log::error!(
             "SERVTD_ATTR mismatch vs hardcoded: expected {EXPECTED_SERVTD_ATTR:#x}, got {actual_attr:#x}"
-        );
-        return Err(MigrationResult::InvalidParameter);
-    }
-    if actual_attr != expected_init_attr {
-        log::error!(
-            "SERVTD_ATTR mismatch vs INIT_ATTR: expected {expected_init_attr:#x}, got {actual_attr:#x}"
         );
         return Err(MigrationResult::InvalidParameter);
     }
@@ -154,8 +146,8 @@ pub fn read_servtd_ext(
     })
 }
 
-/// Verify that CURR_SERVTD_ATTR of the target TD matches both the hardcoded
-/// expected value and the INIT_ATTR from MigTDData's TDINFO.
+/// Verify that CURR_SERVTD_ATTR of the target TD (VMM input) matches the
+/// hardcoded expected value (MigTD internal).
 ///
 /// Per GHCI 1.5: Both source and destination MigTDs must verify this before
 /// any TDG.SERVTD.WR operations (mig_dec_key, mig_version).
@@ -167,17 +159,7 @@ pub fn verify_servtd_attr(
     let actual_attr = result.content;
     if actual_attr != EXPECTED_SERVTD_ATTR {
         log::error!(
-            "SERVTD_ATTR mismatch vs hardcoded: expected {EXPECTED_SERVTD_ATTR:#x}, got {actual_attr:#x}"
-        );
-        return Err(MigrationResult::InvalidParameter);
-    }
-
-    let init_result =
-        tdcall_servtd_rd(binding_handle, TDCS_FIELD_SERVTD_INIT_ATTR, target_td_uuid)?;
-    let expected_init_attr = init_result.content;
-    if actual_attr != expected_init_attr {
-        log::error!(
-            "SERVTD_ATTR mismatch vs INIT_ATTR: expected {expected_init_attr:#x}, got {actual_attr:#x}"
+            "SERVTD_ATTR mismatch: VMM wrote {actual_attr:#x}, MigTD expects {EXPECTED_SERVTD_ATTR:#x}"
         );
         return Err(MigrationResult::InvalidParameter);
     }


### PR DESCRIPTION
The verify_servtd_attr and read_servtd_ext functions compared CURR_SERVTD_ATTR against INIT_ATTR read from the target TD. This check is invalid because INIT_ATTR is only populated when the rebind feature is supported, while the initial binding does not set it.

Remove the redundant INIT_ATTR comparison and keep only the hardcoded EXPECTED_SERVTD_ATTR verification which ensures the VMM wrote the correct value.

Closes #845