### PR TITLE
feat(migtd): route warn/error/fatal logs to COM1 serial port

### DIFF
--- a/src/migtd/src/driver/vmcall_raw.rs
+++ b/src/migtd/src/driver/vmcall_raw.rs
@@ -16,8 +16,6 @@ pub fn vmcall_raw_device_init() {
 
 #[track_caller]
 pub fn panic_with_guest_crash_reg_report(errorcode: u64, msg: &[u8]) -> ! {
-    #[cfg(not(feature = "vmcall-raw"))]
-    let _ = errorcode;
     let location = core::panic::Location::caller();
     let file = location.file();
     let line = location.line();
@@ -26,6 +24,16 @@ pub fn panic_with_guest_crash_reg_report(errorcode: u64, msg: &[u8]) -> ! {
     } else {
         " non-UTF8 message".to_string()
     };
+
+    // Always surface the fatal condition on the serial port via td-logger,
+    // independent of any surrounding logging that the caller may have done.
+    log::error!(
+        "MigTD fatal (code=0x{:x}): {} at {}:{}\n",
+        errorcode,
+        panic_message,
+        file,
+        line
+    );
 
     #[cfg(feature = "vmcall-raw")]
     {


### PR DESCRIPTION
MigTD debugging has historically required ad-hoc TDVMCALL.IO writes inserted by hand, because failure paths often did not call any of the log::* macros and there was no guarantee that fatal exits reached the host console.

td-logger is already initialised with LevelFilter::Trace and, with the tdx feature, writes each byte to COM1 (0x3F8) via TDVMCALL.IO, which QEMU forwards through -serial mon:stdio. This change makes that serial path the canonical debugging channel:

Add release_max_level_info to the log dependency so release builds compile out debug!/trace! while keeping info!, warn! and error! on the serial line. No VMM changes, no shared buffer and no extra TDVMCALL are required.
Emit log::error! from panic_with_guest_crash_reg_report with the error code, message and caller file:line so every fatal exit is visible on the serial port even when the surrounding code forgot to log.
Fixes #430 

Reopen #838 