### PR TITLE
fix(Cargo.lock): resolve GHSA-phqj-4mhp-q6mq

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1582,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "openssl"
-version = "0.10.79"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
  "bitflags 2.11.0",
  "cfg-if",
@@ -1616,9 +1616,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.115"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -2297,6 +2297,7 @@ dependencies = [
  "rustls-webpki",
  "serde",
  "serde_json",
+ "spin 0.10.0",
  "spin 0.9.8",
  "sys_time 0.1.0",
  "untrusted",
@@ -2326,6 +2327,12 @@ checksum = "d5fe4ccb98d9c292d56fec89a5e07da7fc4cf0dc11e156b41793132775d3e591"
 dependencies = [
  "lock_api",
 ]
+
+[[package]]
+name = "spin"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1527984ca054dfca79333baec451042863f485fbee01b7bf6d911de915cac865"
 
 [[package]]
 name = "spinning_top"
@@ -2643,7 +2650,7 @@ dependencies = [
  "lazy_static",
  "log",
  "sha2 0.11.0",
- "spin 0.10.0",
+ "spin 0.12.0",
  "tdx-mock-data",
  "tdx-tdcall",
  "tokio",


### PR DESCRIPTION
Upgrades openssl to 0.10.80 to resolve GHSA-phqj-4mhp-q6mq