### PR TITLE
migtd: harden EnableLogArea handling (reserved validation + gated set_max_level)

### DIFF
--- a/src/migtd/src/bin/migtd/cvmemu.rs
+++ b/src/migtd/src/bin/migtd/cvmemu.rs
@@ -14,9 +14,7 @@ use alloc::vec::Vec;
 use migtd;
 use migtd::driver::vmcall_raw::panic_with_guest_crash_reg_report;
 use migtd::migration::event;
-use migtd::migration::logging::{
-    create_logarea, enable_logarea, init_vmm_logger, u8_to_levelfilter,
-};
+use migtd::migration::logging::{create_logarea, enable_logarea, init_vmm_logger};
 use migtd::migration::session::{exchange_msk, report_status};
 use migtd::migration::MigrationResult;
 
@@ -479,12 +477,6 @@ fn handle_pre_mig_emu() -> i32 {
                             .await
                             .map(|_| MigrationResult::Success)
                             .unwrap_or_else(|e| e);
-
-                            log::info!(migration_request_id = wfr_info.mig_request_id;
-                                "Setting log level to {}\n",
-                                wfr_info.log_max_level
-                            );
-                            log::set_max_level(u8_to_levelfilter(wfr_info.log_max_level));
 
                             if status == MigrationResult::Success {
                                 log::trace!(migration_request_id = wfr_info.mig_request_id; "Successfully completed Enable LogArea\n");

--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -573,12 +573,6 @@ fn handle_pre_mig() {
                             .map(|_| MigrationResult::Success)
                             .unwrap_or_else(|e| e);
 
-                            log::info!( migration_request_id = wfr_info.mig_request_id;
-                                "Setting log level to {}\n",
-                                wfr_info.log_max_level
-                            );
-                            log::set_max_level(u8_to_levelfilter(wfr_info.log_max_level));
-
                             if status == MigrationResult::Success {
                                 log::trace!(migration_request_id = wfr_info.mig_request_id; "Successfully completed Enable LogArea\n");
                             } else {

--- a/src/migtd/src/migration/logging.rs
+++ b/src/migtd/src/migration/logging.rs
@@ -307,6 +307,9 @@ pub async fn enable_logarea(log_max_level: u8, request_id: u64, data: &mut Vec<u
         LOGGING_INFORMATION
             .logarea_initialized
             .store(true, Ordering::SeqCst);
+        // Keep the crate-global log gate in sync with the per-MigTD gate so
+        // both filters agree; only done on the validated success path.
+        log::set_max_level(u8_to_levelfilter(log_max_level));
         #[cfg(not(test))]
         log::info!( migration_request_id = request_id;
             "enable_logarea: Logging has been enabled with MaxLevel: {}\n",
@@ -316,7 +319,7 @@ pub async fn enable_logarea(log_max_level: u8, request_id: u64, data: &mut Vec<u
         Ok(())
     } else {
         log::error!( migration_request_id = request_id;
-            "enable_logarea: Logging has been enabled with MaxLevel: {}\n",
+            "enable_logarea: rejected request with invalid MaxLogLevel: {}\n",
             log_max_level
         );
         data.extend_from_slice(

--- a/src/migtd/src/migration/mod.rs
+++ b/src/migtd/src/migration/mod.rs
@@ -29,29 +29,6 @@ use r_efi::efi::Guid;
 use rust_std_stub::io;
 use scroll::{Pread, Pwrite};
 
-/// Implement `read_from_bytes(data_length, payload)` for a fixed-size
-/// `#[derive(Pread)]` struct. Validates `data_length == size_of::<Self>()`
-/// and rejects payloads with trailing bytes.
-#[cfg(feature = "vmcall-raw")]
-macro_rules! impl_read_from_bytes {
-    ($t:ty) => {
-        #[cfg(feature = "vmcall-raw")]
-        impl $t {
-            pub fn read_from_bytes(
-                data_length: u32,
-                payload: &[u8],
-            ) -> core::result::Result<Self, MigrationResult> {
-                if data_length != core::mem::size_of::<Self>() as u32 {
-                    return Err(MigrationResult::InvalidParameter);
-                }
-                payload
-                    .pread(0)
-                    .map_err(|_| MigrationResult::InvalidParameter)
-            }
-        }
-    };
-}
-
 /// Implement `read_from_bytes(data_length, payload)` for a struct whose layout
 /// starts with `mig_request_id: u64` followed by optional data bytes.
 /// Accepts either the full struct or just the `mig_request_id` (with the
@@ -239,7 +216,24 @@ pub struct EnableLogAreaInfo {
 }
 
 #[cfg(feature = "vmcall-raw")]
-impl_read_from_bytes!(EnableLogAreaInfo);
+impl EnableLogAreaInfo {
+    pub fn read_from_bytes(
+        data_length: u32,
+        payload: &[u8],
+    ) -> core::result::Result<Self, MigrationResult> {
+        if data_length != core::mem::size_of::<Self>() as u32 {
+            return Err(MigrationResult::InvalidParameter);
+        }
+        let info: Self = payload
+            .pread(0)
+            .map_err(|_| MigrationResult::InvalidParameter)?;
+        // GHCI 1.5 v6 Table 3-50: reserved bytes MUST be zero.
+        if info.reserved.iter().any(|&b| b != 0) {
+            return Err(MigrationResult::InvalidParameter);
+        }
+        Ok(info)
+    }
+}
 
 #[repr(C)]
 #[derive(Debug, Pread, Pwrite)]


### PR DESCRIPTION
## Summary

Hardens the GHCI 1.5 v6 `EnableLogArea` (operation `4`) request path. Three correctness issues are addressed in a single PR.
Closes #664 

## Spec reference

GHCI 1.5 v6 Table 3-50 defines the `EnableLogArea` request payload as a 16-byte struct:

| Offset | Length | Field |
|--------|--------|-------|
| 0 | 8 | `mig_request_id` |
| 8 | 1 | `log_max_level` |
| 9 | 7 | reserved (**must be 0**) |

`log_max_level` must be one of `1=Error`, `2=Warn`, `3=Info`, `4=Debug`, `5=Trace`. The VMM is the producer; MigTD must validate and propagate.

## Issues fixed

1. **`log::set_max_level` was called unconditionally** in both transport handlers (`src/migtd/src/bin/migtd/main.rs` and `src/migtd/src/bin/migtd/cvmemu.rs`), even when `enable_logarea()` had rejected the request with `InvalidParameter`. A malformed VMM request (e.g. `log_max_level = 0xFF`) would leave `LOGGING_INFORMATION.maxloglevel` at `0` (Off) — the structured-log gate — but still flip the crate-global `log::max_level()` to `Trace` via the `5 | _` arm of `u8_to_levelfilter`. The two filters disagreed.

2. **`EnableLogAreaInfo.reserved[7]` was never validated.** PR #882 added "reserved must be zero" checks for the Prepare Migration / Prepare Rebinding payloads; the same hardening was missing for op 4 (`EnableLogArea`).

3. **The error-path log message in `enable_logarea()` incorrectly reused the success message text** (`"Logging has been enabled with MaxLevel: …"`) even when rejecting an invalid level.

## Fixes

- **`src/migtd/src/migration/mod.rs`** — Replace `impl_read_from_bytes!(EnableLogAreaInfo)` with a custom `read_from_bytes` that rejects non-zero reserved bytes with `MigrationResult::InvalidParameter` (matching the PR #882 pattern). The now-unused `impl_read_from_bytes!` macro is removed.
- **`src/migtd/src/migration/logging.rs`** — Move the `log::set_max_level(u8_to_levelfilter(log_max_level))` call inside `enable_logarea()` so it only runs on the validated success path, after the `u8_to_loglevel` check. The crate-global gate now always matches the per-MigTD `LOGGING_INFORMATION.maxloglevel`. Correct the error-path log message to say `"rejected request with invalid MaxLogLevel"`.
- **`src/migtd/src/bin/migtd/main.rs`** and **`src/migtd/src/bin/migtd/cvmemu.rs`** — Drop the duplicated `log::set_max_level` and the preceding `"Setting log level to …"` `info!` from both handlers (now handled inside `enable_logarea`). Drop the now-unused `u8_to_levelfilter` import from `cvmemu.rs`.

## Tests

```
cargo test -p migtd --lib --features vmcall-raw
…
test result: ok. 15 passed; 0 failed; 0 ignored
```

All 11 pre-existing `migration::logging::test::*` cases pass, including `test_enable_logarea` which exercises both the failure-before-create_logarea path and the success path.