### PR TITLE
fix(virtio/mem): reject BAR regions overlapping TD private DRAM

### DIFF
--- a/src/devices/pci/src/mmio.rs
+++ b/src/devices/pci/src/mmio.rs
@@ -38,6 +38,39 @@ pub fn init_mmio() {
     *MMIO64.lock() = MMIO64_START;
 }
 
+/// Device MMIO is never allowed to live below 1 MiB. That range is reserved
+/// for legacy low memory and is not a valid MMIO aperture.
+pub const MMIO_LOW_LIMIT: u64 = 0x10_0000;
+
+/// Returns `true` if `[base, base + length)` hits RAM or the low 1 MiB.
+/// Defense in depth for host-controlled BARs.
+pub fn region_overlaps_private_dram(base: u64, length: u64) -> bool {
+    let end = match base.checked_add(length) {
+        Some(end) => end,
+        None => return true,
+    };
+
+    if base < MMIO_LOW_LIMIT {
+        return true;
+    }
+
+    let memory_map = MEMORY_MAP.lock();
+    for region in memory_map.iter() {
+        let region_end = match region.addr.checked_add(region.size) {
+            Some(region_end) => region_end,
+            None => return true,
+        };
+
+        // Overlap test for the half-open intervals [base, end) and
+        // [region.addr, region_end).
+        if base < region_end && end > region.addr {
+            return true;
+        }
+    }
+
+    false
+}
+
 #[cfg(feature = "fuzz")]
 pub fn alloc_mmio32(size: u32) -> Result<u32> {
     let cur = *MMIO_OFFSET.lock();

--- a/src/devices/virtio/src/mem.rs
+++ b/src/devices/virtio/src/mem.rs
@@ -33,6 +33,12 @@ impl MemoryRegion {
     pub fn new(base: u64, length: u64) -> Option<MemoryRegion> {
         let _ = base.checked_add(length)?;
 
+        // Reject host-controlled BARs that hit private DRAM or the low 1 MiB.
+        #[cfg(not(feature = "fuzz"))]
+        if pci::region_overlaps_private_dram(base, length) {
+            return None;
+        }
+
         Some(MemoryRegion { base, length })
     }
 


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Medium | INV-4 violated: BAR-derived MemoryRegion never checked vs TD private DRAM | VirtioVsock::new -> VirtioPciTransport::init -> mem::MemoryRegion::new \| src/devices/virtio/src/mem.rs (MemoryRegion::new); BAR parse in src/devices/vsock/src/transport/virtio_pci.rs | Add td_private_range() lookup in MemoryRegion::new; reject if [base,base+length) intersects TD private DRAM or is below 1MiB. Enforce regardless of tdcall feature. | weakness | For the shipped tdcall build every BAR-derived region (self.region, notify_region, msix_table) is only ever accessed through mmio_read_*/mmio_write_*, which under tdcall route the access through tdvmcall_mmio_read/write. That means the VMM performs the operation, not the guest CPU, and the VMM already cannot touch MigTD private DRAM under TDX. So pointing a BAR at a private GPA gains the attacker nothing new: writes never corrupt private memory and reads only return data the VMM already controls as the device emulator. The residual concern is purely defense-in-depth: MemoryRegion still exposes raw-deref accessors (as_bytes, as_slice, read, write) that ignore the tdcall feature, but no current path uses them on a BAR region, so it is not reachable today. |