### PR TITLE
SPDM improvements

### DIFF
--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -962,7 +962,7 @@ async fn migration_src_exchange_msk(
     })?
     .map_err(|e| {
         log::error!("exchange_msk: spdm_requester_transfer_msk error: {:?}\n", e);
-        e
+        spdm::decode_spdm_session_err(e)
     })?;
     log::info!("MSK exchange completed\n");
 
@@ -1008,7 +1008,7 @@ async fn migration_dst_exchange_msk(
     })?
     .map_err(|e| {
         log::error!("exchange_msk: spdm_responder_transfer_msk error: {:?}\n", e);
-        e
+        spdm::decode_spdm_session_err(e)
     })?;
     log::info!("MSK exchange completed\n");
 

--- a/src/migtd/src/spdm/mod.rs
+++ b/src/migtd/src/spdm/mod.rs
@@ -386,3 +386,30 @@ impl From<MigrationResult> for SpdmStatus {
         }
     }
 }
+
+/// Decode an SpdmStatus returned by an SPDM session body into a
+/// MigrationResult, preserving application-level errors carried over the wire
+/// as `SpdmErrorVendorDefined`.
+///
+/// On the destination (local responder failure) the application code is
+/// already encoded as `StatusCode::VDM` and decoded by the existing
+/// `From<SpdmStatus>` impl. On the source (requester receiving a peer ERROR
+/// response) the code arrives in `error_data` as Param2 of the SPDM ERROR
+/// message; that path is not covered by `From<SpdmStatus>` so we extract it
+/// here.
+pub(crate) fn decode_spdm_session_err(e: SpdmStatus) -> MigrationResult {
+    let local = MigrationResult::from(e);
+    if local != MigrationResult::SecureSessionError {
+        return local;
+    }
+    if let Some(ref ed) = e.error_data {
+        if ed.length >= 4
+            && ed.data[2] == spdmlib::message::SpdmErrorCode::SpdmErrorVendorDefined.get_u8()
+        {
+            if let Ok(decoded) = MigrationResult::try_from(ed.data[3]) {
+                return decoded;
+            }
+        }
+    }
+    MigrationResult::SecureSessionError
+}

