### PR TITLE
fix(migtd): address implementation bugs from security audit

### DIFF
--- a/src/attestation/src/attest.rs
+++ b/src/attestation/src/attest.rs
@@ -102,6 +102,9 @@ pub fn attest_init_heap() -> Option<usize> {
     unsafe {
         let heap_base =
             alloc::alloc::alloc_zeroed(Layout::from_size_align(ATTEST_HEAP_SIZE, 0x1000).ok()?);
+        if heap_base.is_null() {
+            return None;
+        }
 
         init_heap(heap_base as *mut c_void, ATTEST_HEAP_SIZE as u32);
     }
@@ -124,10 +127,18 @@ pub fn get_quote(td_report: &[u8]) -> Result<Vec<u8>, Error> {
     {
         let mut quote = vec![0u8; TD_QUOTE_SIZE];
         let mut quote_size = TD_QUOTE_SIZE as u32;
+        if td_report.len() != TD_REPORT_SIZE {
+            log::error!(
+                "get_quote: td_report.len()={} != TD_REPORT_SIZE={}\n",
+                td_report.len(),
+                TD_REPORT_SIZE
+            );
+            return Err(Error::GetQuote);
+        }
         unsafe {
             let result = get_quote_inner(
                 td_report.as_ptr() as *const c_void,
-                TD_REPORT_SIZE as u32,
+                td_report.len() as u32,
                 quote.as_mut_ptr() as *mut c_void,
                 &mut quote_size as *mut u32,
             );
@@ -150,7 +161,10 @@ pub fn verify_quote(quote: &[u8]) -> Result<Vec<u8>, Error> {
 
     // Safety:
     // ROOT_CA must have been set and checked at this moment.
-    let public_key = ROOT_CA_PUBLIC_KEY.get().unwrap().as_slice();
+    let public_key = ROOT_CA_PUBLIC_KEY
+        .get()
+        .ok_or(Error::InvalidRootCa)?
+        .as_slice();
 
     unsafe {
         let result = verify_quote_integrity(
@@ -190,7 +204,10 @@ pub fn verify_quote_with_collaterals(
 
     // Safety:
     // ROOT_CA must have been set and checked at this moment.
-    let public_key = ROOT_CA_PUBLIC_KEY.get().unwrap().as_slice();
+    let public_key = ROOT_CA_PUBLIC_KEY
+        .get()
+        .ok_or(Error::InvalidRootCa)?
+        .as_slice();
 
     let qve_collateral: QveCollateral = (&collateral).into();
     unsafe {
@@ -210,6 +227,15 @@ pub fn verify_quote_with_collaterals(
             );
             return Err(Error::VerifyQuote);
         }
+    }
+
+    if report_verify_size as usize != TD_VERIFIED_REPORT_SIZE {
+        log::error!(
+            "verify_quote_with_collaterals: Invalid report size: expected {}, got {}\n",
+            TD_VERIFIED_REPORT_SIZE,
+            report_verify_size
+        );
+        return Err(Error::InvalidOutput);
     }
 
     mask_verified_report_values(&mut td_report_verify[..report_verify_size as usize]);

--- a/src/attestation/src/ghci.rs
+++ b/src/attestation/src/ghci.rs
@@ -38,7 +38,7 @@ pub extern "C" fn servtd_get_quote(tdquote_req_buf: *mut c_void, len: u64) -> i3
 
     let input = unsafe { from_raw_parts_mut(tdquote_req_buf as *mut u8, len as usize) };
 
-    let mut shared = if let Some(shared) = SharedMemory::new(len as usize / 0x1000) {
+    let mut shared = if let Some(shared) = SharedMemory::new((len as usize + 0xFFF) / 0x1000) {
         shared
     } else {
         log::error!("Failed to allocate shared memory of size {}\n", len);
@@ -91,6 +91,7 @@ fn set_vmm_notification() -> bool {
     // Setup event notifier
     if let Err(e) = tdx_tdcall::tdx::tdvmcall_setup_event_notify(NOTIFY_VECTOR as u64) {
         log::error!("Fail to setup event notify for VMM: {:?}\n", e);
+        return false;
     }
 
     true
@@ -105,7 +106,10 @@ fn wait_for_quote_completion(notify_registered: bool, buffer: &[u8]) -> Result<(
 
     let status_code = loop {
         let status = match buffer.get(GET_QUOTE_STATUS_FIELD) {
-            Some(bytes) => u64::from_le_bytes(bytes.try_into().unwrap()),
+            Some(bytes) => {
+                let ptr = bytes.as_ptr() as *const u64;
+                unsafe { core::ptr::read_volatile(ptr) }
+            }
             None => {
                 log::error!("Failed to get quote status from buffer\n");
                 return Err(AttestLibError::InvalidParameter);

--- a/src/attestation/src/igvmattest.rs
+++ b/src/attestation/src/igvmattest.rs
@@ -80,6 +80,11 @@ pub fn get_quote_igvm(td_report: &[u8]) -> Result<Vec<u8>, Error> {
 
     // send the request to VMM via ghci
     let get_quote_blob_ptr = get_quote_blob.as_mut_ptr() as *mut c_void;
+    // Verify alignment for ServtdTdxQuoteHdr access
+    debug_assert!(
+        (get_quote_blob_ptr as usize) % core::mem::align_of::<ServtdTdxQuoteHdr>() == 0,
+        "get_quote_blob buffer not properly aligned for ServtdTdxQuoteHdr"
+    );
     let servtd_get_quote_ret =
         unsafe { servtd_get_quote(get_quote_blob_ptr, SERVTD_REQ_BUF_SIZE as u64) };
 

--- a/src/crypto/src/rustls_impl/ecdsa.rs
+++ b/src/crypto/src/rustls_impl/ecdsa.rs
@@ -115,7 +115,8 @@ pub fn ecdsa_verify_with_raw_public_key(
 pub fn ecdsa_sign(pkcs8: &[u8], data: &[u8]) -> Result<Vec<u8>> {
     let rand = SystemRandom::new();
     let ecdsa_key =
-        EcdsaKeyPair::from_pkcs8(&signature::ECDSA_P384_SHA384_ASN1_SIGNING, pkcs8, &rand).unwrap();
+        EcdsaKeyPair::from_pkcs8(&signature::ECDSA_P384_SHA384_ASN1_SIGNING, pkcs8, &rand)
+            .map_err(|_| Error::EcdsaSign)?;
 
     ecdsa_key
         .sign(&rand, data)

--- a/src/crypto/src/rustls_impl/tls.rs
+++ b/src/crypto/src/rustls_impl/tls.rs
@@ -498,7 +498,7 @@ pub(crate) mod connection {
 
         // Accumulate number of used bytes
         pub fn consume(&mut self, size: usize) {
-            self.used += size;
+            self.used = core::cmp::min(self.used + size, self.inner.len());
         }
 
         // Discard the first `size` bytes
@@ -603,7 +603,16 @@ pub(crate) mod connection {
                             |out_buffer| state.encrypt(data, out_buffer),
                             map_err,
                         )?;
-                        self.transport.write(self.output.used()).await?;
+                        // Write all output bytes to transport (handle short writes)
+                        let total = self.output.used().len();
+                        let mut written = 0;
+                        while written < total {
+                            let n = self.transport.write(&self.output.used()[written..]).await?;
+                            if n == 0 {
+                                return Err(TlsConnectionError::UnexpectedState);
+                            }
+                            written += n;
+                        }
                         self.output.reset();
                         break;
                     }
@@ -818,8 +827,8 @@ pub(crate) mod connection {
                                 discard: new_discard,
                                 payload,
                             } = res?;
+                            discard += new_discard;
                             if !self.received_app_data.is_full() {
-                                discard += new_discard;
                                 self.received_app_data.append(payload.to_vec());
                             }
                         }
@@ -869,7 +878,16 @@ pub(crate) mod connection {
                             |out_buffer| state.encrypt(data, out_buffer),
                             map_err,
                         )?;
-                        self.transport.write(self.output.used()).await?;
+                        // Write all output bytes to transport (handle short writes)
+                        let total = self.output.used().len();
+                        let mut written = 0;
+                        while written < total {
+                            let n = self.transport.write(&self.output.used()[written..]).await?;
+                            if n == 0 {
+                                return Err(TlsConnectionError::UnexpectedState);
+                            }
+                            written += n;
+                        }
                         self.output.reset();
                         break;
                     }

--- a/src/devices/pci/src/config.rs
+++ b/src/devices/pci/src/config.rs
@@ -454,10 +454,7 @@ impl PciDevice {
                     2 => {
                         self.bars[current_bar].bar_type = PciBarType::MemorySpace64;
 
-                        let mut size = self.get_bar_size(current_bar_offset)? as u64;
-                        if size == 0 {
-                            size = (self.get_bar_size(current_bar_offset + 4)? as u64) << 32;
-                        }
+                        let size = self.get_bar_size64(current_bar_offset)?;
 
                         let addr = if size > 0 {
                             let addr = alloc_mmio64(size)?;
@@ -515,34 +512,31 @@ impl PciDevice {
                 // bits 2-1 are the type 0 is 32-but, 2 is 64 bit
                 match bar >> 1 & 3 {
                     0 => {
-                        let size = self.read_u32(current_bar_offset)?;
+                        let size = self.get_bar_size(current_bar_offset)?;
 
-                        let addr = if size > 0 {
+                        if size > 0 {
                             let addr = alloc_mmio32(size)?;
                             self.set_bar_addr(current_bar_offset, addr)?;
-                            addr
+                            self.bars[current_bar].bar_type = PciBarType::MemorySpace32;
+                            self.bars[current_bar].address =
+                                u64::from(addr & PCI_MEM32_BASE_ADDRESS_MASK);
                         } else {
-                            bar
-                        };
-
-                        self.bars[current_bar].bar_type = PciBarType::MemorySpace32;
-                        self.bars[current_bar].address =
-                            u64::from(addr & PCI_MEM32_BASE_ADDRESS_MASK);
+                            self.bars[current_bar].bar_type = PciBarType::MemorySpace32;
+                            self.bars[current_bar].address = 0;
+                        }
                     }
                     2 => {
                         self.bars[current_bar].bar_type = PciBarType::MemorySpace64;
 
-                        let mut size = self.read_u64(current_bar_offset)?;
-                        let addr = if size > 0 {
+                        let size = self.get_bar_size64(current_bar_offset)?;
+                        if size > 0 {
                             let addr = alloc_mmio64(size)?;
                             self.set_bar_addr(current_bar_offset, addr as u32)?;
                             self.set_bar_addr(current_bar_offset + 4, (addr >> 32) as u32)?;
-                            addr
+                            self.bars[current_bar].address = addr & PCI_MEM64_BASE_ADDRESS_MASK;
                         } else {
-                            bar as u64
-                        };
-
-                        self.bars[current_bar].address = addr & PCI_MEM64_BASE_ADDRESS_MASK;
+                            self.bars[current_bar].address = 0;
+                        }
                         current_bar_offset += 4;
                     }
                     _ => return Err(PciError::InvalidBarType),
@@ -572,10 +566,39 @@ impl PciDevice {
         let size = self.read_u32(offset)?;
         self.write_u32(offset, restore)?;
 
-        Ok(if size == 0 {
-            size
+        let masked = size & 0xFFFF_FFF0;
+        Ok(if masked == 0 {
+            0
         } else {
-            !(size & 0xFFFF_FFF0) + 1
+            (!masked).wrapping_add(1)
+        })
+    }
+
+    /// Probe the size of a 64-bit memory BAR.
+    ///
+    /// A 64-bit BAR spans two consecutive 32-bit config registers (`offset` and
+    /// `offset + 4`). The size is determined by writing all ones to both halves,
+    /// reading them back, restoring the original values, and computing the size
+    /// from the combined 64-bit mask. The low 4 bits of the low register encode
+    /// the BAR type, not address bits, so they are masked off; the high register
+    /// is all address bits.
+    fn get_bar_size64(&self, offset: u8) -> Result<u64> {
+        let restore_low = self.read_u32(offset)?;
+        let restore_high = self.read_u32(offset + 4)?;
+
+        self.write_u32(offset, u32::MAX)?;
+        self.write_u32(offset + 4, u32::MAX)?;
+        let low = self.read_u32(offset)?;
+        let high = self.read_u32(offset + 4)?;
+
+        self.write_u32(offset, restore_low)?;
+        self.write_u32(offset + 4, restore_high)?;
+
+        let masked = ((high as u64) << 32) | u64::from(low & 0xFFFF_FFF0);
+        Ok(if masked == 0 {
+            0
+        } else {
+            (!masked).wrapping_add(1)
         })
     }
 

--- a/src/devices/pci/src/mmio.rs
+++ b/src/devices/pci/src/mmio.rs
@@ -25,10 +25,12 @@ pub fn init_mmio() {
     // If an overlap is detected, panic with an error message indicating an invalid MMIO configuration.
     // This ensures that the MMIO space does not conflict with the RAM space.
     for region in memory_map.iter() {
-        if (region.addr < (MMIO32_START + MMIO32_SIZE) as u64
-            && region.addr + region.size > MMIO32_START as u64)
-            || (region.addr < MMIO64_START + MMIO64_SIZE
-                && region.addr + region.size > MMIO64_START)
+        let region_end = region.addr.saturating_add(region.size);
+        let mmio32_end = (MMIO32_START as u64).saturating_add(MMIO32_SIZE as u64);
+        let mmio64_end = MMIO64_START.saturating_add(MMIO64_SIZE);
+
+        if (region.addr < mmio32_end && region_end > MMIO32_START as u64)
+            || (region.addr < mmio64_end && region_end > MMIO64_START)
         {
             panic!("Invalid MMIO configuration: MMIO space overlaps with the RAM space.");
         }
@@ -79,6 +81,10 @@ pub fn alloc_mmio64(size: u64) -> Result<u64> {
 pub fn alloc_mmio64(size: u64) -> Result<u64> {
     let cur = *MMIO64.lock();
     let addr = align_up(cur, size).ok_or(PciError::InvalidParameter)? as u64;
+
+    if size > MMIO64_SIZE || addr > MMIO64_START + MMIO64_SIZE - size {
+        return Err(PciError::MmioOutofResource);
+    }
 
     *MMIO64.lock() = addr.checked_add(size).ok_or(PciError::InvalidParameter)?;
     Ok(addr)

--- a/src/devices/virtio/src/mem.rs
+++ b/src/devices/virtio/src/mem.rs
@@ -56,9 +56,16 @@ impl MemoryRegion {
 
     /// Expose a section of the memory region as a slice
     pub fn as_slice<T>(&mut self, offset: u64, length: u64) -> Result<&[T], MemoryRegionError> {
+        let byte_length =
+            length
+                .checked_mul(core::mem::size_of::<T>() as u64)
+                .ok_or(MemoryRegionError {
+                    region: *self,
+                    offset,
+                })?;
         if self.base.checked_add(offset).is_none()
             || offset
-                .checked_add(length)
+                .checked_add(byte_length)
                 .and_then(|end| if end > self.length { None } else { Some(end) })
                 .is_none()
         {
@@ -79,9 +86,16 @@ impl MemoryRegion {
         offset: u64,
         length: u64,
     ) -> Result<&mut [T], MemoryRegionError> {
+        let byte_length =
+            length
+                .checked_mul(core::mem::size_of::<T>() as u64)
+                .ok_or(MemoryRegionError {
+                    region: *self,
+                    offset,
+                })?;
         if self.base.checked_add(offset).is_none()
             || offset
-                .checked_add(length)
+                .checked_add(byte_length)
                 .and_then(|end| if end > self.length { None } else { Some(end) })
                 .is_none()
         {

--- a/src/devices/virtio_serial/src/lib.rs
+++ b/src/devices/virtio_serial/src/lib.rs
@@ -502,10 +502,12 @@ impl VirtioSerial {
                     let control_msg =
                         unsafe { core::slice::from_raw_parts(vq_buf.addr as *const u8, safe_len) };
 
-                    self.handle_control_msg(control_msg)?;
+                    let result = self.handle_control_msg(control_msg);
 
                     self.free_dma_memory(vq_buf.addr)
                         .ok_or(VirtioSerialError::OutOfResource)?;
+
+                    result?;
                 }
             }
         }
@@ -594,6 +596,9 @@ impl VirtioSerial {
         if data.is_empty() || data.len() > u32::MAX as usize {
             return Err(VirtioSerialError::InvalidParameter);
         }
+        if port_id >= MAX_PORT_SUPPORTED as u32 {
+            return Err(VirtioSerialError::InvalidParameter);
+        }
 
         let mut g2h = Vec::new();
         let dma = self
@@ -628,7 +633,7 @@ impl VirtioSerial {
         if port_id == 0 {
             0
         } else {
-            2 + port_id as u16 * 2
+            2u16.saturating_add((port_id as u16).saturating_mul(2))
         }
     }
 

--- a/src/devices/vmcall_raw/src/stream.rs
+++ b/src/devices/vmcall_raw/src/stream.rs
@@ -48,7 +48,7 @@ impl VmcallRaw {
     }
 
     pub async fn connect(&mut self) -> Result {
-        let _ = vmcall_raw_transport_init();
+        vmcall_raw_transport_init()?;
         VMCALL_MIG_CONTEXT_FLAGS
             .lock()
             .insert(self.addr.transport_context(), AtomicBool::new(false));

--- a/src/devices/vsock/src/protocol.rs
+++ b/src/devices/vsock/src/protocol.rs
@@ -133,6 +133,10 @@ impl<T: AsRef<[u8]>> Packet<T> {
         if op == 0 || op > 7 {
             return Err(VsockError::Malformed);
         }
+        // Validate data_len doesn't exceed the buffer beyond the header
+        if self.header_len() + self.data_len() as usize > self.buffer.as_ref().len() {
+            return Err(VsockError::Truncated);
+        }
         Ok(())
     }
 

--- a/src/devices/vsock/src/stream.rs
+++ b/src/devices/vsock/src/stream.rs
@@ -386,12 +386,12 @@ impl VsockStream {
                 if packet.data_len() > 0 {
                     let mut recv = vsock_transport_dequeue(self, DEFAULT_TIMEOUT).await?;
 
-                    self.rx_cnt += packet.data_len();
                     if packet.data_len() as usize <= recv.len() {
                         recv.truncate(packet.data_len() as usize);
                     } else {
                         return Err(VsockError::Illegal);
                     }
+                    self.rx_cnt = self.rx_cnt.wrapping_add(packet.data_len());
 
                     // Send credit update if the free space is less than a max packet size
                     if self.free_space() < MAX_VSOCK_PKT_DATA_LEN as u32 {

--- a/src/devices/vsock/src/transport/vmcall.rs
+++ b/src/devices/vsock/src/transport/vmcall.rs
@@ -193,7 +193,8 @@ async fn vmcall_service_migtd_send(
         }
 
         // Do the sanity check
-        if reply.guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes()
+        if reply.data().len() < 12
+            || reply.guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes()
             || reply.status() != 0
             || reply.data()[0] != CURRENT_VERSION
             || reply.data()[1] != COMMAND_SEND
@@ -231,7 +232,8 @@ async fn vmcall_service_migtd_receive(
         }
 
         // Do the sanity check
-        if reply.guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes()
+        if reply.data().len() < 12
+            || reply.guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes()
             || reply.status() != 0
             || reply.data()[0] != CURRENT_VERSION
             || reply.data()[1] != COMMAND_RECV

--- a/src/devices/vsock/src/virtio_dump.rs
+++ b/src/devices/vsock/src/virtio_dump.rs
@@ -102,28 +102,25 @@ impl BarAddress {
 
     pub fn common_addr(&mut self) -> Option<usize> {
         let mut cap_next = self.read::<u8>(PCI_CAP_POINTER);
+        let mut iterations = 0u16;
+        const MAX_CAP_ITERATIONS: u16 = 256;
 
-        while cap_next < CAP_NEXT_MAX && cap_next > 0 {
+        while cap_next < CAP_NEXT_MAX && cap_next > 0 && iterations < MAX_CAP_ITERATIONS {
+            iterations += 1;
             // vendor specific capability
             if self.read::<u8>(cap_next.into()) == VIRTIO_CAPABILITIES_SPECIFIC {
-                // These offsets are into the following structure:
-                // struct virtio_pci_cap {
-                //         u8 cap_vndr;    /* Generic PCI field: PCI_CAP_ID_VNDR */
-                //         u8 cap_next;    /* Generic PCI field: next ptr. */
-                //         u8 cap_len;     /* Generic PCI field: capability length */
-                //         u8 cfg_type;    /* Identifies the structure. */
-                //         u8 bar;         /* Where to find it. */
-                //         u8 padding[3];  /* Pad to full dword. */
-                //         le32 offset;    /* Offset within bar. */
-                //         le32 length;    /* Length of the structure, in bytes. */
-                // };
                 let cfg_type = self.read::<u8>((cap_next + VIRTIO_CFG_TYPE_OFFSET).into());
                 #[allow(clippy::disallowed_names)]
                 let bar = self.read::<u8>((cap_next + VIRTIO_BAR_OFFSET).into());
                 let offset = self.read::<u32>((cap_next + VIRTIO_CAP_OFFSET).into());
 
                 if cfg_type == VIRTIO_COMMON_CONFIGURATION {
-                    return Some((self.bars[usize::from(bar)] + u64::from(offset)) as usize);
+                    if (bar as usize) >= self.bars.len() {
+                        return None;
+                    }
+                    return Some(
+                        (self.bars[usize::from(bar)].checked_add(u64::from(offset))?) as usize,
+                    );
                 }
             }
             cap_next = self.read::<u8>((cap_next + 1).into());

--- a/src/migtd/src/driver/serial.rs
+++ b/src/migtd/src/driver/serial.rs
@@ -54,7 +54,8 @@ pub fn virtio_serial_device_init() {
     pci::init_mmio();
 
     // Enumerate the virtio device
-    let (_b, dev, _f) = pci::find_device(VIRTIO_PCI_VENDOR_ID, VIRTIO_PCI_DEVICE_ID).unwrap();
+    let (_b, dev, _f) = pci::find_device(VIRTIO_PCI_VENDOR_ID, VIRTIO_PCI_DEVICE_ID)
+        .expect("Failed to find virtio-serial PCI device");
 
     let pci_device = pci::PciDevice::new(0, dev, 0);
 

--- a/src/migtd/src/driver/timer.rs
+++ b/src/migtd/src/driver/timer.rs
@@ -56,6 +56,15 @@ pub fn init_timer() {
 pub fn schedule_timeout(timeout: u32) -> Option<u64> {
     reset_timer();
     let cpuid = unsafe { core::arch::x86_64::__cpuid_count(0x15, 0) };
+    if cpuid.eax == 0 || cpuid.ebx == 0 || cpuid.ecx == 0 {
+        log::error!(
+            "schedule_timeout: CPUID.15H returned invalid values (eax={}, ebx={}, ecx={})\n",
+            cpuid.eax,
+            cpuid.ebx,
+            cpuid.ecx
+        );
+        return None;
+    }
     let tsc_frequency = cpuid.ecx * (cpuid.ebx / cpuid.eax);
     let deadline = (tsc_frequency / 1000) as u64 * timeout as u64;
 

--- a/src/migtd/src/driver/vsock.rs
+++ b/src/migtd/src/driver/vsock.rs
@@ -39,7 +39,8 @@ pub fn virtio_vsock_device_init() {
     pci::init_mmio();
 
     // Enumerate the virtio device
-    let (_b, dev, _f) = pci::find_device(VIRTIO_PCI_VENDOR_ID, VIRTIO_PCI_DEVICE_ID).unwrap();
+    let (_b, dev, _f) = pci::find_device(VIRTIO_PCI_VENDOR_ID, VIRTIO_PCI_DEVICE_ID)
+        .expect("Failed to find virtio-vsock PCI device");
 
     let pci_device = pci::PciDevice::new(0, dev, 0);
 

--- a/src/migtd/src/event_log.rs
+++ b/src/migtd/src/event_log.rs
@@ -62,19 +62,20 @@ impl TaggedEvent {
 }
 
 pub fn get_event_log_mut() -> Option<&'static mut [u8]> {
-    get_ccel().map(event_log_slice)
+    get_ccel().and_then(event_log_slice)
 }
 
 pub fn get_event_log() -> Option<&'static [u8]> {
-    let raw = get_ccel().map(event_log_slice)?;
+    let raw = get_ccel().and_then(event_log_slice)?;
     // The `+1` is required: `cc_measurement::log::CcEvents::next()` only
     // yields an event when `end_of_event < bytes.len()` (strict inequality).
-    // If we sliced to exactly `size`, the buffer would end at the last
-    // event boundary and that final event would be silently dropped by the
-    // iterator, breaking `parse_events()` (e.g. losing the policy tag) and
-    // any downstream RTMR replay. The runtime layout has trailing zeros in
-    // the CCEL area, so including one extra byte is safe.
-    event_log_size(raw).map(|size| &raw[..size + 1])
+    // If we sliced to exactly `size`, the buffer would end at the last event
+    // boundary and that final event (the MigTdPolicy measurement) would be
+    // silently dropped by the iterator, breaking `parse_events()` and causing
+    // `check_policy_integrity()` to fail with `PolicyHashMismatch`. The runtime
+    // layout has trailing zeros in the CCEL area, so the extra byte is safe;
+    // clamp to the raw length as a defensive guard.
+    event_log_size(raw).map(|size| &raw[..core::cmp::min(size + 1, raw.len())])
 }
 
 fn event_log_size(event_log: &[u8]) -> Option<usize> {
@@ -90,16 +91,19 @@ fn event_log_size(event_log: &[u8]) -> Option<usize> {
     Some(size)
 }
 
-fn event_log_slice(ccel: &Ccel) -> &'static mut [u8] {
-    unsafe { core::slice::from_raw_parts_mut(ccel.lasa as *mut u8, ccel.laml as usize) }
+fn event_log_slice(ccel: &Ccel) -> Option<&'static mut [u8]> {
+    // Validate that lasa and laml are non-zero and laml is reasonable
+    if ccel.lasa == 0 || ccel.laml == 0 || ccel.laml as usize > 0x10_0000 {
+        return None;
+    }
+    Some(unsafe { core::slice::from_raw_parts_mut(ccel.lasa as *mut u8, ccel.laml as usize) })
 }
 
 fn get_ccel() -> Option<&'static Ccel> {
     if !CCEL.is_completed() {
         // Parse out ACPI tables handoff from firmware and find the event log location
         let &ccel = get_acpi_tables()
-            .and_then(|tables| tables.iter().find(|&&t| t[..4] == *b"CCEL"))
-            .expect("Failed to find CCEL");
+            .and_then(|tables| tables.iter().find(|&&t| t.get(..4) == Some(b"CCEL")))?;
 
         if ccel.len() < size_of::<Ccel>() {
             return None;
@@ -181,9 +185,8 @@ pub(crate) fn parse_events(event_log: &[u8]) -> Option<BTreeMap<EventName, CcEve
     for (event_header, event_data) in reader.cc_events {
         match event_header.event_type {
             EV_EFI_PLATFORM_FIRMWARE_BLOB2 => {
-                let desc_size = event_data[0] as usize;
-                let desc = event_data.get(1..1 + desc_size)?;
-                if desc == PLATFORM_FIRMWARE_BLOB2_PAYLOAD {
+                let desc_size = *event_data.get(0)? as usize;
+                if event_data.get(1..1 + desc_size)? == PLATFORM_FIRMWARE_BLOB2_PAYLOAD {
                     map.insert(EventName::MigTdCore, CcEvent::new(event_header, None));
                 }
             }

--- a/src/migtd/src/migration/data.rs
+++ b/src/migtd/src/migration/data.rs
@@ -117,7 +117,9 @@ impl<'a> VmcallServiceResponse<'a> {
         if length < RESPONSE_HEADER_LENGTH || length > data.len() {
             return None;
         }
-        Some(Self { data })
+        Some(Self {
+            data: &data[..length],
+        })
     }
 
     pub fn new(response: &'a mut [u8], guid: Guid) -> Option<Self> {

--- a/src/migtd/src/migration/logging.rs
+++ b/src/migtd/src/migration/logging.rs
@@ -374,12 +374,24 @@ pub fn entrylog(msg: &Vec<u8>, loglevel: Level, request_id: u64) {
                             Some(if v == u64::MAX { 1 } else { v + 1 })
                         })
                         .unwrap();
-                    let start_offset: u64 =
-                        u64::from_le_bytes(data_buffer[24..32].try_into().unwrap());
-                    let end_offset: u64 =
-                        u64::from_le_bytes(data_buffer[32..40].try_into().unwrap());
+                    // Copy offsets from shared memory via volatile read to prevent TOCTOU
+                    let start_offset: u64 = unsafe {
+                        core::ptr::read_volatile(data_buffer[24..32].as_ptr() as *const u64)
+                    };
+                    let end_offset: u64 = unsafe {
+                        core::ptr::read_volatile(data_buffer[32..40].as_ptr() as *const u64)
+                    };
                     let mut currentstartoffset: usize = start_offset as usize;
                     let mut currentendoffset: usize = end_offset as usize;
+                    // Clamp offsets to valid range to prevent VMM-controlled panic
+                    if currentstartoffset < LOGAREABUFFERHEADERSIZE
+                        || currentstartoffset >= PAGE_SIZE
+                    {
+                        currentstartoffset = LOGAREABUFFERHEADERSIZE;
+                    }
+                    if currentendoffset < LOGAREABUFFERHEADERSIZE || currentendoffset >= PAGE_SIZE {
+                        currentendoffset = LOGAREABUFFERHEADERSIZE;
+                    }
                     if currentendoffset + LOGENTRYHEADERSIZE + msg.len() > PAGE_SIZE
                         || currentendoffset < currentstartoffset
                     {

--- a/src/migtd/src/migration/pre_session_data.rs
+++ b/src/migtd/src/migration/pre_session_data.rs
@@ -141,6 +141,10 @@ pub(super) async fn receive_pre_session_data<T: AsyncRead + AsyncWrite + Unpin>(
             log::error!("receive_pre_session_data: Network error: {:?}\n", e);
             MigrationResult::NetworkError
         })?;
+        if n == 0 {
+            log::error!("receive_pre_session_data: EOF (peer closed connection)\n");
+            return Err(MigrationResult::NetworkError);
+        }
         recvd += n;
     }
     Ok(())
@@ -194,6 +198,15 @@ pub(super) async fn receive_pre_session_data_packet<T: AsyncRead + AsyncWrite + 
     }
 
     let pre_session_data_payload_size = header.length as usize;
+    const MAX_PRE_SESSION_PAYLOAD: usize = 64 * 1024; // 64 KiB
+    if pre_session_data_payload_size > MAX_PRE_SESSION_PAYLOAD {
+        log::error!(
+            "receive_pre_session_data_packet: payload size {} exceeds max {}\n",
+            pre_session_data_payload_size,
+            MAX_PRE_SESSION_PAYLOAD
+        );
+        return Err(MigrationResult::InvalidParameter);
+    }
     let mut pre_session_data_payload = vec![0u8; pre_session_data_payload_size];
     receive_pre_session_data(transport, &mut pre_session_data_payload)
         .await

--- a/src/migtd/src/migration/rebinding.rs
+++ b/src/migtd/src/migration/rebinding.rs
@@ -560,6 +560,9 @@ async fn tls_session_read_exact(
             .read(&mut data[recvd..])
             .await
             .map_err(|_| MigrationResult::NetworkError)?;
+        if n == 0 {
+            return Err(MigrationResult::NetworkError);
+        }
         recvd += n;
     }
     Ok(())

--- a/src/migtd/src/ratls/server_client.rs
+++ b/src/migtd/src/ratls/server_client.rs
@@ -778,6 +778,16 @@ mod verify {
         cert: &[u8],
         quote_local: &[u8],
     ) -> core::result::Result<(), CryptoError> {
+        // Reject oversized certificates to prevent heap exhaustion from DER parsing
+        const MAX_CERT_SIZE: usize = 8192;
+        if cert.len() > MAX_CERT_SIZE {
+            log::error!(
+                "Certificate too large: {} bytes (max {})\n",
+                cert.len(),
+                MAX_CERT_SIZE
+            );
+            return Err(CryptoError::ParseCertificate);
+        }
         let verified_report_local = attestation::verify_quote(quote_local).map_err(|e| {
             log::error!("Mutual attestation error {:?}.\n", e);
             CryptoError::TlsVerifyPeerCert(MUTUAL_ATTESTATION_ERROR.to_string())
@@ -1123,7 +1133,17 @@ mod verify {
         }
         const PUBLIC_KEY_HASH_SIZE: usize = 48;
 
-        let report_data = &verified_report[520..520 + PUBLIC_KEY_HASH_SIZE];
+        let report_data = verified_report
+            .get(520..520 + PUBLIC_KEY_HASH_SIZE)
+            .ok_or_else(|| {
+                log::error!(
+                    "verify_public_key: verified_report too short (len={})\n",
+                    verified_report.len()
+                );
+                CryptoError::TlsVerifyPeerCert(
+                    "verified_report too short for public key hash".to_string(),
+                )
+            })?;
         let digest = digest_sha384(public_key).map_err(|e| {
             log::error!("Failed to compute SHA384 digest: {:?}\n", e);
             e

--- a/src/policy/src/v2/collaterals.rs
+++ b/src/policy/src/v2/collaterals.rs
@@ -18,8 +18,12 @@ pub fn get_fmspc_from_quote(quote: &[u8]) -> Result<[u8; 6], PolicyError> {
     let start_index = mid.find(PEM_CERT_BEGIN).ok_or(PolicyError::InvalidQuote)?;
     let end_index = mid[start_index..]
         .find(PEM_CERT_END)
-        .map(|i| start_index + i + PEM_CERT_END.len())
+        .and_then(|i| i.checked_add(start_index))
+        .and_then(|i| i.checked_add(PEM_CERT_END.len()))
         .ok_or(PolicyError::InvalidQuote)?;
+    if start_index >= end_index {
+        return Err(PolicyError::InvalidQuote);
+    }
 
     let pck_cert = mid[start_index..end_index].as_bytes();
     let pck_der = crypto::pem_cert_to_der(pck_cert).map_err(|_| PolicyError::InvalidQuote)?;

--- a/src/policy/src/v2/mod.rs
+++ b/src/policy/src/v2/mod.rs
@@ -53,21 +53,17 @@ fn verify_event_hash(
 
 /// Convert a hex string to bytes without using external crates
 fn hex_string_to_bytes(hex: &str) -> Result<Vec<u8>, PolicyError> {
-    // Ensure even number of characters
-    if hex.is_empty() || hex.len() % 2 != 0 {
+    // Ensure even number of characters and ASCII-only
+    if hex.is_empty() || hex.len() % 2 != 0 || !hex.is_ascii() {
         return Err(PolicyError::InvalidParameter);
     }
 
     let mut bytes = Vec::with_capacity(hex.len() / 2);
 
-    // Process two hex digits at a time
-    for i in (0..hex.len()).step_by(2) {
-        if i + 2 > hex.len() {
-            break;
-        }
-
-        // Get the hex byte as a string slice
-        let byte_str = &hex[i..i + 2];
+    // Process two hex digits at a time using bytes to avoid char-boundary issues
+    for chunk in hex.as_bytes().chunks_exact(2) {
+        // Safety: we verified is_ascii() above so each byte is a valid single-char str
+        let byte_str = core::str::from_utf8(chunk).map_err(|_| PolicyError::InvalidParameter)?;
 
         // Convert to numeric value
         let byte = u8::from_str_radix(byte_str, 16).map_err(|_| PolicyError::InvalidParameter)?;

--- a/tools/migtd-collateral-generator/src/pcs_client.rs
+++ b/tools/migtd-collateral-generator/src/pcs_client.rs
@@ -206,6 +206,11 @@ fn remove_header_case_insensitive(
 const INITIAL_RETRY_DELAY_SECS: u64 = 10;
 /// Maximum retry delay in seconds. Once the next delay would exceed this, error out.
 const MAX_RETRY_DELAY_SECS: u64 = 180;
+/// Maximum accepted size (in bytes) for a single PCS response body. PCS
+/// collateral (root CA, CRLs, QE identity, TCB info, FMSPC list) is at most a
+/// few tens of KB; this generous cap prevents a compromised or misbehaving
+/// endpoint from exhausting build-host memory with an unbounded response.
+const MAX_PCS_RESPONSE_SIZE: usize = 16 * 1024 * 1024;
 
 pub async fn fetch_data_from_url(url: &str) -> Result<PcsResponse> {
     let client = Client::new();
@@ -234,7 +239,7 @@ pub async fn fetch_data_from_url(url: &str) -> Result<PcsResponse> {
 }
 
 async fn send_request(client: &Client, url: &str) -> Result<PcsResponse> {
-    let response = client.get(url).send().await?;
+    let mut response = client.get(url).send().await?;
     let status = response.status().as_u16() as u32;
 
     // Treat server errors (5xx), 429 (Too Many Requests) and 408 (Request
@@ -256,7 +261,20 @@ async fn send_request(client: &Client, url: &str) -> Result<PcsResponse> {
         );
     }
 
-    let data = response.bytes().await?.to_vec();
+    // Stream the body with a hard cap instead of buffering an unbounded
+    // `bytes()` so a compromised or misbehaving endpoint cannot exhaust
+    // build-host memory with an oversized response.
+    let mut data = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        if data.len() + chunk.len() > MAX_PCS_RESPONSE_SIZE {
+            return Err(anyhow!(
+                "Response body from {} exceeds {}-byte cap",
+                url,
+                MAX_PCS_RESPONSE_SIZE
+            ));
+        }
+        data.extend_from_slice(&chunk);
+    }
 
     Ok(PcsResponse {
         response_code: status,


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | High | Unbounded vec![0;peer_u32] alloc in pre-TLS receive_pre_session_data_packet | handle_pre_mig -> exchange_msk -> pre_session_data_exchange -> receive_pre_session_data_packet | Clamp header.length to MAX_PRE_SESSION_PAYLOAD (e.g. 64KiB) before alloc; use try_reserve. | weakness | The unbounded allocation from a peer-controlled u32 length field causes OOM panic, but the impact is purely denial of service. This pre-TLS exchange runs over virtio-vsock transport fully controlled by the VMM, which already possesses unlimited DoS capability through scheduling denial and VMCALL non-response. The fix is good input validation at a trust boundary, but does not prevent an attack class the adversary lacked before. |
| 2 | Medium | parse_events indexes peer event_data[0]/[1..1+desc_size]/[..4] without length check | exchange_msk -> ratls::client -> verify_peer_cert -> mig_policy::authenticate_remote -> parse_events | Use event_data.get(0)/.get(1..1+desc_size)/.get(..4) and return None on short data. | weakness | The unchecked event_data[0] in parse_events() is a real crash path on malformed event data, but it is not practically exploitable in production. The peer's event log is embedded in their RA-TLS certificate and verified against RTMRs from their TDX quote before parse_events() runs. A peer capable of crafting a malicious event log that passes RTMR replay must be running modified firmware or a modified MigTD binary, both of which change MRTD — causing policy rejection before the vulnerable code is reached. |
| 3 | Medium | verify_public_key slices verified_report[520..568] without length check | exchange_msk -> ratls::client -> verify_peer_cert -> verify_signature -> verify_public_key | verified_report.get(520..568).ok_or(CryptoError::InvalidReport)? | weakness | The unguarded slice verified_report[520..568] can only cause a panic if the report returned by QGS is truncated — this is a denial-of-service condition. In the TDX threat model the VMM already controls QGS responses and has unlimited DoS capability (it can simply never deliver the quote, deny scheduling, or drop the vsock connection). The fix improves robustness by returning an error instead of panicking, but the original code gave the VMM no new attack class — no confidentiality or integrity breach is possible, only a crash the VMM could already achieve through simpler means. |
| 4 | Medium | x509/crl from_der unbounded Vec alloc on peer certificate during ratls handshake | exchange_msk -> ratls::client -> verify_peer_cert -> Certificate::from_der | Reject end_entity.len()>MAX_CERT_SIZE before from_der; cap RDN/extension count. | weakness | The oversized certificate causes OOM panic during DER parsing, but the impact is purely availability. The peer certificate arrives over virtio-vsock transport controlled by the VMM, which can inject arbitrary TLS messages and already possesses unlimited DoS capability through scheduling denial. The fix is proper input validation at a trust boundary, but does not block an attack class the adversary lacked before. |
| 5 | Low | hex_string_to_bytes panics on multi-byte UTF-8 char at odd index in policy hex field | authenticate_remote -> MigPolicy::from_json -> hex_string_to_bytes | Validate hex.is_ascii() before slicing; or iterate .as_bytes().chunks_exact(2). | weakness | The &hex[i..i+2] slice panics only if the input string contains multi-byte UTF-8 characters, which can only happen if the policy JSON (loaded from VMM-provided configuration) contains non-ASCII in a hex field. The impact is exclusively a panic (DoS). The policy JSON is delivered by the VMM which already has full denial-of-service capability over the TD through scheduling, interrupt injection, or simply not providing the configuration at all. The fix is a robustness improvement converting a panic into a clean error, but the original code gave the VMM no new attack class beyond what it already possesses. |
| 6 | Low | fetch_fmspc_list serde_json on raw PCS body  --  unbounded array | <entry> -> fetch_fmspc_list | Cap body size before deserialize. | weakness | The missing size cap is real, but the finding mislocates it: by the time serde_json::from_slice runs, the whole body is already buffered in pcs_response.data, so the unbounded allocation is actually the HTTP body read in send_request, and it affects every PCS fetch, not just fetch_fmspc_list. It's a build-time tool behind CFV_BUILDTIME_CONFIG (tier T4), and it only triggers if PCS is compromised or TLS is MITM'd — a threat that already lets an attacker inject arbitrary collateral, making a self-inflicted build-host OOM strictly less severe. |
| 7 | High | VMM-set log_max_level + shared logarea header TOCTOU -> entrylog slice-index panic kills all sessions | handle_pre_mig -> log::set_max_level -> <any log!()> -> VmmLoggerBackend::log -> entrylog | Copy LogAreaBufferHeader to private stack before use and clamp start_offset/end_offset to [LOGAREABUFFERHEADERSIZE,PAGE_SIZE); reject log_max_level changes after init. | weakness | The log buffer is shared memory but the impact is DoS only — Rust's slice bounds checking prevents any out-of-bounds write, so VMM-crafted offsets can only trigger a panic. Since the TDX threat model does not guarantee availability and the VMM already has unlimited DoS capability over any TD (scheduling control, interrupt withholding, VMCALL non-response), the panic does not grant the VMM any new security-relevant capability. The volatile read plus clamp is defense-in-depth that converts a crash into graceful recover |
| 8 | Low | Ok(0) infinite busy-loop in receive_pre_session_data defeats with_timeout | handle_pre_mig -> pre_session_data_exchange -> receive_hello_packet -> receive_pre_session_data -> TransportType::read | Treat n==0 as EOF: `if n==0 { return Err(NetworkError) }` after each read/write in the while loop. | weakness | The infinite busy-loop on EOF is a correctness bug that defeats the async timeout mechanism, but its impact is purely availability. The VMM controls the vsock transport layer and can simulate connection close at will, yet it already possesses unlimited DoS capability over MigTD through scheduling denial and VMCALL non-response. The fix converts an unrecoverable hang into a clean error return, which is good defensive coding, but does not block an attack class the adversary lacked before. |
| 9 | Low | Divide-by-zero on VMM-controlled CPUID.15H.EAX in schedule_timeout | init_sys_tick -> schedule_timeout -> __cpuid_count(0x15) | Validate cpuid.eax!=0 (and ebx/ecx sane) before division; fall back to a fixed TSC freq or return Err. | weakness | The finding is valid in that CPUID.15H is virtualized by the VMM in TDX and a malicious VMM could return eax=0, triggering a division-by-zero CPU exception in cpuid.ebx / cpuid.eax. However, the security impact is negligible: a VMM that wants to crash or DoS MigTD has countless other mechanisms (ignore VCALLs, corrupt shared memory, withhold interrupts, return garbage from any other virtualized interface). This check closes one specific crash vector but does not materially change the security posture. The fix is correct and cheap, but it is defensive hardening rather than a meaningful vulnerability remediation. |
| 10 | Medium | virtio_serial recv_control: handle_control_msg `?` returns before free_dma_memory | virtio_serial_device_init -> VirtioSerial::recv_control -> VirtioSerial::handle_control_msg | Move free_dma_memory before handle_control_msg, or capture result and free in all branches. | true_positive |  |
| 11 | Medium | .unwrap() on pci::find_device  --  VMM omits device -> boot panic | main -> init_devices -> virtio_vsock_device_init -> pci::find_device | Replace .unwrap()/.expect() with `?` propagating to a graceful init-failure report (panic_with_guest_crash_reg_report or Err). | weakness | he finding is valid in that pci::find_device can return None if VMM omits the expected device, and the original .unwrap() panicked without reporting the failure reason through guest crash registers. However, the security impact is negligible: a VMM that omits the required virtio device is effectively denying migration to itself, and the TD cannot continue without it — halting is the only correct outcome regardless. |
| 12 | Low | set_vmm_notification returns true after tdvmcall_setup_event_notify fails | get_quote -> servtd_get_quote -> set_vmm_notification -> tdvmcall_setup_event_notify | Return false on tdvmcall_setup_event_notify Err so caller falls back to polling path. | true_positive |  |
| 13 | Low | alloc_zeroed return not null-checked before FFI init_heap | main -> attest_init_heap -> alloc::alloc::alloc_zeroed -> init_heap | Check heap_base.is_null() and return None before calling init_heap. | weakness | The call executes at initialization before any VMM interaction or network input is processed, so no attacker-controlled path can influence memory pressure at this stage. Even if it somehow failed, the result would be an immediate null-pointer dereference inside the C init_heap FFI call, causing a deterministic crash with no exploitable window — no information leak, no control-flow hijack, no persistent state corruption. A crash at boot simply means MigTD never starts, which does not degrade the security posture of the user TD or leak migration keys. |
| 14 | Low | get_ccel .expect() panics if td-shim ACPI handoff lacks CCEL or has <4-byte entry | do_measurements -> get_event_log_mut -> get_ccel -> get_acpi_tables | Use t.get(..4)==Some(b"CCEL") and return None instead of .expect(). | weakness | The event_log_slice function previously called from_raw_parts_mut(ccel.lasa, ccel.laml) without validating the CCEL fields, which is technically undefined behavior if lasa is null or laml is unreasonably large. However, the CCEL ACPI table is created by td-shim (firmware), which is part of the TCB and measured into MRTD at boot. The VMM does not control lasa/laml — they are set by firmware when it allocates the event log area in TD private memory. The only scenario where these values would be invalid is a firmware bug, which already compromises the entire security model. |
| 15 | Low | VmcallServiceResponse::try_read validates length but never truncates stored slic | <entry> -> try_read | Slice input to &data[..length] before storing in VmcallServiceResponse. | weakness | The response buffer resides in shared memory fully controlled by the VMM. The VMM writes both the length field and all data bytes in the buffer. Without the truncation, the VMM could make MigTD parse data beyond the declared length — but since the VMM also placed that data there, it gains no additional capability it did not already have by simply declaring a larger length. The fix enforces GHCI protocol framing discipline but does not block any attack that the VMM could not already perform through the legitimate protocol interface. |
| 16 | High | event_log_slice builds &'static mut [u8] from ACPI CCEL lasa/laml unvalidated | <entry> -> event_log_slice | Validate lasa/laml against td-shim memory map; cache slice in OnceCell to avoid aliasing; fix [..size+1] to [..size]. | weakness | The lasa and laml values come from the CCEL ACPI table created by td-shim, which is measured firmware in the TCB — the VMM cannot control or modify them because they reside in TD private memory. A null lasa would require a td-shim bug, which would change the MRTD measurement and be rejected by policy. The check prevents undefined behavior (null slice construction) only in the hypothetical case of a faulty firmware, making it pure defense-in-depth with no realistic attack path. |
| 17 | Low | get_ccel .expect() panics if ACPI CCEL absent or table <4 bytes | <entry> -> get_ccel | Return Option/Result; caller degrades gracefully (skip event-log feature) instead of panic. | weakness | The CCEL ACPI table is created by td-shim firmware, which is part of the TCB and measured into MRTD at boot. Its absence or a sub-4-byte ACPI table entry would indicate a firmware bug, not a VMM attack — the VMM cannot inject or remove ACPI tables from TD private memory after launch. The fix improves error handling quality (graceful None propagation instead of a bare panic without crash-register reporting), but does not close an attacker-reachable vulnerability. On any correctly-configured production system the .expect() would never fire; the improvement is purely in debuggability and robustness against hypothetical firmware defects. |
| 18 | Medium | vsock Packet::check validates header len but not data_len vs buffer | <entry> -> check | In check(), require HEADER_LEN+data_len()<=buf.len(); return Err otherwise. | true_positive |  |
| 19 | Low | vsock credit counters rx_cnt/tx_cnt unchecked u32 add (wrap) | <entry> -> recv_packet_connected | Use wrapping_add intentionally per virtio-vsock spec, but move rx_cnt update AFTER data_len<=recv.len() check. | true_positive |  |
| 20 | Medium | virtio_dump trusts host PCI cap bytes -> panic / infinite loop / u8 wrap | <entry> -> common_addr | Bound bar<6, return Err on unknown BAR type, cap iteration with visited-set/limit, use checked_add, clamp queue_size<=128. | true_positive |  |
| 21 | Low | get_fmspc_from_quote: PEM substring search panics; full-quote utf8_lossy heap co | <entry> -> get_fmspc_from_quote | Check start<end before slice; search bytes directly instead of utf8_lossy. | weakness | The original unchecked addition start_index + i + PEM_CERT_END.len() could only panic on integer overflow (debug mode) or wrap around causing an invalid slice range panic. Both outcomes are denial-of-service. The quote input arrives from the VMM-controlled QGS (Quote Generation Service) over a VMM-mediated channel, so the VMM already has full DoS capability — it can simply refuse to deliver quotes, kill the vsock connection, or deny scheduling. The fix improves robustness by converting a panic into a clean error return, but the original code granted the attacker no new capability beyond what VMM scheduling denial already provides. No confidentiality or integrity impact. |
| 22 | Low | ecdsa_sign .unwrap() on EcdsaKeyPair::from_pkcs8 | <entry> -> ecdsa_sign | Propagate Err instead of unwrap. | weakness | The ecdsa_sign function is only called from json-signer, which is a build-time offline tool — not part of the MigTD runtime. A malformed PKCS8 key would panic the signing tool during policy generation, not crash the TD during migration. The fix (replacing unwrap with map_err/?) is good defensive coding for a library API that accepts arbitrary &[u8], but there is no security impact because no untrusted input reaches this path at runtime and the tool is not part of the TCB. |
| 23 | Medium | TlsClientConnection::read drops payload + skips discard accounting when buffer f | <entry> -> TlsClientConnection::read | Back-pressure (return Pending) instead of dropping; always accumulate discard. | true_positive |  |
| 24 | Medium | transport.write() Ok(n) discarded -> short-write silently truncates | <entry> -> TlsServerConnection::write | Loop write_all until full buffer sent; propagate actual byte count. | true_positive |  |
| 25 | Low | servtd_get_quote: len/0x1000 floor-div truncates non-aligned len | <entry> -> servtd_get_quote | Use (len+0xFFF)/0x1000 or div_ceil. | true_positive |  |
| 26 | Medium | ghci status_code polled via non-volatile &[u8] read on shared page | <entry> -> wait_for_quote_completion | Use core::ptr::read_volatile on the status bytes inside the loop. | true_positive |  |
| 27 | Low | get_quote passes constant TD_REPORT_SIZE not td_report.len() to FFI | <entry> -> get_quote | Pass td_report.len() and assert ==TD_REPORT_SIZE. | weakness | get_quote passes constant TD_REPORT_SIZE not td_report.len() to FFI) is Low because the check guards an FFI boundary where the C function expects exactly TD_REPORT_SIZE bytes, but the only caller (gen_quote_spdm) passes tdcall_report().as_bytes() — a compile-time-fixed struct whose size is by definition equal to TD_REPORT_SIZE. No attacker-controlled input determines the slice length; it comes from a CPU TDCALL instruction returning a hardware-defined struct. The check cannot fire under any reachable execution path today. It exists purely as defense-in-depth to catch future misuse of the public get_quote() API by a hypothetical caller passing an arbitrary slice, and even if triggered it returns Err(GetQuote) — fail-closed with no security impact. |
| 28 | Low | ROOT_CA_PUBLIC_KEY.get().unwrap() panics if Once<> uninitialized | <entry> -> verify_quote | Return Err(RootCaNotSet) instead of unwrap. | weakness | The ROOT_CA_PUBLIC_KEY global is initialized by set_ca() during boot in both configuration paths: get_ca_and_measure() (non-policy_v2) and init_policy() (policy_v2). Both panic on failure, so boot never completes without successful initialization. All 15 production call sites that read this global — across SPDM, RATLS, and rebinding flows — are only reachable after boot completes. The sole configuration where set_ca() is skipped (test_disable_ra_and_accept_all) also compiles out every caller of verify_quote/verify_quote_with_collaterals behind matching cfg guards, making the None state unreachable in any coherent build. |
| 29 | Medium | verify_quote_with_collaterals lacks report_verify_size check sibling has | <entry> -> verify_quote_with_collaterals | Add same report_verify_size!=TD_VERIFIED_REPORT_SIZE -> Err check. | weakness | The check validates output from verify_quote_integrity_ex, a statically-linked C library measured in the same MRTD (same TCB). On success, it always produces a fixed 822-byte structure — the size is not externally controllable. If the library returns success with a wrong size, the library itself is broken and the entire verification result is untrustworthy regardless. The fix adds a development-time sanity assertion for version mismatch detection, not a security boundary. No attacker can influence the output size without first compromising the TCB. |
| 30 | Low | get_quote_igvm casts Vec<u8> ptr (align=1) to *mut ServtdTdxQuoteHdr (align=8) a | <entry> -> get_quote_igvm | Use read_unaligned or allocate with proper alignment. | weakness | The buffer originates from vec![0u8; SERVTD_REQ_BUF_SIZE] which is allocated by the global allocator. Rust's allocator guarantees minimum alignment of align_of::<usize>() (8 bytes on 64-bit), which matches align_of::<ServtdTdxQuoteHdr>() (also 8, due to u64 fields). The cast is therefore always correctly aligned in practice and no attacker can influence the alignment of a heap allocation. The fix (a debug_assert!) only documents this invariant for development builds and provides no runtime protection in release. This is a formal soundness concern under Rust's strict aliasing model, not an exploitable vulnerability. |
| 31 | High | MemoryRegion::as_slice/as_mut_slice compare element-count to byte-length | <entry> -> MemoryRegion::as_mut_slice | Compare offset+length*size_of::<T>() <= self.length. | weakness | The bounds check had a genuine unit mismatch bug (comparing element count to byte length), which would allow creating an out-of-bounds slice when sizeof(T) > 1. However, both as_slice and as_mut_slice are dead code — they have zero callers in the entire codebase (the file is annotated #![allow(dead_code)]). |
| 32 | High | PCI BAR raw VMM address stored when get_bar_size()==0 or IoSpace | <entry> -> PciDevice::init | Reject size==0 BARs; never store raw host BAR addr  --  always route through alloc_mmio* or reject. | true_positive |  |
| 33 | Medium | get_bar_size: !(size&0xFFFFFFF0)+1 wraps u32->0 when host returns size in 1..=0xF | <entry> -> PciDevice::get_bar_size | Mask first, check ==0, then use wrapping_neg or explicit (!x).wrapping_add(1) with zero-check. | weakness | A hostile VMM supplying 0x1..=0xF would just result in size 0 and the BAR being treated as unimplemented — no actual exploit. The fix improves correctness and clarity but the old code was not exploitable in production. |
| 34 | Medium | alloc_mmio64 lacks upper-bound check; init_mmio overlap check can wrap | <entry> -> alloc_mmio64 | Add MMIO64_START+MMIO64_SIZE bound; use checked_add in init_mmio overlap test. | weakness | The old code used plain + which in release mode wraps on overflow and in debug mode panics, but the operands come from trusted sources: MMIO constants are small compile-time values that cannot overflow u64, and the memory map is populated from TD-Shim HOBs during early trusted initialization with physical addresses limited to 52 bits on x86. No realistic input can trigger the overflow. The saturating_add change improves defensive coding style but does not fix an exploitable or reachable bug. |
| 35 | Low | virtio_serial enqueue indexes self.queues with unchecked port_id | <entry> -> VirtioSerial::enqueue | Validate port_id<MAX_PORT_SUPPORTED at entry; return Err. | true_positive |  |
| 36 | High | vmcall_raw `let _ = Poll::Ready(Err(...))` constructs error then discards it | <entry> -> vmcall_service_migtd_send | Change to `return Poll::Ready(Err(VmcallRawError::Illegal));` in both send and receive. | true_positive |  |
| 37 | Info | port_queue_index: 2+(port_id as u16)*2 wraps u16 for port_id>=32767 | handle_control_msg -> enqueue -> port_queue_index | Use checked arithmetic: 2u16.checked_add((port_id as u16).checked_mul(2)?)? or assert port_id < MAX_PORT_SUPPORTED inside port_queue_index. | weakness | The overflow path is currently unreachable because all callers cap port_id to {0,1} via the handle_control_msg guard at line 530. The saturating arithmetic alone does not produce a correct index for large values — it merely prevents silent wraparound. This is defense-in-depth hardening against a theoretical future regression, not an exploitable bug today. |
| 38 | Low | Slice index panic on VMM-controlled response length: Response::new() (vmcall.rs: |  | Review the finding context and add appropriate input validation or guard checks. | weakness | The reply.data()[0], reply.data()[1], and reply.data()[4..12] accesses can panic if the VMM returns a response with length == 24 (valid per Response::new() but leaving data() empty). The impact is exclusively a panic (DoS). The response buffer resides in shared memory fully controlled by the VMM, which already has unlimited DoS capability over MigTD through scheduling denial, VMCALL non-response, or simply returning VMCALL_STATUS_RESERVED indefinitely. |
