### PR TITLE
fix(policy): reject non-canonical TCB date in policy v2 compare

### DIFF
--- a/src/policy/Cargo.toml
+++ b/src/policy/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 
 [dependencies]
 cc-measurement = { path = "../../deps/td-shim/cc-measurement"}
+chrono = { version = "0.4", default-features = false, features = ["alloc"] }
 crypto = { path = "../crypto" }
 log = { version = "0.4.13", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"]}

--- a/src/policy/src/v2/policy.rs
+++ b/src/policy/src/v2/policy.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use alloc::{collections::BTreeMap, string::String, string::ToString, vec::Vec};
+use chrono::NaiveDateTime;
 use core::{
     cmp::Ordering,
     convert::{TryFrom, TryInto},
@@ -607,6 +608,18 @@ struct PolicyProperty {
     pub reference: Reference,
 }
 
+/// Returns true only for a canonical, fixed-width ISO-8601 UTC timestamp of the
+/// exact form "YYYY-MM-DDTHH:MM:SSZ" (e.g. "2025-01-01T00:00:00Z"). Lexicographic
+/// ordering of date strings is only valid under this canonical form, so callers
+/// that compare dates with `>=` must reject anything else.
+fn is_canonical_iso8601(s: &str) -> bool {
+    const FORMAT: &str = "%Y-%m-%dT%H:%M:%SZ";
+
+    NaiveDateTime::parse_from_str(s, FORMAT)
+        .map(|timestamp| timestamp.format(FORMAT).to_string() == s)
+        .unwrap_or(false)
+}
+
 impl PolicyProperty {
     pub fn evaluate_integer(
         &self,
@@ -718,8 +731,14 @@ impl PolicyProperty {
                 match self.operation.as_str() {
                     "equal" => Ok(value == reference_value),
                     "greater-or-equal" => {
-                        // Simple lexicographical comparison works for ISO-8601 format (e.g. "2025-01-01T00:00:00Z")
-                        // This is because ISO-8601 is designed to be sortable as strings
+                        // The lexicographical comparison below is only correct when both
+                        // operands are canonical, fixed-width ISO-8601 timestamps (e.g.
+                        // "2025-01-01T00:00:00Z"). A non-canonical value such as "2024-9-1"
+                        // would sort incorrectly (byte '9' > '1'), so reject anything that is
+                        // not in the canonical form before comparing, failing closed.
+                        if !is_canonical_iso8601(value) || !is_canonical_iso8601(reference_value) {
+                            return Err(PolicyError::InvalidReference);
+                        }
                         Ok(value >= reference_value)
                     }
                     _ => Err(PolicyError::InvalidOperation),
@@ -930,6 +949,28 @@ mod test {
         assert!(!tcb_date_policy
             .evaluate_string("2025-06-15T11:00:00Z", Some("2025-06-15T12:00:00Z"),)
             .unwrap());
+    }
+
+    #[test]
+    fn test_policy_tcb_date_rejects_malformed_timestamps() {
+        const VALID_TIMESTAMP: &str = "2025-06-15T12:00:00Z";
+        const INVALID_TIMESTAMPS: [&str; 2] = ["2025-6-15T12:00:00Z", "2025-13-40T25:61:61Z"];
+
+        let policy = PolicyProperty {
+            operation: "greater-or-equal".to_string(),
+            reference: Reference::String(VALID_TIMESTAMP.to_string()),
+        };
+        for value in INVALID_TIMESTAMPS {
+            assert!(policy.evaluate_string(value, None).is_err());
+        }
+
+        for reference in INVALID_TIMESTAMPS {
+            let policy = PolicyProperty {
+                operation: "greater-or-equal".to_string(),
+                reference: Reference::String(reference.to_string()),
+            };
+            assert!(policy.evaluate_string(VALID_TIMESTAMP, None).is_err());
+        }
     }
 
     #[test]

--- a/src/policy/src/v2/policy.rs
+++ b/src/policy/src/v2/policy.rs
@@ -607,6 +607,35 @@ struct PolicyProperty {
     pub reference: Reference,
 }
 
+/// Returns true only for a canonical, fixed-width ISO-8601 UTC timestamp of the
+/// exact form "YYYY-MM-DDTHH:MM:SSZ" (e.g. "2025-01-01T00:00:00Z"). Lexicographic
+/// ordering of date strings is only valid under this canonical form, so callers
+/// that compare dates with `>=` must reject anything else.
+fn is_canonical_iso8601(s: &str) -> bool {
+    let b = s.as_bytes();
+    if b.len() != 20 {
+        return false;
+    }
+    let is_digit = |i: usize| b[i].is_ascii_digit();
+    (0..4).all(is_digit)
+        && b[4] == b'-'
+        && is_digit(5)
+        && is_digit(6)
+        && b[7] == b'-'
+        && is_digit(8)
+        && is_digit(9)
+        && b[10] == b'T'
+        && is_digit(11)
+        && is_digit(12)
+        && b[13] == b':'
+        && is_digit(14)
+        && is_digit(15)
+        && b[16] == b':'
+        && is_digit(17)
+        && is_digit(18)
+        && b[19] == b'Z'
+}
+
 impl PolicyProperty {
     pub fn evaluate_integer(
         &self,
@@ -718,8 +747,14 @@ impl PolicyProperty {
                 match self.operation.as_str() {
                     "equal" => Ok(value == reference_value),
                     "greater-or-equal" => {
-                        // Simple lexicographical comparison works for ISO-8601 format (e.g. "2025-01-01T00:00:00Z")
-                        // This is because ISO-8601 is designed to be sortable as strings
+                        // The lexicographical comparison below is only correct when both
+                        // operands are canonical, fixed-width ISO-8601 timestamps (e.g.
+                        // "2025-01-01T00:00:00Z"). A non-canonical value such as "2024-9-1"
+                        // would sort incorrectly (byte '9' > '1'), so reject anything that is
+                        // not in the canonical form before comparing, failing closed.
+                        if !is_canonical_iso8601(value) || !is_canonical_iso8601(reference_value) {
+                            return Err(PolicyError::InvalidReference);
+                        }
                         Ok(value >= reference_value)
                     }
                     _ => Err(PolicyError::InvalidOperation),


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Medium | PolicyProperty::evaluate_string greater-or-equal uses raw lexicographic compare on tcb_date | verify_peer_cert -> authenticate_remote -> MigPolicy::evaluate -> PolicyProperty::evaluate_string | Parse to chrono::NaiveDate before compare; reject non-canonical formats. | weakness | Why this is a weakness, not an exploitable true positive: the finding's lexicographic arithmetic is real, but no attacker-controlled input can reach that comparison in a non-canonical form. The left operand is never a free-form string; it is the binary R_TCB_DATE field read as a u64 and rendered through chrono's %Y-%m-%dT%H:%M:%SZ, which always emits zero-padded fixed-width digits, and its value is anchored to the Intel-signed root CA via quote verification, so neither the VMM nor a remote peer can place 2024-9-1 there. The right operand is a policy/collateral field that only materializes after the ECDSA signature over the raw bytes is verified and the peer chain is pinned to the same root CA, so it cannot be forged across a trust boundary either. The only way a non-canonical date enters the compare is a human typing it into a hand-edited, then-signed source file (the *_raw.json policy or td_identity.json), which is a mistake by the already-fully-trusted policy producer rather than an exploit primitive. That makes it a robustness gap, not a remotely reachable vulnerability |