--- a/src/migtd/src/spdm/spdm_rebind.rs
+++ b/src/migtd/src/spdm/spdm_rebind.rs
@@ -27,6 +27,22 @@ pub async fn spdm_requester_rebind_old(
     rebind_info: &MigtdMigrationInformation,
     remote_policy: Vec<u8>,
 ) -> Result<(), SpdmStatus> {
+    // `send_and_receive_pub_key` (called below) encodes the requester's
+    // ephemeral ECDSA private key into
+    // `spdm_requester.common.app_context_data_buffer` so libspdm's
+    // asymmetric signing callback can read it. That buffer is a plain
+    // `[u8; SIZE]` with no automatic cleanup, so wipe it on every return
+    // path here.
+    let result = spdm_requester_rebind_old_inner(spdm_requester, rebind_info, remote_policy).await;
+    spdm_requester.common.app_context_data_buffer.zeroize();
+    result
+}
+
+async fn spdm_requester_rebind_old_inner(
+    spdm_requester: &mut RequesterContext,
+    rebind_info: &MigtdMigrationInformation,
+    remote_policy: Vec<u8>,
+) -> Result<(), SpdmStatus> {
     Box::pin(spdm_requester.send_receive_spdm_version()).await?;
     Box::pin(spdm_requester.send_receive_spdm_capability()).await?;
     Box::pin(spdm_requester.send_receive_spdm_algorithm()).await?;

--- a/src/migtd/src/spdm/spdm_req.rs
+++ b/src/migtd/src/spdm/spdm_req.rs
@@ -745,7 +745,7 @@ async fn send_and_receive_sdm_exchange_migration_info(
     vendor_id[..VDM_MESSAGE_VENDOR_ID_LEN].copy_from_slice(&VDM_MESSAGE_VENDOR_ID);
     let vendor_id = VendorIDStruct { len: 4, vendor_id };
 
-    let exchange_information = exchange_info(mig_info, false)?;
+    let exchange_information = exchange_info(mig_info, true)?;
 
     let mut payload = vec![0u8; MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE];
     let mut writer = Writer::init(&mut payload);
@@ -907,7 +907,7 @@ async fn send_and_receive_sdm_exchange_migration_info(
         },
     };
 
-    let mig_ver = cal_mig_version(false, &exchange_information, &remote_information)?;
+    let mig_ver = cal_mig_version(true, &exchange_information, &remote_information)?;
     set_mig_version(mig_info, mig_ver)?;
     write_msk(mig_info, &remote_information.key)?;
     log::info!("Set MSK and report status\n");

--- a/src/migtd/src/spdm/spdm_req.rs
+++ b/src/migtd/src/spdm/spdm_req.rs
@@ -26,6 +26,7 @@ use spdmlib::{
     requester::RequesterContext,
 };
 use spin::Mutex;
+use zeroize::Zeroize;
 extern crate alloc;
 use crate::{
     config::get_policy, event_log::get_event_log, migration::session::ExchangeInformation,
@@ -87,6 +88,27 @@ pub fn spdm_requester<T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static>
 }
 
 pub async fn spdm_requester_transfer_msk(
+    spdm_requester: &mut RequesterContext,
+    mig_info: &MigtdMigrationInformation,
+    #[cfg(feature = "policy_v2")] remote_policy: Vec<u8>,
+) -> Result<(), SpdmStatus> {
+    // `send_and_receive_pub_key` encodes the requester's ephemeral ECDSA
+    // private key into `spdm_requester.common.app_context_data_buffer` so
+    // libspdm's asymmetric signing callback can read it. The libspdm
+    // `SpdmContext` provides no automatic cleanup for that buffer (it is a
+    // plain `[u8; SIZE]`), so wipe it on every return path here.
+    let result = spdm_requester_transfer_msk_inner(
+        spdm_requester,
+        mig_info,
+        #[cfg(feature = "policy_v2")]
+        remote_policy,
+    )
+    .await;
+    spdm_requester.common.app_context_data_buffer.zeroize();
+    result
+}
+
+async fn spdm_requester_transfer_msk_inner(
     spdm_requester: &mut RequesterContext,
     mig_info: &MigtdMigrationInformation,
     #[cfg(feature = "policy_v2")] remote_policy: Vec<u8>,

--- a/src/migtd/src/spdm/spdm_req.rs
+++ b/src/migtd/src/spdm/spdm_req.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 use crate::mig_policy;
+use crate::migration::MigrationResult;
 use crate::{
     migration::{
         data::MigrationSessionKey,
@@ -710,7 +711,7 @@ fn verify_peer_attestation_v2(
                 .get_session_via_id(session_id)
                 .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
             session.teardown();
-            return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+            return Err(SpdmStatus::from(MigrationResult::PolicyUnsatisfiedError));
         }
 
         // 3. Verify REPORTDATA binding using supplemental data from authenticate_remote
@@ -728,7 +729,7 @@ fn verify_peer_attestation_v2(
                     .get_session_via_id(session_id)
                     .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
                 session.teardown();
-                return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+                return Err(SpdmStatus::from(MigrationResult::MutualAttestationError));
             }
         }
     }
@@ -1196,7 +1197,7 @@ pub async fn send_and_receive_sdm_rebind_attest_info(
                 .get_session_via_id(session_id)
                 .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
             session.teardown();
-            return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+            return Err(SpdmStatus::from(MigrationResult::PolicyUnsatisfiedError));
         }
 
         // Verify that the peer's REPORTDATA is bound to this SPDM session's TH1
@@ -1208,7 +1209,7 @@ pub async fn send_and_receive_sdm_rebind_attest_info(
                 .get_session_via_id(session_id)
                 .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
             session.teardown();
-            return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+            return Err(SpdmStatus::from(MigrationResult::MutualAttestationError));
         }
     }
 

--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -9,6 +9,7 @@ use crate::migration::rebinding::{write_rebinding_session_token, write_servtd_re
 use crate::migration::servtd_ext::verify_servtd_attr;
 #[cfg(feature = "policy_v2")]
 use crate::migration::servtd_ext::{verify_servtd_attr, write_approved_servtd_ext_hash, ServtdExt};
+use crate::migration::MigrationResult;
 use crate::{
     config::get_policy,
     event_log::get_event_log,
@@ -735,7 +736,7 @@ fn rsp_verify_peer_attestation_v2(
                     .get_session_via_id(session_id)
                     .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
                 session.teardown();
-                return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+                return Err(SpdmStatus::from(MigrationResult::PolicyUnsatisfiedError));
             }
             Ok(s) => s,
         };
@@ -754,7 +755,7 @@ fn rsp_verify_peer_attestation_v2(
                     .get_session_via_id(session_id)
                     .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
                 session.teardown();
-                return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+                return Err(SpdmStatus::from(MigrationResult::MutualAttestationError));
             }
         }
 
@@ -1160,7 +1161,7 @@ pub fn handle_exchange_rebind_attest_info_req(
                 .get_session_via_id(session_id)
                 .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
             session.teardown();
-            return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+            return Err(SpdmStatus::from(MigrationResult::PolicyUnsatisfiedError));
         }
 
         // Verify that the peer's REPORTDATA is bound to this SPDM session's TH1
@@ -1172,7 +1173,7 @@ pub fn handle_exchange_rebind_attest_info_req(
                 .get_session_via_id(session_id)
                 .ok_or(SPDM_STATUS_INVALID_STATE_LOCAL)?;
             session.teardown();
-            return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+            return Err(SpdmStatus::from(MigrationResult::MutualAttestationError));
         }
     }
 

