### PR TITLE
fix(migtd): wipe migration key material from TLS and SPDM buffers

### DIFF
--- a/src/crypto/src/rustls_impl/tls.rs
+++ b/src/crypto/src/rustls_impl/tls.rs
@@ -393,6 +393,7 @@ pub(crate) mod connection {
         },
         ClientConfig, ServerConfig,
     };
+    use zeroize::Zeroize;
 
     pub const PAGE_SIZE: usize = 0x1000;
     pub const TLS_BUFFER_SIZE: usize = 16 * PAGE_SIZE;
@@ -493,6 +494,8 @@ pub(crate) mod connection {
 
         // Reset the used
         pub fn reset(&mut self) {
+            // Zeroize plaintext before clearing the buffer.
+            self.inner[..self.used].zeroize();
             self.used = 0;
         }
 
@@ -503,8 +506,18 @@ pub(crate) mod connection {
 
         // Discard the first `size` bytes
         pub fn discard(&mut self, size: usize) {
+            let old_used = self.used;
             self.inner.copy_within(size..self.used, 0);
             self.used -= size;
+            // Wipe the vacated tail.
+            self.inner[self.used..old_used].zeroize();
+        }
+    }
+
+    impl Drop for TlsBuffer {
+        fn drop(&mut self) {
+            // Zeroize the backing allocation on drop.
+            self.inner.zeroize();
         }
     }
 
@@ -762,12 +775,25 @@ pub(crate) mod connection {
         fn consume(&mut self, mut used: usize) {
             while let Some(mut buf) = self.chunks.pop_front() {
                 if used < buf.len() {
+                    // Wipe the consumed prefix.
+                    buf[..used].zeroize();
                     buf.drain(..used);
                     self.chunks.push_front(buf);
                     break;
                 } else {
                     used -= buf.len();
+                    // Zeroize the fully consumed chunk.
+                    buf.zeroize();
                 }
+            }
+        }
+    }
+
+    impl Drop for ChunkVecBuffer {
+        fn drop(&mut self) {
+            // Zeroize unread buffered plaintext on drop.
+            for chunk in &mut self.chunks {
+                chunk.zeroize();
             }
         }
     }

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -94,11 +94,25 @@ lazy_static! {
     pub static ref REQUESTS: Mutex<BTreeSet<u64>> = Mutex::new(BTreeSet::new());
 }
 
+#[repr(C)]
 #[derive(Default)]
 pub struct ExchangeInformation {
+    pub key: MigrationSessionKey,
     pub min_ver: u16,
     pub max_ver: u16,
-    pub key: MigrationSessionKey,
+    // Explicit zeroed padding field.
+    pub reserved: [u8; 4],
+}
+
+impl ExchangeInformation {
+    fn validate(&self) -> Result<()> {
+        if self.reserved != [0; 4] {
+            log::error!("ExchangeInformation::validate: reserved field must be zero\n");
+            return Err(MigrationResult::InvalidParameter);
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(not(feature = "spdm_attestation"))]
@@ -863,6 +877,7 @@ async fn migration_src_exchange_msk(
         log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk(): Incorrect ExchangeInformation size Size - Expected: {} Actual: {}\n", size_of::<ExchangeInformation>(), size);
         return Err(MigrationResult::NetworkError);
     }
+    remote_information.validate()?;
     shutdown_transport(ratls_client.transport_mut(), info.mig_info.mig_request_id).await?;
     Ok(())
 }
@@ -924,6 +939,7 @@ async fn migration_dst_exchange_msk(
         log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk(): Incorrect ExchangeInformation size. Size - Expected: {} Actual: {}\n", size_of::<ExchangeInformation>(), size);
         return Err(MigrationResult::NetworkError);
     }
+    remote_information.validate()?;
     shutdown_transport(ratls_server.transport_mut(), info.mig_info.mig_request_id).await?;
     Ok(())
 }
@@ -1293,6 +1309,19 @@ mod test {
     use crate::migration::{session::cal_mig_version, MigrationResult};
 
     use super::ExchangeInformation;
+
+    #[test]
+    fn test_exchange_information_validate_rejects_non_zero_reserved() {
+        let mut info = ExchangeInformation::default();
+
+        assert!(info.validate().is_ok());
+
+        info.reserved = [1, 0, 0, 0];
+        assert!(matches!(
+            info.validate(),
+            Err(MigrationResult::InvalidParameter)
+        ));
+    }
 
     #[test]
     fn test_cal_mig_version() {

--- a/src/migtd/src/spdm/spdm_rebind.rs
+++ b/src/migtd/src/spdm/spdm_rebind.rs
@@ -83,6 +83,20 @@ pub async fn spdm_responder_rebind_new<'a>(
     spdm_responder_ex.peer_data = peer_data;
     spdm_responder_ex.info = ResponderContextExInfo::RebindInformation(rebind_info);
 
+    // Zeroize the responder key buffer on every return path.
+    let result = spdm_responder_rebind_new_inner(spdm_responder_ex).await;
+    spdm_responder_ex
+        .responder_context
+        .common
+        .app_context_data_buffer
+        .zeroize();
+
+    result
+}
+
+async fn spdm_responder_rebind_new_inner(
+    spdm_responder_ex: &mut ResponderContextEx<'_>,
+) -> Result<(), SpdmStatus> {
     let spdm_responder = &mut spdm_responder_ex.responder_context;
     let mut writer = Writer::init(&mut spdm_responder.common.app_context_data_buffer);
 
@@ -94,8 +108,5 @@ pub async fn spdm_responder_rebind_new<'a>(
         .encode(&mut writer)
         .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
 
-    Box::pin(rsp_handle_message(spdm_responder)).await?;
-    spdm_responder.common.app_context_data_buffer.zeroize();
-
-    Ok(())
+    Box::pin(rsp_handle_message(spdm_responder)).await
 }

--- a/src/migtd/src/spdm/spdm_req.rs
+++ b/src/migtd/src/spdm/spdm_req.rs
@@ -910,6 +910,7 @@ async fn send_and_receive_sdm_exchange_migration_info(
     let remote_information = ExchangeInformation {
         min_ver: min_import_version,
         max_ver: max_import_version,
+        reserved: [0u8; 4],
         key: MigrationSessionKey {
             fields: <[u64; 4]>::read(reader).ok_or(SPDM_STATUS_INVALID_MSG_SIZE)?,
         },

--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -157,6 +157,21 @@ pub async fn spdm_responder_transfer_msk(
 
     spdm_responder_ex.peer_data = peer_data;
 
+    // Zeroize the responder key buffer on every return path.
+    let result = spdm_responder_transfer_msk_inner(spdm_responder_ex, mig_info).await;
+    spdm_responder_ex
+        .responder_context
+        .common
+        .app_context_data_buffer
+        .zeroize();
+
+    result
+}
+
+async fn spdm_responder_transfer_msk_inner(
+    spdm_responder_ex: &mut ResponderContextEx<'_>,
+    mig_info: &MigtdMigrationInformation,
+) -> Result<(), SpdmStatus> {
     let spdm_responder = &mut spdm_responder_ex.responder_context;
     let mut writer = Writer::init(&mut spdm_responder.common.app_context_data_buffer);
 
@@ -168,10 +183,7 @@ pub async fn spdm_responder_transfer_msk(
         .encode(&mut writer)
         .map_err(|_| SPDM_STATUS_BUFFER_FULL)?;
 
-    Box::pin(rsp_handle_message(spdm_responder)).await?;
-    spdm_responder.common.app_context_data_buffer.zeroize();
-
-    Ok(())
+    Box::pin(rsp_handle_message(spdm_responder)).await
 }
 
 pub async fn rsp_handle_message(spdm_responder: &mut ResponderContext) -> Result<(), SpdmStatus> {
@@ -861,6 +873,7 @@ pub fn handle_exchange_mig_info_req(
     let remote_information = ExchangeInformation {
         min_ver: min_export_version,
         max_ver: max_export_version,
+        reserved: [0u8; 4],
         key: MigrationSessionKey {
             fields: <[u64; 4]>::read(reader).ok_or(SPDM_STATUS_INVALID_MSG_SIZE)?,
         },


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Medium | ExchangeInformation::as_bytes leaks 4B uninit padding to remote peer over TLS | exchange_msk -> exchange_info -> ExchangeInformation::as_bytes -> ratls_write | Add #[repr(C)] and zero-init via Default/zeroed(); or serialise field-by-field. | true_positive | Because #[derive(Default)] only initializes the named fields and size_of::<Self>() includes the alignment padding, from_raw_parts reads those bytes off the stack and ratls_client.write() sends them to the peer, which is a genuine CWE-908 uninitialized-memory disclosure. The severity is genuinely low, since the recipient is an already-attested, authenticated peer MigTD and the leaked bytes are version-adjacent padding rather than key material, but it is a real leak and not a false positive. |
| 2 | Medium | TLS plaintext buffers retain decrypted MSK after session  --  no zeroize on drop | exchange_msk -> SecureChannel::read -> TlsConnection::read -> ChunkVecBuffer::consume | impl Drop for ChunkVecBuffer/TlsBuffer that zeroizes inner Vec; or wrap in Zeroizing<Vec<u8>>. | true_positive | The decrypted MSK genuinely flows through two plaintext buffers that were never wiped: rustls decrypts records in place inside input: TlsBuffer (whose reset() only set used = 0 and discard() left stale plaintext in the tail, with no Drop), and received_app_data: ChunkVecBuffer stores payload.to_vec() copies that consume() dropped via pop_front()/drain() without zeroizing. So the 32-byte AES-256 key really did linger in freed heap and buffer tails, which is a real CWE-226, and it is inconsistent with the project's own intent since MigrationSessionKey already derives Zeroize/ZeroizeOnDrop.<br><br>MigTD's heap is TD-private encrypted memory the VMM cannot read, and virtio descriptors point at shared memory, so exploitation needs a separate in-TD memory-read primitive — making this defense-in-depth (effectively T4) rather than remotely reachable |
| 3 | Medium | app_context_data_buffer.zeroize() skipped on peer-triggered error path | spdm_responder_transfer_msk -> rsp_handle_message | Use a scopeguard/defer or Zeroizing<> wrapper so zeroize runs on all exit paths including `?`. | true_positive | In spdm_rsp.rs:150 the ? on rsp_handle_message(spdm_responder).await? genuinely returns before the app_context_data_buffer.zeroize() on the next line, so a peer that drives the responder into an Err after libspdm's signing callback has written the ephemeral RA-TLS private key into that buffer leaves the key material un-wiped, which is a real CWE-460 missing-cleanup. It is clearly a defect rather than intended behavior, because the codebase already applies the correct wrapper/inner pattern with unconditional zeroize for the requester in spdm_rebind.rs:24, and the same bug exists a second time in spdm_responder_rebind_new, so it is an inconsistency the authors simply missed on the responder side. One technical correction to the finding: at the encode() call the buffer holds PrivateKeyDer::default() (empty), not the P-384 key; the real key only enters the buffer later when libspdm's signing callback runs during message handling, so the leak window is during rsp_handle_message, but the mechanism and the fix still hold. |