### PR TITLE
fix(migtd): harden virtqueue, vsock, SPDM and policy against untruste…

### DIFF
--- a/deps/td-shim-AzCVMEmu/td-payload-emu/src/mm/shared/mod.rs
+++ b/deps/td-shim-AzCVMEmu/td-payload-emu/src/mm/shared/mod.rs
@@ -18,6 +18,7 @@ static SHARED_ALLOC_SIZES: Mutex<BTreeMap<usize, usize>> = Mutex::new(BTreeMap::
 
 pub struct SharedMemory {
     buf: Vec<u8>,
+    shadow: Vec<u8>,
 }
 
 impl SharedMemory {
@@ -29,6 +30,7 @@ impl SharedMemory {
         let size = pages.checked_mul(4096)?;
         Some(Self {
             buf: Vec::from_iter(core::iter::repeat(0u8).take(size)),
+            shadow: Vec::new(),
         })
     }
 
@@ -42,9 +44,11 @@ impl SharedMemory {
     }
 
     pub fn copy_to_private_shadow(&mut self) -> Option<&[u8]> {
-        // In emulation mode, just return the buffer directly since we're not dealing with
-        // actual shared/private memory conversion like in real TDX
-        Some(&self.buf)
+        // Copy into a separate shadow buffer so the returned slice is an immutable
+        // snapshot, matching the real td-payload shared->private memcpy semantics.
+        self.shadow.clear();
+        self.shadow.extend_from_slice(&self.buf);
+        Some(&self.shadow)
     }
 }
 

--- a/src/devices/vsock/src/stream.rs
+++ b/src/devices/vsock/src/stream.rs
@@ -109,11 +109,11 @@ impl VsockStream {
     }
 
     pub fn bind(&mut self, addr: &VsockAddr) -> Result {
-        if USED_PORT.lock().contains(&addr.port()) {
+        let mut used_port = USED_PORT.lock();
+        if !used_port.insert(addr.port()) {
             return Err(VsockError::AddressAlreadyUsed);
         }
-
-        USED_PORT.lock().insert(addr.port());
+        drop(used_port);
         self.addr.local.set_port(addr.port);
         Ok(())
     }
@@ -457,14 +457,16 @@ lazy_static! {
 }
 
 pub fn get_unused_port() -> Option<u32> {
-    let mut port = UNUSED_PORT_COUNTER.lock().checked_add(1)?;
+    let mut counter = UNUSED_PORT_COUNTER.lock();
+    let mut used_port = USED_PORT.lock();
+    let mut port = counter.checked_add(1)?;
 
-    while USED_PORT.lock().contains(&port) {
+    while used_port.contains(&port) {
         port = port.checked_add(1)?;
     }
 
-    USED_PORT.lock().insert(port);
-    *UNUSED_PORT_COUNTER.lock() = port;
+    used_port.insert(port);
+    *counter = port;
 
     Some(port)
 }

--- a/src/migtd/src/mig_policy.rs
+++ b/src/migtd/src/mig_policy.rs
@@ -286,16 +286,12 @@ mod v2 {
         let servtd_ext_src_obj =
             ServtdExt::read_from_bytes(servtd_ext_src).ok_or(PolicyError::InvalidParameter)?;
         let init_td_info = verify_init_tdinfo(init_tdinfo, &servtd_ext_src_obj)?;
-        let _engine_svn = policy
-            .servtd_tcb_mapping
-            .get_engine_svn_by_measurements(&Measurements::new_from_bytes(
-                &init_td_info.mrtd,
-                &init_td_info.rtmr0,
-                &init_td_info.rtmr1,
-                None,
-                None,
-            ))
-            .ok_or(PolicyError::SvnMismatch)?;
+
+        // migtdengine check: enginesvnsrc >= enginesvninit
+        policy.servtd_tcb_mapping.check_engine_not_older(
+            &engine_measurements_of(&tdx_report.td_info),
+            &engine_measurements_of(&init_td_info),
+        )?;
 
         // If backward policy exists, evaluate the migration src based on it.
         let relative_reference = get_local_tcb_evaluation_info()?;
@@ -541,6 +537,16 @@ mod v2 {
             u64::from_le_bytes(servtd_ext.init_attr),
             &servtd_ext.init_servtd_info_hash,
         )
+    }
+
+    /// `getengineinfo` measurement scope: the design guide classifies a MigTD
+    /// engine by `mrtd||rtmr[0-1]` only.
+    fn engine_measurements(mrtd: &[u8], rtmr0: &[u8], rtmr1: &[u8]) -> Measurements {
+        Measurements::new_from_bytes(mrtd, rtmr0, rtmr1, None, None)
+    }
+
+    fn engine_measurements_of(td_info: &TdInfo) -> Measurements {
+        engine_measurements(&td_info.mrtd, &td_info.rtmr0, &td_info.rtmr1)
     }
 
     fn get_rtmrs_from_tdinfo(
@@ -891,17 +897,18 @@ mod v2 {
                 ServtdExt::read_from_bytes(servtd_ext_src).ok_or(PolicyError::InvalidParameter)?;
             let init_td_info = verify_init_tdinfo(init_tdinfo, &servtd_ext_obj)?;
 
-            // Allowlist gate: init MigTD measurements must be in servtd_tcb_mapping
-            let _engine_svn = policy
+            let slice = |range: core::ops::Range<usize>| {
+                suppl_data.get(range).ok_or(PolicyError::InvalidParameter)
+            };
+            let peer = engine_measurements(
+                slice(Report::R_MIGTD_MRTD)?,
+                slice(Report::R_MIGTD_RTMR0)?,
+                slice(Report::R_MIGTD_RTMR1)?,
+            );
+            // migtdengine check: enginesvnsrc >= enginesvninit
+            policy
                 .servtd_tcb_mapping
-                .get_engine_svn_by_measurements(&Measurements::new_from_bytes(
-                    &init_td_info.mrtd,
-                    &init_td_info.rtmr0,
-                    &init_td_info.rtmr1,
-                    None,
-                    None,
-                ))
-                .ok_or(PolicyError::SvnMismatch)?;
+                .check_engine_not_older(&peer, &engine_measurements_of(&init_td_info))?;
         }
 
         Ok(suppl_data)

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -599,11 +599,10 @@ pub async fn wait_for_request() -> Result<MigrationInformation> {
                     .ok_or(MigrationResult::InvalidParameter)?;
             let request_id = mig_info.mig_info.mig_request_id;
 
-            if REQUESTS.lock().contains(&request_id) {
-                Poll::Pending
-            } else {
-                REQUESTS.lock().insert(request_id);
+            if REQUESTS.lock().insert(request_id) {
                 Poll::Ready(Ok(mig_info))
+            } else {
+                Poll::Pending
             }
         } else if wfr.operation == 0 {
             Poll::Pending

--- a/src/migtd/src/spdm/mod.rs
+++ b/src/migtd/src/spdm/mod.rs
@@ -85,7 +85,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SpdmDeviceIo for MigtdTransport<T
         while recvd < VMCALL_SPDM_MESSAGE_HEADER_SIZE {
             let n = self
                 .transport
-                .read(&mut buffer[recvd..])
+                .read(&mut buffer[recvd..VMCALL_SPDM_MESSAGE_HEADER_SIZE])
                 .await
                 // ConnectionAborted maps from VmcallRawError::VmmCanceled.
                 // The SpdmDeviceIo trait cannot represent this error, so just
@@ -108,10 +108,11 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SpdmDeviceIo for MigtdTransport<T
             return Err(0_usize);
         }
 
-        while recvd < payload_size + VMCALL_SPDM_MESSAGE_HEADER_SIZE {
+        let total = payload_size + VMCALL_SPDM_MESSAGE_HEADER_SIZE;
+        while recvd < total {
             let n = self
                 .transport
-                .read(&mut buffer[recvd..])
+                .read(&mut buffer[recvd..total])
                 .await
                 .map_err(|e| {
                     if e.kind() == rust_std_stub::io::ErrorKind::ConnectionAborted {
@@ -122,7 +123,7 @@ impl<T: AsyncRead + AsyncWrite + Unpin + Send> SpdmDeviceIo for MigtdTransport<T
             recvd += n;
         }
 
-        Ok(recvd)
+        Ok(total)
     }
 
     async fn flush_all(&mut self) -> SpdmResult {

--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -149,15 +149,19 @@ pub fn spdm_responder<'a, T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'sta
     Ok((responder_context_ex, device_io_ref))
 }
 
-pub async fn spdm_responder_transfer_msk(
-    spdm_responder_ex: &mut ResponderContextEx<'_>,
-    mig_info: &MigtdMigrationInformation,
+pub async fn spdm_responder_transfer_msk<'a>(
+    spdm_responder_ex: &mut ResponderContextEx<'a>,
+    mig_info: &'a MigtdMigrationInformation,
     #[cfg(feature = "policy_v2")] peer_data: Vec<u8>,
 ) -> Result<(), SpdmStatus> {
     #[cfg(not(feature = "policy_v2"))]
     let peer_data = Vec::new();
 
     spdm_responder_ex.peer_data = peer_data;
+    // Mark this responder as operating in migration mode so the migration-mode
+    // handlers (mig-attest op 0x03, mig-info op 0x05) accept the request; their
+    // MigrationInformation variant guard rejects rebind-mode confusion.
+    spdm_responder_ex.info = ResponderContextExInfo::MigrationInformation(mig_info);
 
     // Zeroize the responder key buffer on every return path.
     let result = spdm_responder_transfer_msk_inner(spdm_responder_ex, mig_info).await;
@@ -534,13 +538,6 @@ pub fn handle_exchange_mig_attest_info_req(
     #[cfg(feature = "policy_v2")]
     let servtd_ext_bytes_vec = servtd_ext_bytes.to_vec();
 
-    // Store SERVTD_EXT in ResponderContextEx for later use during MSK exchange
-    #[cfg(feature = "policy_v2")]
-    unsafe {
-        let spdm_responder_ex = upcast_mut(responder_context);
-        spdm_responder_ex.servtd_ext = ServtdExt::read_from_bytes(servtd_ext_bytes);
-    };
-
     // Init TDINFO from src (used for SERVTD_HASH verification)
     let vdm_element = VdmMessageElement::read(reader).ok_or(SPDM_STATUS_INVALID_MSG_SIZE)?;
     if vdm_element.element_type != VdmMessageElementType::TdReportInit {
@@ -595,6 +592,14 @@ pub fn handle_exchange_mig_attest_info_req(
             responder_context,
             session_id,
         )?;
+
+        // Persist SERVTD_EXT only after attestation verification succeeded, so
+        // unverified peer-supplied data is never stored in the responder context
+        // (its hash is later written to TDCS during MSK exchange in op 0x05).
+        unsafe {
+            let spdm_responder_ex = upcast_mut(responder_context);
+            spdm_responder_ex.servtd_ext = ServtdExt::read_from_bytes(&servtd_ext_bytes_vec);
+        };
     }
 
     let mut writer = Writer::init(vendor_defined_rsp_payload);
@@ -802,6 +807,17 @@ pub fn handle_exchange_mig_info_req(
     reader: &mut Reader<'_>,
     vendor_defined_rsp_payload: &mut [u8],
 ) -> SpdmResult<usize> {
+    // Reject if not in migration mode: a rebind session shares the
+    // transcript_before_finish precondition and must not reach write_msk.
+    let spdm_responder_ex = unsafe { upcast_mut(responder_context) };
+    if !matches!(
+        &spdm_responder_ex.info,
+        ResponderContextExInfo::MigrationInformation(_)
+    ) {
+        error!("Migration info is not set in responder context.\n");
+        return Err(SPDM_STATUS_INVALID_MSG_FIELD);
+    }
+
     // The VDM message for secret migration info exchange MUST be sent after mutual attested session establishment.
     let session_id = if let Some(sid) = session_id {
         sid

--- a/src/policy/src/v2/policy.rs
+++ b/src/policy/src/v2/policy.rs
@@ -305,12 +305,12 @@ impl<'a> PolicyData<'a> {
         relative_reference: &PolicyEvaluationInfo,
         skip_global: bool,
     ) -> Result<(), PolicyError> {
-        match self.forward_policy.as_ref() {
-            Some(policy) => {
-                Self::evaluate_policy_block(policy, value, relative_reference, skip_global)
-            }
-            None => Ok(()),
-        }
+        Self::evaluate_policy_block(
+            self.forward_policy.as_ref(),
+            value,
+            relative_reference,
+            skip_global,
+        )
     }
 
     pub fn evaluate_policy_backward(
@@ -319,12 +319,12 @@ impl<'a> PolicyData<'a> {
         relative_reference: &PolicyEvaluationInfo,
         skip_global: bool,
     ) -> Result<(), PolicyError> {
-        match self.backward_policy.as_ref() {
-            Some(policy) => {
-                Self::evaluate_policy_block(policy, value, relative_reference, skip_global)
-            }
-            None => Ok(()),
-        }
+        Self::evaluate_policy_block(
+            self.backward_policy.as_ref(),
+            value,
+            relative_reference,
+            skip_global,
+        )
     }
 
     pub fn evaluate_policy_common(
@@ -333,29 +333,60 @@ impl<'a> PolicyData<'a> {
         relative_reference: &PolicyEvaluationInfo,
         skip_global: bool,
     ) -> Result<(), PolicyError> {
-        match self.policy.as_ref() {
-            Some(policy) => {
-                Self::evaluate_policy_block(policy, value, relative_reference, skip_global)
-            }
-            None => Ok(()),
-        }
+        Self::evaluate_policy_block(self.policy.as_ref(), value, relative_reference, skip_global)
     }
 
     fn evaluate_policy_block(
-        block: &Vec<PolicyTypes>,
+        block: Option<&Vec<PolicyTypes>>,
         value: &PolicyEvaluationInfo,
         relative_reference: &PolicyEvaluationInfo,
         skip_global: bool,
     ) -> Result<(), PolicyError> {
-        for policy_type in block {
-            match policy_type {
-                PolicyTypes::Global(global) if !skip_global => {
-                    global.evaluate(value, relative_reference)?
+        // Apply explicit policy constraints, if present.
+        if let Some(block) = block {
+            for policy_type in block {
+                match policy_type {
+                    PolicyTypes::Global(global) if !skip_global => {
+                        global.evaluate(value, relative_reference)?
+                    }
+                    PolicyTypes::Servtd(migtd) => migtd.evaluate(value, relative_reference)?,
+                    _ => {}
                 }
-                PolicyTypes::Servtd(migtd) => migtd.evaluate(value, relative_reference)?,
-                _ => {}
             }
         }
+
+        // Always enforce mandatory deny checks, even if a policy block is absent.
+        Self::enforce_mandatory_deny(value, skip_global)?;
+
+        Ok(())
+    }
+
+    /// Enforce non-optional deny checks.
+    ///
+    /// Reject `Revoked` platform status when global checks are enabled.
+    /// Always check engine status; treat unknown (`None`) as denied.
+    fn enforce_mandatory_deny(
+        value: &PolicyEvaluationInfo,
+        skip_global: bool,
+    ) -> Result<(), PolicyError> {
+        if !skip_global {
+            if let Some(status) = value.tcb_status.as_deref() {
+                if TcbStatus::try_from(status)? == TcbStatus::Revoked {
+                    return Err(PolicyError::TcbEvaluation);
+                }
+            }
+        }
+
+        // Engine status must be known; fail closed on `None`.
+        match value.migtd_tcb_status.as_deref() {
+            Some(status) => {
+                if ServtdTcbStatus::try_from(status)? == ServtdTcbStatus::Revoked {
+                    return Err(PolicyError::SvnMismatch);
+                }
+            }
+            None => return Err(PolicyError::UnqualifiedMigTdInfo),
+        }
+
         Ok(())
     }
 
@@ -1182,5 +1213,83 @@ mod test {
         assert!(!tcb_evaluation_number_policy
             .evaluate_integer(4, Some(relative_reference))
             .unwrap());
+    }
+
+    #[test]
+    fn test_absent_block_denies_revoked_platform() {
+        // No block: still deny `Revoked` platform status.
+        let value = PolicyEvaluationInfo {
+            tcb_status: Some("Revoked".to_string()),
+            ..PolicyEvaluationInfo::default()
+        };
+        let relative = PolicyEvaluationInfo::default();
+
+        // `skip_global = false` evaluates platform status.
+        assert!(
+            PolicyData::<'static>::evaluate_policy_block(None, &value, &relative, false).is_err()
+        );
+    }
+
+    #[test]
+    fn test_absent_block_denies_revoked_engine() {
+        // No block: still deny `Revoked` engine status.
+        let value = PolicyEvaluationInfo {
+            migtd_tcb_status: Some("Revoked".to_string()),
+            ..PolicyEvaluationInfo::default()
+        };
+        let relative = PolicyEvaluationInfo::default();
+
+        // Engine status is checked even with `skip_global = true`.
+        assert!(
+            PolicyData::<'static>::evaluate_policy_block(None, &value, &relative, true).is_err()
+        );
+    }
+
+    #[test]
+    fn test_absent_block_allows_non_revoked() {
+        // No block: non-`Revoked` status is allowed.
+        let value = PolicyEvaluationInfo {
+            tcb_status: Some("UpToDate".to_string()),
+            migtd_tcb_status: Some("UpToDate".to_string()),
+            ..PolicyEvaluationInfo::default()
+        };
+        let relative = PolicyEvaluationInfo::default();
+
+        assert!(
+            PolicyData::<'static>::evaluate_policy_block(None, &value, &relative, false).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_skip_global_ignores_platform_status() {
+        // In rebinding (`skip_global`), platform status is ignored.
+        let value = PolicyEvaluationInfo {
+            tcb_status: Some("Revoked".to_string()),
+            migtd_tcb_status: Some("UpToDate".to_string()),
+            ..PolicyEvaluationInfo::default()
+        };
+        let relative = PolicyEvaluationInfo::default();
+
+        assert!(
+            PolicyData::<'static>::evaluate_policy_block(None, &value, &relative, true).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_unclassifiable_engine_is_denied() {
+        // Fail closed: unknown engine status (`None`) is denied in all paths.
+        let value = PolicyEvaluationInfo {
+            tcb_status: Some("UpToDate".to_string()),
+            migtd_tcb_status: None,
+            ..PolicyEvaluationInfo::default()
+        };
+        let relative = PolicyEvaluationInfo::default();
+
+        assert!(
+            PolicyData::<'static>::evaluate_policy_block(None, &value, &relative, false).is_err()
+        );
+        assert!(
+            PolicyData::<'static>::evaluate_policy_block(None, &value, &relative, true).is_err()
+        );
     }
 }

--- a/src/policy/src/v2/servtd_collateral.rs
+++ b/src/policy/src/v2/servtd_collateral.rs
@@ -83,9 +83,13 @@ impl TdIdentity {
     }
 
     pub fn get_tcb_level_by_svn(&self, svn: u16) -> Option<&TcbLevel> {
+        // TCB levels are breakpoints: pick the highest isvsvn <= reported svn
+        // (floor match), not an exact match. Exact match can reject valid
+        // newer svns and miss `Revoked` deny for in-between values.
         self.tcb_levels
             .iter()
-            .find(|&level| level.tcb.isvsvn == svn)
+            .filter(|level| level.tcb.isvsvn <= svn)
+            .max_by_key(|level| level.tcb.isvsvn)
     }
 }
 

--- a/src/policy/src/v2/servtd_collateral.rs
+++ b/src/policy/src/v2/servtd_collateral.rs
@@ -233,6 +233,32 @@ impl TdTcbMapping {
         None
     }
 
+    /// `migtdengine check`: the peer engine must not be older than the engine
+    /// recorded at initial binding (`enginesvnsrc >= enginesvninit`).
+    ///
+    /// `enginedatesrc >= enginedateinit` is not compared separately: the engine
+    /// date is looked up from this SVN in `servtd_identity`, so it follows only
+    /// while `tcbLevels` are non-decreasing in `isvsvn` — Intel's Enclave
+    /// Identity convention, which nothing here validates.
+    pub fn check_engine_not_older(
+        &self,
+        peer: &Measurements,
+        init: &Measurements,
+    ) -> Result<(), PolicyError> {
+        let peer_svn = self
+            .get_engine_svn_by_measurements(peer)
+            .ok_or(PolicyError::SvnMismatch)?;
+        let init_svn = self
+            .get_engine_svn_by_measurements(init)
+            .ok_or(PolicyError::SvnMismatch)?;
+
+        if peer_svn < init_svn {
+            return Err(PolicyError::SvnMismatch);
+        }
+
+        Ok(())
+    }
+
     #[inline]
     fn compare_measurements(pattern: &Measurements, target: &Measurements) -> bool {
         // Convert both to uppercase for case-insensitive comparison
@@ -309,6 +335,46 @@ mod test {
         assert!(engine
             .get_engine_svn_by_measurements(&td_measurements)
             .is_none());
+    }
+
+    #[test]
+    fn test_check_engine_not_older() {
+        let engine =
+            |tag: u8| Measurements::new_from_bytes(&[tag; 48], &[tag; 48], &[tag; 48], None, None);
+        let mapping = TdTcbMapping {
+            id: String::from("TEST"),
+            version: 1,
+            issue_date: String::from("2025-01-01T00:00:00Z"),
+            next_update: String::from("2026-01-01T00:00:00Z"),
+            mr_signer: String::from("00"),
+            isv_prod_id: 1,
+            svn_mappings: [(0xa1u8, 1u16), (0xb2, 2)]
+                .iter()
+                .map(|(tag, isvsvn)| SvnMapping {
+                    td_measurements: engine(*tag),
+                    isvsvn: *isvsvn,
+                })
+                .collect(),
+        };
+
+        // Downgrade: peer engine older than the engine bound at init.
+        assert!(mapping
+            .check_engine_not_older(&engine(0xa1), &engine(0xb2))
+            .is_err());
+        assert!(mapping
+            .check_engine_not_older(&engine(0xb2), &engine(0xa1))
+            .is_ok());
+        assert!(mapping
+            .check_engine_not_older(&engine(0xa1), &engine(0xa1))
+            .is_ok());
+
+        // Either side unresolvable on the local mapping is a rejection.
+        assert!(mapping
+            .check_engine_not_older(&engine(0xcc), &engine(0xa1))
+            .is_err());
+        assert!(mapping
+            .check_engine_not_older(&engine(0xa1), &engine(0xcc))
+            .is_err());
     }
 
     #[test]

--- a/tools/json-signer/src/lib.rs
+++ b/tools/json-signer/src/lib.rs
@@ -49,6 +49,15 @@ pub fn json_sign(json_key: &str, data: &[u8], private_key: &[u8]) -> Result<Vec<
 }
 
 pub fn json_sign_detached(data: &[u8], private_key: &[u8]) -> Result<Vec<u8>, Error> {
+    // Detached signing is finalized via `json_set_signature`, which embeds
+    // canonical serde bytes. Require canonical input here too, so signed bytes
+    // match embedded bytes and verification cannot fail due to reserialization.
+    let value: Value = serde_json::from_slice(data)?;
+    let canonical_data = serde_json::to_vec(&value)?;
+    if data != canonical_data {
+        return Err(Error::NotCanonical);
+    }
+
     let private_key_der =
         crypto::ecdsa::pem_to_der_from_slice(private_key).map_err(|_| Error::InvalidKey)?;
     let signature = crypto::ecdsa::ecdsa_sign(&private_key_der, data).map_err(|_| Error::Sign)?;


### PR DESCRIPTION
Commit ##1

| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Medium | MigtdTransport::receive over-reads past frame boundary on stream transport | rsp_handle_message -> process_message -> SpdmDeviceIo::receive -> MigtdTransport::receive -> AsyncRead::read | First loop must read into &mut buffer[recvd..VMCALL_SPDM_MESSAGE_HEADER_SIZE]; second loop into &mut buffer[recvd..payload_size+12]; return payload_size+12 not recvd. | true_positive | The first loop reads into &mut buffer[recvd..] (the whole remaining buffer), so on a stream transport a coalesced read can return more than 12 bytes — recvd can already exceed payload_size+12. The second loop then never executes (or under-reads), and it returns recvd, handing the next frame's bytes to spdmlib as trailing garbage and desyncing the stream. Both reads must be capped: header to [recvd..12], payload to [recvd..payload+12], and return payload+12 |
| 2 | Medium | get_tcb_level_by_svn requires exact isvsvn match | <entry> -> TdIdentity::get_tcb_level_by_svn | Use highest level with isvsvn<=svn (floor match) per Intel TCB-Info semantics. | true_positive | The original exact-match (isvsvn == svn) misuses Intel TCB-Info/Enclave-Identity semantics, where tcbLevels are descending breakpoints and a reported svn must floor-match to the highest level with isvsvn <= svn; treating it as an exact lookup returns None for any svn between or above listed levels, which both rejects valid newer peers (availability) and lets an in-between svn skip the mandatory Revoked deny that it should have floored into (security). The floor-match fix is the correct, spec-conformant behavior and is backward-compatible for exact hits, so the finding is a genuine semantic defect. |
| 3 | Medium | json_set_signature re-parses+re-serializes via serde_json::Value before embeddin | <entry> -> json_set_signature | Sign raw input bytes; embed signature without re-serializing the data block. | weakness | The behavior is real, but it is fail-closed and only affects tooling: canonicalization is required so the same JSON always maps to the same bytes before signing/embedding. With the guard in json_sign_detached, non-canonical input is rejected early, and verification uses the exact embedded bytes. |
| 4 | Low | check-then-act across two separate spin::Mutex lock scopes | <entry> -> wait_for_request | Hold single lock across contains+insert; or use BTreeSet::insert return value. | weakness | There is one global EXECUTOR driven by a single poll_tasks() loop on the main thread, and the up-to-12 "concurrent" sessions are merely interleaved at .await points; since there is no .await between contains() and insert(), the whole window runs inside one task poll and no other session can interleave. REQUESTS is TD-private memory and request_id comes from the already-snapshotted private_mem, so the VMM cannot race or influence it. |
| 5 | Low | USED_PORT.lock().contains() then separate .lock().insert() in VsockStream::bind  --  latent split | VsockStream::bind | Hold single guard: `let mut g=USED_PORT.lock(); if g.contains(..){Err} else {g.insert(..);Ok}`. | weakness | The split-lock is real — bind and get_unused_port released the USED_PORT guard between contains() and insert(), so a concurrent binder could race into the gap and two streams could share a local port, colliding in BINDING_PKT_QUEUES. But in the shipped single-vCPU cooperative executor there is no preemption and no .await between the check and the insert, so there is no interleaving point and it is unreachable today; the finding itself rates it T5/internal/HARDENING. |
| 6 | Low | Rebind responder: op 0x03 (no variant check) -> op 0x05 (no variant check) -> write_msk(default) | spdm_responder_rebind_new -> migtd_vdm_msg_rsp_dispatcher_ex -> handle_exchange_mig_attest_info_req -> migtd_vdm_msg_rsp_dispatcher_ex -> handle_exchange_mig_info_req -> write_msk | Gate both migration-mode handlers on ResponderContextExInfo::MigrationInformation variant. | weakness | The op 0x05 handler handle_exchange_mig_info_req lacked the MigrationInformation variant guard that its three siblings have, and because vdm_message_transcript_before_finish is shared across modes, a legitimate rebind-attest could satisfy its only precondition — letting op 0x05 run in rebind mode against the default (zeroed) migration_info. However it stops short of a real key compromise: in rebind mode the buffer holds MigtdMigrationInformation::default(), so verify_servtd_attr(binding_handle=0, default_uuid) issues tdcall_servtd_rd against a non-bound handle and returns an attribute mismatch (or TDX error), failing before write_msk. So the chain is blocked by verify_servtd_attr, making it a weakness rather than a true positive — the added variant guard closes the mode-confusion gap early and restores symmetry with the other handlers, which is the correct hardening regardless. |
| 7 | Low | SPDM migration responder stores peer-supplied servtd_ext BEFORE attestation veri |  | Review the finding context and add appropriate input validation or guard checks. | weakness | In the production path the same peer-supplied servtd_ext bytes are verified inside rsp_verify_peer_attestation_v2; if that fails, op 0x03 returns Err, op 0x05 never runs, and write_approved_servtd_ext_hash is never reached, so no attacker-chosen hash ever reaches TDCS. The "write attacker-chosen APPROVED_SERVTD_EXT_HASH" primitive only materializes when attestation verification is compiled out (AzCVMEmu/test_mock_report/use-mock-quote), which are non-production test paths with no hostile peer. The original "store-before-verify" ordering was therefore a robustness/hardening defect rather than an exploitable flaw. |
| 8 | Info | AzCVMEmu copy_to_private_shadow returns alias to buf  --  no snapshot copy | SharedMemory::copy_to_private_shadow | Clone into a separate shadow Vec<u8> in the emu stub to preserve API contract parity with real td-payload, even if not strictly required for safety. | weakness | In AzCVMEmu builds buf is a process-private heap Vec with no concurrent host writer and the executor is single-threaded cooperative, so returning Some(&self.buf) instead of a copy grants no exploitable TOCTOU — the finding itself rates it Info/HARDENING/T5. The only real gap is fidelity: real td-payload returns a private snapshot decoupled from later shared-memory writes, while the emu stub returned a live alias, so a test relying on snapshot semantics could behave differently than production. That makes it a robustness weakness, not a vulnerability, and the trivial emu-only fix (copy into a separate shadow Vec) is justified for parity even though no security issue exists. |

commit ##2

| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 3 | High | v2 evaluate_policy_forward/backward/common return Ok(()) when block is None | -> PolicyData::evaluate_policy_forward | Treat None as Err(PolicyIncomplete) or require at least one constraint per direction. | true_positive | The core claim is correct: evaluate_policy_forward/backward/common returned Ok(()) when the policy block was None, so an absent block silently skipped mandatory TCB and engine checks — a genuine fail-open that the design guide's acceptance procedure does not sanction (absence-permissive rules exist only for fmspc and the CRL numbers, never for TCB status or engine). However, the finding's RATLS_PEER_CERT / T1 "directly reachable from untrusted peer" framing is wrong: the evaluated policy is the local, signature-verified get_verified_policy(), not peer-supplied input, so it is not remotely exploitable and not Critical. |