### PR TITLE
rebinding: populate UTF-8 reason string on SPDM error paths

### DIFF
--- a/src/migtd/src/migration/rebinding.rs
+++ b/src/migtd/src/migration/rebinding.rs
@@ -177,13 +177,21 @@ pub async fn start_rebinding(
 pub async fn rebinding_old_prepare(
     transport: TransportType,
     info: &MigtdMigrationInformation,
-    _data: &mut Vec<u8>,
+    data: &mut Vec<u8>,
     #[cfg(feature = "policy_v2")] remote_policy: Vec<u8>,
 ) -> Result<(), MigrationResult> {
     use core::ops::DerefMut;
 
     const SPDM_TIMEOUT: Duration = Duration::from_secs(60); // 60 seconds
     let (mut spdm_requester, device_io_ref) = spdm::spdm_requester(transport).map_err(|_e| {
+        #[cfg(feature = "vmcall-raw")]
+        data.extend_from_slice(
+            &format!(
+                "Error: rebinding_old_prepare(): Failed in spdm_requester transport. Migration ID: {:x}\n",
+                info.mig_request_id,
+            )
+            .into_bytes(),
+        );
         log::error!(
             "rebinding: Failed in spdm_requester transport. Migration ID: {}\n",
             info.mig_request_id
@@ -201,6 +209,14 @@ pub async fn rebinding_old_prepare(
     )
     .await
     .map_err(|e| {
+        #[cfg(feature = "vmcall-raw")]
+        data.extend_from_slice(
+            &format!(
+                "Error: rebinding_old_prepare(): spdm_requester_rebind_old timed out ({:?}). Migration ID: {:x}\n",
+                e, info.mig_request_id,
+            )
+            .into_bytes(),
+        );
         log::error!(
             "rebinding: spdm_requester_rebind_old timeout error: {:?}\n",
             e
@@ -208,6 +224,14 @@ pub async fn rebinding_old_prepare(
         e
     })?
     .map_err(|e| {
+        #[cfg(feature = "vmcall-raw")]
+        data.extend_from_slice(
+            &format!(
+                "Error: rebinding_old_prepare(): spdm_requester_rebind_old failed ({:?}). Migration ID: {:x}\n",
+                e, info.mig_request_id,
+            )
+            .into_bytes(),
+        );
         log::error!("rebinding: spdm_requester_rebind_old error: {:?}\n", e);
         e
     })?;
@@ -223,13 +247,21 @@ pub async fn rebinding_old_prepare(
 pub async fn rebinding_new_prepare(
     transport: TransportType,
     info: &MigtdMigrationInformation,
-    _data: &mut Vec<u8>,
+    data: &mut Vec<u8>,
     #[cfg(feature = "policy_v2")] remote_policy: Vec<u8>,
 ) -> Result<(), MigrationResult> {
     use core::ops::DerefMut;
 
     const SPDM_TIMEOUT: Duration = Duration::from_secs(60); // 60 seconds
     let (mut spdm_responder, device_io_ref) = spdm::spdm_responder(transport).map_err(|_e| {
+        #[cfg(feature = "vmcall-raw")]
+        data.extend_from_slice(
+            &format!(
+                "Error: rebinding_new_prepare(): Failed in spdm_responder transport. Migration ID: {:x}\n",
+                info.mig_request_id,
+            )
+            .into_bytes(),
+        );
         log::error!(
             "rebinding: Failed in spdm_responder transport. Migration ID: {}\n",
             info.mig_request_id
@@ -248,6 +280,14 @@ pub async fn rebinding_new_prepare(
     )
     .await
     .map_err(|e| {
+        #[cfg(feature = "vmcall-raw")]
+        data.extend_from_slice(
+            &format!(
+                "Error: rebinding_new_prepare(): spdm_responder_rebind_new timed out ({:?}). Migration ID: {:x}\n",
+                e, info.mig_request_id,
+            )
+            .into_bytes(),
+        );
         log::error!(
             "rebinding: spdm_responder_rebind_new timeout error: {:?}\n",
             e
@@ -255,6 +295,14 @@ pub async fn rebinding_new_prepare(
         e
     })?
     .map_err(|e| {
+        #[cfg(feature = "vmcall-raw")]
+        data.extend_from_slice(
+            &format!(
+                "Error: rebinding_new_prepare(): spdm_responder_rebind_new failed ({:?}). Migration ID: {:x}\n",
+                e, info.mig_request_id,
+            )
+            .into_bytes(),
+        );
         log::error!("rebinding: spdm_responder_rebind_new error: {:?}\n", e);
         e
     })?;


### PR DESCRIPTION
## Summary

The non-SPDM `rebinding_old_prepare` / `rebinding_new_prepare` populate the VMM ReportStatus reason buffer (`data: &mut Vec<u8>`) on transport failures, gated by `#[cfg(feature = "vmcall-raw")]`. The SPDM-featured counterparts had the parameter spelled `_data` and never wrote to it, so GHCI 1.5 `ReportStatus` (p. 47–48, Tables 3-55/3-56) carried no diagnostic payload when an SPDM rebind failed.

## Change

Mirror the non-SPDM pattern at the three SPDM error sites in both `rebinding_old_prepare` and `rebinding_new_prepare`:

- `spdm_requester` / `spdm_responder` transport setup failure
- `with_timeout` timeout around `spdm_requester_rebind_old` / `spdm_responder_rebind_new`
- the SPDM rebind operation itself

Each `.map_err` closure now pushes a one-line UTF-8 reason string (operation name, `MigrationResult` variant, migration ID in hex) into `data`, gated by `#[cfg(feature = "vmcall-raw")]` to match the non-SPDM RA-TLS arms. `log::error!` calls are preserved verbatim.

No behavior change with `vmcall-raw` off — `data` is unused, same warning the existing non-SPDM functions already emit on that configuration.

## Test

```
cargo check -p migtd --no-default-features \
  --features main,stack-guard,spdm_attestation,virtio-vsock,policy_v2,test_disable_ra_and_accept_all \
  --target x86_64-unknown-none
cargo check -p migtd --no-default-features \
  --features main,stack-guard,virtio-vsock,policy_v2,test_disable_ra_and_accept_all \
  --target x86_64-unknown-none
```

Both clean. The `vmcall-raw` + `spdm_attestation` build has 3 pre-existing errors on `main` (`mig_socket_info` field, `setup_transport` arity) that are out of scope for this PR.

## Reference

GHCI 1.5 April 2026: Tables 3-55 / 3-56 — `ReportStatus` data buffer carries a UTF-8 reason string describing why a migration/rebind failed.