### PR TITLE
feat(vmcall_raw): handle VMM cancellation (0x302)

### DIFF
--- a/src/devices/vmcall_raw/src/lib.rs
+++ b/src/devices/vmcall_raw/src/lib.rs
@@ -50,6 +50,8 @@ pub enum VmcallRawError {
     NotReady,
     /// Tdvmcall error
     TdVmcallErr,
+    /// VMM canceled the migration session
+    VmmCanceled,
     /// Interrupt error
     Interrupt,
 }
@@ -68,6 +70,7 @@ impl Display for VmcallRawError {
             VmcallRawError::AddressAlreadyUsed => write!(f, "AddressAlreadyUsed"),
             VmcallRawError::NotReady => write!(f, "NotReady"),
             VmcallRawError::TdVmcallErr => write!(f, "TdVmcallErr"),
+            VmcallRawError::VmmCanceled => write!(f, "VmmCanceled"),
             VmcallRawError::Interrupt => write!(f, "Interrupt"),
         }
     }
@@ -83,7 +86,11 @@ impl error::Error for VmcallRawError {}
 
 impl From<VmcallRawError> for io::Error {
     fn from(e: VmcallRawError) -> Self {
-        io::Error::new(io::ErrorKind::Other, e)
+        let kind = match e {
+            VmcallRawError::VmmCanceled => io::ErrorKind::ConnectionAborted,
+            _ => io::ErrorKind::Other,
+        };
+        io::Error::new(kind, e)
     }
 }
 

--- a/src/devices/vmcall_raw/src/transport/vmcall.rs
+++ b/src/devices/vmcall_raw/src/transport/vmcall.rs
@@ -25,7 +25,9 @@ lazy_static! {
     pub static ref VMCALL_MIG_CONTEXT_FLAGS: Mutex<BTreeMap<u64, AtomicBool>> =
         Mutex::new(BTreeMap::new());
 }
-const TDX_VMCALL_VMM_SUCCESS: u8 = 1;
+const TDX_VMCALL_VMM_SUCCESS: u8 = 0x01;
+const TDX_VMCALL_STATUS_NOT_COMPLETED: u8 = 0x02;
+const TDX_VMCALL_STATUS_VMM_CANCEL: u8 = 0x03;
 
 fn push_stream_queues(stream: &VmcallRaw, buf: Vec<u8>) {
     if buf.is_empty() {
@@ -139,6 +141,16 @@ async fn vmcall_service_migtd_send(
         let data_status_bytes = data_status.to_le_bytes();
 
         if data_status_bytes[0] != TDX_VMCALL_VMM_SUCCESS {
+            if data_status_bytes[0] == TDX_VMCALL_STATUS_NOT_COMPLETED
+                && data_status_bytes[1] == TDX_VMCALL_STATUS_VMM_CANCEL
+            {
+                log::warn!(
+                    "VMM canceled migration session (migration_request_id={}, data_status=0x{:x})\n",
+                    mig_request_id,
+                    data_status
+                );
+                return Poll::Ready(Err(VmcallRawError::VmmCanceled));
+            }
             return Poll::Pending;
         }
 
@@ -181,6 +193,16 @@ async fn vmcall_service_migtd_receive(
         let data_status_bytes = data_status.to_le_bytes();
 
         if data_status_bytes[0] != TDX_VMCALL_VMM_SUCCESS {
+            if data_status_bytes[0] == TDX_VMCALL_STATUS_NOT_COMPLETED
+                && data_status_bytes[1] == TDX_VMCALL_STATUS_VMM_CANCEL
+            {
+                log::warn!(
+                    "VMM canceled migration session (migration_request_id={}, data_status=0x{:x})\n",
+                    mig_request_id,
+                    data_status
+                );
+                return Poll::Ready(Err(VmcallRawError::VmmCanceled));
+            }
             return Poll::Pending;
         }
 

--- a/src/migtd/src/migration/mod.rs
+++ b/src/migtd/src/migration/mod.rs
@@ -372,6 +372,7 @@ impl From<CryptoError> for MigrationResult {
 impl From<io::Error> for MigrationResult {
     fn from(e: io::Error) -> Self {
         match e.kind() {
+            io::ErrorKind::ConnectionAborted => MigrationResult::VmmCanceled,
             io::ErrorKind::InvalidData => {
                 let desc = e.to_string();
 

--- a/src/migtd/src/spdm/mod.rs
+++ b/src/migtd/src/spdm/mod.rs
@@ -57,7 +57,15 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SpdmDeviceIo for MigtdTransport<T
         while sent < buffer.len() {
             match self.transport.write(&buffer[sent..]).await {
                 Ok(len) => sent += len,
-                Err(_) => return Err(SPDM_STATUS_SEND_FAIL),
+                // ConnectionAborted maps from VmcallRawError::VmmCanceled.
+                // The SpdmDeviceIo trait cannot represent this error, so just
+                // log and return the generic SPDM_STATUS_SEND_FAIL.
+                Err(e) => {
+                    if e.kind() == rust_std_stub::io::ErrorKind::ConnectionAborted {
+                        log::warn!("VMM canceled migration session during SPDM send\n");
+                    }
+                    return Err(SPDM_STATUS_SEND_FAIL);
+                }
             }
         }
         Ok(())
@@ -79,7 +87,15 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SpdmDeviceIo for MigtdTransport<T
                 .transport
                 .read(&mut buffer[recvd..])
                 .await
-                .map_err(|_| 0_usize)?;
+                // ConnectionAborted maps from VmcallRawError::VmmCanceled.
+                // The SpdmDeviceIo trait cannot represent this error, so just
+                // log and return the generic receive error.
+                .map_err(|e| {
+                    if e.kind() == rust_std_stub::io::ErrorKind::ConnectionAborted {
+                        log::warn!("VMM canceled migration session during SPDM receive\n");
+                    }
+                    0_usize
+                })?;
             recvd += n;
         }
 
@@ -97,7 +113,12 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SpdmDeviceIo for MigtdTransport<T
                 .transport
                 .read(&mut buffer[recvd..])
                 .await
-                .map_err(|_| 0_usize)?;
+                .map_err(|e| {
+                    if e.kind() == rust_std_stub::io::ErrorKind::ConnectionAborted {
+                        log::warn!("VMM canceled migration session during SPDM receive\n");
+                    }
+                    0_usize
+                })?;
             recvd += n;
         }
 


### PR DESCRIPTION
The VMM signals migration session cancellation by writing data_status byte[0]=0x02, byte[1]=0x03 (0x302) to the shared buffer.

Previously, 0x302 was treated as a generic TdVmcallErr, reported as SecureSessionError (6), change to propagate and report it as VmmCanceled (10) in ReportStatus.

In the SPDM path, MigtdTransport's send/receive implement the SpdmDeviceIo trait which cannot represent this error in its return types (SpdmResult and Result<usize, usize>). Log a warning when ConnectionAborted is detected so the VMM cancellation is visible in logs, even though the typed error cannot propagate through the SPDM library's trait boundary.