### PR TITLE
fix(deps): apply security fixes to td-shim-AzCVMEmu

### DIFF
--- a/deps/td-shim-AzCVMEmu/td-payload-emu/src/arch/idt/mod.rs
+++ b/deps/td-shim-AzCVMEmu/td-payload-emu/src/arch/idt/mod.rs
@@ -5,6 +5,8 @@
 use interrupt_emu as intr;
 pub use intr::InterruptStack;
 
+const IDT_ENTRY_COUNT: usize = u8::MAX as usize + 1;
+
 #[derive(Copy, Clone)]
 pub struct InterruptCallback(fn(&mut InterruptStack));
 
@@ -18,6 +20,10 @@ impl InterruptCallback {
 }
 
 pub fn register_interrupt_callback(vector: usize, cb: InterruptCallback) -> Result<(), ()> {
+    // Validate vector fits in u8 for the IDT registry.
+    if vector >= IDT_ENTRY_COUNT {
+        return Err(());
+    }
     // Store raw fn into interrupt-emu registry
     intr::register(vector as u8, cb.0);
     Ok(())

--- a/deps/td-shim-AzCVMEmu/td-payload-emu/src/mm/shared/mod.rs
+++ b/deps/td-shim-AzCVMEmu/td-payload-emu/src/mm/shared/mod.rs
@@ -4,9 +4,17 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use alloc::boxed::Box;
+use alloc::collections::BTreeMap;
 use alloc::vec::Vec;
+use spin::Mutex;
 
 const PAGE_SIZE: usize = 0x1000;
+
+/// Records the exact byte size allocated for each shared-page address so that
+/// `free_shared_pages` deallocates with the original `Layout` rather than one
+/// reconstructed from a caller-supplied page count (a mismatch would cause
+/// allocator UB).
+static SHARED_ALLOC_SIZES: Mutex<BTreeMap<usize, usize>> = Mutex::new(BTreeMap::new());
 
 pub struct SharedMemory {
     buf: Vec<u8>,
@@ -47,7 +55,9 @@ pub unsafe fn alloc_shared_pages(num: usize) -> Option<usize> {
     let size = PAGE_SIZE.checked_mul(num)?;
     let buf = Vec::from_iter(core::iter::repeat(0u8).take(size)).into_boxed_slice();
     let ptr = Box::into_raw(buf) as *mut u8;
-    Some(ptr as usize)
+    let addr = ptr as usize;
+    SHARED_ALLOC_SIZES.lock().insert(addr, size);
+    Some(addr)
 }
 
 /// Allocate a single shared page in emulation mode
@@ -59,9 +69,24 @@ pub unsafe fn alloc_shared_page() -> Option<usize> {
 
 /// Free shared pages allocated in emulation mode
 /// # Safety
-/// The caller needs to ensure the correctness of the addr and page num
+/// The caller needs to ensure the correctness of the addr. The dealloc size is
+/// taken from the size recorded at allocation time, so it always matches the
+/// original `Layout`; `num` is used only as a consistency check.
 pub unsafe fn free_shared_pages(addr: usize, num: usize) {
-    let size = PAGE_SIZE.checked_mul(num).expect("Invalid page num");
+    // An unknown address means a double-free or a free of an unowned pointer:
+    // fail fast rather than silently masking allocator misuse.
+    let size = SHARED_ALLOC_SIZES
+        .lock()
+        .remove(&addr)
+        .unwrap_or_else(|| panic!("free_shared_pages: unknown addr {:#x}", addr));
+    // `size` is always a multiple of PAGE_SIZE, so this division is exact and
+    // cannot overflow. A mismatch means the caller passed a wrong page count.
+    assert_eq!(
+        num,
+        size / PAGE_SIZE,
+        "free_shared_pages: page count mismatch for {:#x}",
+        addr
+    );
     let ptr = addr as *mut u8;
     let _ = Box::from_raw(core::slice::from_raw_parts_mut(ptr, size));
 }

--- a/deps/td-shim-AzCVMEmu/tdx-tdcall/src/tdx_emu.rs
+++ b/deps/td-shim-AzCVMEmu/tdx-tdcall/src/tdx_emu.rs
@@ -1063,6 +1063,12 @@ pub fn tdcall_servtd_rebind_approve(
     rebind_session_token: &[u8],
     target_td_uuid: &[u64],
 ) -> Result<[u64; 4], TdCallError> {
+    if target_td_uuid.len() != 4 {
+        return Err(TdCallError::TdxExitInvalidParameters);
+    }
+    if rebind_session_token.len() != 32 {
+        return Err(TdCallError::TdxExitInvalidParameters);
+    }
     warn!(
         "AzCVMEmu: tdcall_servtd_rebind_approve emulated: old_binding_hanlde=0x{:x} target_td_uuid= 0x{:x?}",
         old_binding_handle, target_td_uuid


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Low | tdcall_servtd_rebind_approve indexes target_td_uuid/token without length check | <entry> -> tdcall_servtd_rebind_approve | Use .get(..) and return Err on short slices. | weakness | The defect is real; the emulated tdcall_servtd_rebind_approve indexes target_td_uuid[0..3] and run copy_from_slice(&rebind_session_token[..32]) with no length check, so a slice shorter than 4 u64 or 32 bytes panics (CWE-248). But it is not an exploitable true positive. This is AzCVMEmu emulation code, outside the production TDX TCB — in the shipped product this call is a hardware TDCALL, and the production wrapper in tdx.rs:952-958 already validates both lengths (target_td_uuid.len() != 4 \|\| rebind_session_token.len() != REBIND_SESSION_TOKEN_SIZE) and returns Err before any indexing. |
| 2 | Medium | free_shared_pages: Box::from_raw with caller-supplied num  --  Layout mismatch + ov | <entry> -> free_shared_pages | Store original Layout alongside allocation; dealloc with that. Return Err on overflow. | weakness | Split the finding into its two claims. The "panic on huge num" via checked_mul(num).expect() is a false positive: num is never attacker-chosen. It is derived internally as dma_size / PAGE_SIZE, and dma_size = align_up(buf.len()) where buf.len() is hard-capped at MAX_VSOCK_PKT_DATA_LEN (64 KiB) by the enqueue guard, so num ≤ 16 and 0x1000 * 16 cannot overflow usize. The huge-num path is mathematically unreachable.<br><br>The "Layout mismatch → heap UB" half is a real defect but only a weakness, not the T1/MUST-FIX it is labeled. Reconstructing the dealloc Box from the caller's num instead of the recorded allocation size is a genuine footgun in an unsafe fn, but it only bites if some caller frees with a different count than it allocated. No in-tree caller does that — every path (the vsock Allocator, and virtio_pci storing dma_size and freeing with dma_size / PAGE_SIZE) is self-consistent. Crucially, the VMM does not control the free num; it controls bounded packet contents/lengths, while the page count is internal allocation bookkeeping. So the "directly reachable from untrusted VMM / oob_write" tag is overstated. This is also emulation-only code (td-payload-emu), outside the production TDX TCB. |
| 3 | Low | register_interrupt_callback truncates usize vector to u8 | <entry> -> register_interrupt_callback | Change parameter type to u8 or assert vector<256. | weakness | The vector parameter is always supplied by MigTD's own code (hardcoded interrupt vector constants passed to register_interrupt_callback), not by any external or VMM-controlled input. The truncation from usize to u8 is only dangerous if a caller passes a value ≥ 256, which no current caller does. The guard converts a hypothetical future misuse into a clean error return rather than silent index wraparound, but today the dangerous path is unreachable — making this defense-in-depth hardening, not remediation of an exploitable vulnerability. |