### PR TITLE
test(migtd): add regression test for ExchangeInformation wire layout

### DIFF
--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -1399,6 +1399,26 @@ mod test {
         assert!(matches!(result, Ok(6)));
     }
 
+    // `ExchangeInformation` is written to the migration peer byte-for-byte via
+    // `as_bytes()`. The four bytes after `max_ver` were implicit trailing
+    // padding that the serializer copied to the peer uninitialized; they are
+    // now a zero-initialized `reserved` field, so the wire form is fully
+    // defined with no leaked bytes.
+    #[cfg(not(feature = "spdm_attestation"))]
+    #[test]
+    fn exchange_information_serializes_without_uninitialized_padding() {
+        assert_eq!(core::mem::size_of::<ExchangeInformation>(), 40);
+        let mut info = ExchangeInformation::default();
+        info.min_ver = 0x0102;
+        info.max_ver = 0x0304;
+        info.key.fields = [0xAAu64; 4];
+        let bytes = info.as_bytes();
+        assert_eq!(bytes.len(), 40);
+        // key 0..32, min_ver 32..34, max_ver 34..36, reserved 36..40: the
+        // trailing four bytes are now always zero rather than leaked memory.
+        assert_eq!(&bytes[36..40], &[0u8; 4]);
+    }
+
     // ---- parse_request-level tests: simulate host data buffers ----
 
     #[cfg(feature = "vmcall-raw")]


### PR DESCRIPTION
This originally fixed ExchangeInformation serializing four bytes of uninitialized trailing padding to the migration peer (no repr(C), implicit padding after max_ver copied out by as_bytes()). The same fix landed on main in 4f33b65 (repr(C) plus an explicit zeroed reserved field), so after rebasing only the regression test is left: it asserts the struct stays 40 bytes and that the reserved bytes serialize as zero, catching any future layout or field-order change that would reintroduce implicit padding.