### PR TITLE
fix(migtd): propagate policy errors in SPDM rebinding path

### DIFF
--- a/src/migtd/src/migration/rebinding.rs
+++ b/src/migtd/src/migration/rebinding.rs
@@ -237,7 +237,7 @@ pub async fn rebinding_old_prepare(
             .into_bytes(),
         );
         log::error!("rebinding: spdm_requester_rebind_old error: {:?}\n", e);
-        e
+        spdm::decode_spdm_session_err(e)
     })?;
     log::info!("Rebind completed\n");
 
@@ -308,7 +308,7 @@ pub async fn rebinding_new_prepare(
             .into_bytes(),
         );
         log::error!("rebinding: spdm_responder_rebind_new error: {:?}\n", e);
-        e
+        spdm::decode_spdm_session_err(e)
     })?;
     log::info!("Rebind completed\n");
 


### PR DESCRIPTION
Use decode_spdm_session_err() in rebinding_old_prepare and rebinding_new_prepare so vendor-defined SPDM errors reach ReportStatus.