### PR TITLE
fix(mig_policy): remove redundant error mapping for tdreport verifica…

### DIFF
--- a/src/migtd/src/mig_policy.rs
+++ b/src/migtd/src/mig_policy.rs
@@ -346,8 +346,7 @@ mod v2 {
         policy_issuer_chain: &[u8],
     ) -> Result<(PolicyEvaluationInfo, VerifiedPolicy<'p>, TdxReport), PolicyError> {
         // 1. Verify quote & get supplemental data
-        let tdreport_verified =
-            verify_tdreport(tdreport).map_err(|_| PolicyError::QuoteVerification)?;
+        let tdreport_verified = verify_tdreport(tdreport)?;
 
         // 2. Verify the signature of the provided policy and the integrity of the event log
         let verified_policy = verify_policy_and_event_log(


### PR DESCRIPTION
…tion

verify_tdreport() already returns PolicyError, so the .map_err() was converting a PolicyError into the same PolicyError unnecessarily.