### PR TITLE
DRAFT: migtd: flip default transport feature from virtio-vsock to vmcall-raw

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -112,12 +112,17 @@ The pre-production attestation policy is:
    * The fmspc list is from https://sbx.api.trustedservices.intel.com/sgx/certification/v4/fmspcs with platform `E5`.
    * The TCB level can be get via `curl -v -X GET "https://sbx.api.trustedservices.intel.com/tdx/certification/v4/tcb?fmspc={}"`.
 
-To use virtio-serial instead of virtio-vsock for the guest-host communication:
+To use virtio-vsock for the guest-host communication (legacy GHCI 1.5 v5-era transport; uses the `<Service>` envelope wrapped over virtio-vsock):
+```
+cargo image --no-default-features --features stack-guard,virtio-vsock
+```
+
+To use virtio-serial instead of vmcall-raw for the guest-host communication:
 ```
 cargo image --no-default-features --features stack-guard,virtio-serial
 ```
 
-To use vmcall-raw for the guest-host communication:
+To use vmcall-raw for the guest-host communication (this is the default; v6-shaped per-leaf `<MigTD.*>` sub-functions per GHCI 1.5 Tables 3-42/3-45/3-52/3-59/3-62):
 ```
 cargo image --no-default-features --features stack-guard,vmcall-raw
 ```

--- a/src/migtd/Cargo.toml
+++ b/src/migtd/Cargo.toml
@@ -68,7 +68,7 @@ zeroize = { version = "1.5.0", features = ["zeroize_derive"]}
 ring = { version = "0.17.14" }
 
 [features]
-default = ["virtio-vsock"]
+default = ["vmcall-raw"]
 cet-shstk = ["td-payload/cet-shstk"]
 coverage = ["minicov"]
 main = ["attestation", "policy/log", "sha2"]

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -12,7 +12,7 @@ use std::{
 };
 use xshell::{cmd, Shell};
 
-const MIGTD_DEFAULT_FEATURES: &str = "stack-guard,virtio-vsock";
+const MIGTD_DEFAULT_FEATURES: &str = "stack-guard,vmcall-raw";
 const MIGTD_KVM_FEATURES: &str = MIGTD_DEFAULT_FEATURES;
 const DEFAULT_TDVF_IMAGE_NAME: &str = "migtd.bin";
 const DEFAULT_IGVM_IMAGE_NAME: &str = "migtd.igvm";
@@ -38,11 +38,11 @@ pub(crate) struct BuildArgs {
     /// Build artifacts in debug mode, without optimizations and with log messages
     #[clap(long)]
     debug: bool,
-    /// Disable the default features `stack-guard` and `virtio-vsock` of `migtd` crate
+    /// Disable the default features `stack-guard` and `vmcall-raw` of `migtd` crate
     #[clap(long)]
     no_default_features: bool,
     /// List of features of `migtd` crate to activate in addition to the default features,
-    /// separated by comma. By default, the `stack-guard` and `virtio-vsock` features are
+    /// separated by comma. By default, the `stack-guard` and `vmcall-raw` features are
     /// enabled
     #[clap(long)]
     features: Option<String>,


### PR DESCRIPTION
## Summary

Make `vmcall-raw` the default transport for the `migtd` crate and for the `cargo image` orchestrator. This is the GHCI 1.5 v6 (April 2026) shaped path that uses the per-leaf `<MigTD.*>` sub-functions (Tables 3-42/3-45/3-52/3-59/3-62), as opposed to the legacy v5-era `<Service>`-envelope path wrapped over virtio-vsock.

## Changes

- `src/migtd/Cargo.toml`: \`default = [\"virtio-vsock\"]\` → \`default = [\"vmcall-raw\"]\`
- `xtask/src/build.rs`: \`MIGTD_DEFAULT_FEATURES\` set to \`\"stack-guard,vmcall-raw\"\`; doc comments on \`--no-default-features\` and \`--features\` updated accordingly.
- `readme.md`: document `virtio-vsock` as an opt-in legacy alternative; mark `vmcall-raw` as the default in the corresponding \`cargo image\` example.

## Build verification

Both feature combinations still compile clean against \`x86_64-unknown-none\`:

\`\`\`
cargo check -p migtd --features main,test_disable_ra_and_accept_all
cargo check -p migtd --no-default-features --features main,stack-guard,virtio-vsock,test_disable_ra_and_accept_all
\`\`\`

## Not in this PR (intentionally out of scope, separate follow-up work)

- Deprecation/removal of the legacy virtio-vsock transport (vsock crate, fuzz targets, sh_script behavior).
- Runtime tutorial in `readme.md` for the vmcall-raw approach (the existing virtio-vsock walk-through still works under explicit \`--features virtio-vsock\`).
- CI matrix changes.