### PR TITLE
fix(migtd): store digests as tagged event bodies

### DIFF
--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -240,7 +240,20 @@ fn get_policy_and_measure(event_log: &mut [u8]) {
         }
     };
 
-    let event_data = policy;
+    // Store only the policy digest as the tagged event body; RTMR is still
+    // extended with the full policy bytes above via `hash_data`. Keeps the
+    // RA-TLS cert (which embeds the event log) under rustls' 64 KiB
+    // MAX_HANDSHAKE_SIZE regardless of policy growth.
+    let event_data = match event_log::calculate_digest(policy) {
+        Ok(d) => d,
+        Err(e) => {
+            log::error!("Failed to digest migration policy: {:?}\n", e);
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InitializationError as u64,
+                b"Failed to digest migration policy",
+            );
+        }
+    };
 
     // Measure and extend the migration policy to RTMR
     let _ = event_log::write_tagged_event_log(
@@ -248,7 +261,7 @@ fn get_policy_and_measure(event_log: &mut [u8]) {
         MR_INDEX_POLICY,
         policy,
         TAGGED_EVENT_ID_POLICY,
-        event_data,
+        &event_data,
     )
     .map_err(|e| {
         log::error!("Failed to log migration policy: {:?}\n", e);
@@ -323,13 +336,26 @@ fn get_policy_issuer_chain_and_measure(event_log: &mut [u8]) {
         }
     };
 
+    // Store only the chain digest as the tagged event body; see comment in
+    // get_policy_and_measure.
+    let event_data = match event_log::calculate_digest(policy_issuer_chain) {
+        Ok(d) => d,
+        Err(e) => {
+            log::error!("Failed to digest policy issuer chain: {:?}\n", e);
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InitializationError as u64,
+                b"Failed to digest policy issuer chain",
+            );
+        }
+    };
+
     // Measure and extend the policy issuer chain to RTMR
     let _ = event_log::write_tagged_event_log(
         event_log,
         MR_INDEX_POLICY_ISSUER_CHAIN,
         policy_issuer_chain,
         TAGGED_EVENT_ID_POLICY_ISSUER_CHAIN,
-        policy_issuer_chain,
+        &event_data,
     )
     .map_err(|e| {
         log::error!("Failed to log policy issuer chain: {:?}\n", e);
@@ -353,13 +379,26 @@ fn get_ca_and_measure(event_log: &mut [u8]) {
         }
     };
 
+    // Store only the CA digest as the tagged event body; see comment in
+    // get_policy_and_measure.
+    let event_data = match event_log::calculate_digest(root_ca) {
+        Ok(d) => d,
+        Err(e) => {
+            log::error!("Failed to digest SGX root CA: {:?}\n", e);
+            panic_with_guest_crash_reg_report(
+                MigrationResult::InitializationError as u64,
+                b"Failed to digest SGX root CA",
+            );
+        }
+    };
+
     // Measure and extend the root certificate to RTMR
     let _ = event_log::write_tagged_event_log(
         event_log,
         MR_INDEX_ROOT_CA,
         root_ca,
         TAGGED_EVENT_ID_ROOT_CA,
-        root_ca,
+        &event_data,
     )
     .map_err(|e| {
         log::error!("Failed to log SGX root CA: {:?}\n", e);


### PR DESCRIPTION
Resolves #922

The RA-TLS certificate embeds the full cc-measurement event log via the EXTNID_MIGTD_EVENT_LOG extension. In the v1 (non-policy_v2) path, the event log entries for the migration policy and SGX root CA carried the raw artifact bytes as their tagged event body, so growing the pre-production policy JSON from ~48 KiB to ~59 KiB pushed the reassembled handshake Certificate message past rustls' MAX_HANDSHAKE_SIZE cap (0xffff, 65535 B), surfacing as a TlsStream error during the RA-TLS handshake over virtio-vsock.

Store only a 48-byte SHA-384 digest of the artifact as the tagged event body in:

  * v1 get_policy_and_measure       (migration policy)
  * v1 get_ca_and_measure           (SGX root CA)
  * v2 get_policy_issuer_chain_and_measure (issuer chain)

RTMR values are unchanged because write_tagged_event_log still receives the full artifact via hash_data. verify_event_log only replays event header digests, and parse_events discards the tag body for these event IDs, so verifier compatibility is preserved. The RA-TLS certificate size is now decoupled from policy size and stays well under the rustls handshake cap regardless of future policy growth.