--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -71,7 +71,6 @@ impl ResponderContextEx<'_> {
     }
 }
 
-#[cfg(feature = "policy_v2")]
 pub unsafe fn upcast_mut(inner: &mut ResponderContext) -> &mut ResponderContextEx {
     let ptr = inner as *mut ResponderContext as *mut u8;
     let outer_ptr = ptr.sub(0) as *mut ResponderContextEx;
@@ -357,6 +356,16 @@ pub fn handle_exchange_mig_attest_info_req(
     reader: &mut Reader<'_>,
     vendor_defined_rsp_payload: &mut [u8],
 ) -> SpdmResult<usize> {
+    // Migration attestation messages must be handled only when migration info is set.
+    let spdm_responder_ex = unsafe { upcast_mut(responder_context) };
+    if !matches!(
+        &spdm_responder_ex.info,
+        ResponderContextExInfo::MigrationInformation(_)
+    ) {
+        error!("Migration info is not set in responder context.\n");
+        return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+    }
+
     let session_id = if session_id.is_some() {
         session_id
     } else {

--- a/src/migtd/src/spdm/spdm_vdm.rs
+++ b/src/migtd/src/spdm/spdm_vdm.rs
@@ -489,12 +489,19 @@ pub fn migtd_vdm_msg_rsp_dispatcher_ex<'a>(
     if let Ok(vdm_payload_size) = vdm_payload_size {
         vdm_rsp_payload.rsp_length = vdm_payload_size as u32;
     } else {
-        responder_context.write_spdm_error(SpdmErrorCode::SpdmErrorUnspecified, 0, &mut writer);
-        let used = writer.used();
-        return (
-            Err(vdm_payload_size.err().unwrap()),
-            Some(&rsp_bytes[..used]),
+        let err = vdm_payload_size.err().unwrap();
+        let app_error = if let StatusCode::VDM(vdm) = err.status_code {
+            vdm.vdm_error_code as u8
+        } else {
+            0
+        };
+        responder_context.write_spdm_error(
+            SpdmErrorCode::SpdmErrorVendorDefined,
+            app_error,
+            &mut writer,
         );
+        let used = writer.used();
+        return (Err(err), Some(&rsp_bytes[..used]));
     };
 
     let res = response_header.encode(&mut writer);


### PR DESCRIPTION
 Four small, independent SPDM-side security fixes for migration / rebinding flows.

  Changes

   - Reject ExchangeMigrationAttestInfo VDM unless the responder's ResponderContextExInfo is MigrationInformation(_). Without this guard a peer could drive migration attestation through a rebinding or default context with stale mig_info, breaking the binding between SPDM session and the intended migration. Mirrors the existing guard in handle_exchange_rebind_attest_info_req.
   - Zeroize the requester's app_context_data_buffer on every return path of spdm_requester_transfer_msk and spdm_requester_rebind_old. The buffer holds the per-session ephemeral ECDSA-P384 private key used by libspdm's asym_sign callback â and whose verifier key is attested via TH1 in the TDX quote â and otherwise persisted in TD memory after the function returned.
   - Use source-side semantics in source-only call sites by passing is_src=true to send_and_receive_sdm_exchange_migration_info and cal_mig_version. Restores correct version negotiation and exchange-info layout.
   - Propagate policy errors via VDM error encoding: the responder now encodes policy-failure reasons in a VendorDefined payload, and the requester decodes them via a new decode_spdm_session_err helper so callers receive a meaningful MigrationResult instead of a generic SPDM status.
