### PR TITLE
refactor(vmcall_raw): remove double-dequeue and dead code in receive path

### DIFF
--- a/src/devices/vmcall_raw/src/stream.rs
+++ b/src/devices/vmcall_raw/src/stream.rs
@@ -10,28 +10,11 @@ use core::sync::atomic::AtomicBool;
 
 use crate::{VmcallRawAddr, VmcallRawError};
 
-use alloc::{collections::BTreeMap, collections::VecDeque, vec::Vec};
+use alloc::{collections::VecDeque, vec::Vec};
 use async_io::{AsyncRead, AsyncWrite};
-use lazy_static::lazy_static;
 use rust_std_stub::io;
-use spin::Mutex;
 
 type Result<T = ()> = core::result::Result<T, VmcallRawError>;
-
-lazy_static! {
-    pub(crate) static ref CONNECTION_PKT_QUEUES: Mutex<BTreeMap<VmcallRawAddr, VecDeque<Vec<u8>>>> =
-        Mutex::new(BTreeMap::new());
-}
-
-fn add_stream_to_connection_map(stream: &VmcallRaw) {
-    CONNECTION_PKT_QUEUES
-        .lock()
-        .insert(stream.addr, VecDeque::new());
-}
-
-fn remove_stream_from_connection_map(stream: &VmcallRaw) {
-    CONNECTION_PKT_QUEUES.lock().remove(&stream.addr);
-}
 
 pub struct VmcallRaw {
     pub addr: VmcallRawAddr,
@@ -65,7 +48,6 @@ impl VmcallRaw {
     }
 
     pub async fn connect(&mut self) -> Result {
-        add_stream_to_connection_map(self);
         let _ = vmcall_raw_transport_init();
         VMCALL_MIG_CONTEXT_FLAGS
             .lock()
@@ -115,7 +97,6 @@ impl VmcallRaw {
     }
 
     async fn reset(&mut self) -> Result {
-        remove_stream_from_connection_map(self);
         VMCALL_MIG_CONTEXT_FLAGS
             .lock()
             .remove(&self.addr.transport_context());
@@ -125,10 +106,7 @@ impl VmcallRaw {
     async fn recv_packet_connected(&mut self) -> Result<()> {
         let recv = vmcall_raw_transport_dequeue(self).await?;
 
-        if recv.len() > 0 {
-            let mut recv = vmcall_raw_transport_dequeue(self).await?;
-
-            recv.truncate(recv.len() as usize);
+        if !recv.is_empty() {
             self.data_queue.push_back(recv);
         }
 

--- a/src/devices/vmcall_raw/src/transport/vmcall.rs
+++ b/src/devices/vmcall_raw/src/transport/vmcall.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use super::event::*;
-use crate::stream::{VmcallRaw, CONNECTION_PKT_QUEUES};
+use crate::stream::VmcallRaw;
 use crate::{align_up, VmcallRawError, PAGE_SIZE};
 use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
@@ -26,39 +26,6 @@ lazy_static! {
         Mutex::new(BTreeMap::new());
 }
 const TDX_VMCALL_VMM_SUCCESS: u8 = 1;
-
-fn push_stream_queues(stream: &VmcallRaw, buf: Vec<u8>) {
-    if buf.is_empty() {
-        return;
-    }
-
-    if let Some(stream_queue) = CONNECTION_PKT_QUEUES.lock().get_mut(&stream.addr) {
-        stream_queue.push_back(buf);
-    }
-}
-
-fn pop_stream_queues(stream: &VmcallRaw) -> Option<Vec<u8>> {
-    if let Some(stream_queue) = CONNECTION_PKT_QUEUES.lock().get_mut(&stream.addr) {
-        stream_queue.pop_front()
-    } else {
-        None
-    }
-}
-
-// Parse the packet data from the untrusted source.
-//
-// pkt = MigTD Communication Packet
-fn recv_packet(pkt: &[u8], pkt_len: usize, stream: &VmcallRaw) -> Result<(), ()> {
-    let data: Vec<u8> = pkt
-        .get(..pkt_len)
-        .expect("pkt_len exceeds buffer length")
-        .to_vec();
-
-    assert_eq!(data.len(), pkt_len);
-    push_stream_queues(stream, data);
-
-    Ok(())
-}
 
 pub fn vmcall_raw_transport_init() -> Result<(), VmcallRawError> {
     register_callback(VMCALL_VECTOR, vmcall_raw_intr_notification)?;
@@ -96,10 +63,6 @@ pub async fn vmcall_raw_transport_enqueue(
 }
 
 pub async fn vmcall_raw_transport_dequeue(stream: &VmcallRaw) -> Result<Vec<u8>, VmcallRawError> {
-    if let Some(data) = pop_stream_queues(stream) {
-        return Ok(data);
-    }
-
     let response_buffer_page_count = MAX_VMCALL_RAW_STREAM_MTU / PAGE_SIZE;
     let mut response_buffer =
         SharedMemory::new(response_buffer_page_count).ok_or(VmcallRawError::Illegal)?;
@@ -184,13 +147,12 @@ async fn vmcall_service_migtd_receive(
             return Poll::Pending;
         }
 
-        recv_packet(&response_buf, data_length as usize, stream)?;
+        let data = match response_buf.get(..data_length as usize) {
+            Some(slice) => slice.to_vec(),
+            None => return Poll::Ready(Err(VmcallRawError::TdVmcallErr)),
+        };
 
-        //push a placeholder vector to maintain return type of this function
-        let mut placeholder_stub: Vec<u8> = Vec::new();
-        placeholder_stub.push(1);
-
-        Poll::Ready(Some(placeholder_stub).ok_or(VmcallRawError::Illegal))
+        Poll::Ready(Ok(data))
     })
     .await
 }


### PR DESCRIPTION


The receive path used a unneeded two-step indirection: the first vmcall_raw_transport_dequeue issued a VMCALL, copied data from shared memory into CONNECTION_PKT_QUEUES via recv_packet(), and returned a placeholder vec. The second dequeue then popped the real data from the queue. This was probably copied design from another implementation with 'packet' based stream which is not applicable to vmcall-raw send/receive.

Simplify by having vmcall_service_migtd_receive return the actual data directly — it already copies from SharedMemory (untrusted, host-accessible) into a private Vec via .to_vec(), preserving the security boundary.

Remove dead code: push_stream_queues, pop_stream_queues, recv_packet, CONNECTION_PKT_QUEUES, add_stream_to_connection_map, remove_stream_from_connection_map, and related imports.