### PR TITLE
fix(migtd): harden BAR handling, logging, and collateral fetches

### DIFF
--- a/deps/td-shim-AzCVMEmu/tdx-tdcall/src/lib.rs
+++ b/deps/td-shim-AzCVMEmu/tdx-tdcall/src/lib.rs
@@ -91,6 +91,14 @@ pub mod tdreport {
         TdxReport, TD_REPORT_ADDITIONAL_DATA_SIZE, TD_REPORT_SIZE, TdInfo,
     };
 
+    // The emulated tdcall_report() copies the az-tdx-vtpm TdReport byte-for-byte
+    // into a TD_REPORT_SIZE buffer and transmutes it to TdxReport. Both types are
+    // #[repr(C)] views of the same TDX-module TDREPORT_STRUCT and are 1024 bytes.
+    // transmute already enforces size_of::<TdxReport>() == TD_REPORT_SIZE at compile
+    // time; this guard ensures the *source* layout cannot silently drift (e.g. an
+    // az-tdx-vtpm upgrade) and zero-pad into a malformed report. Build fails instead.
+    const _: () = assert!(core::mem::size_of::<AzTdReport>() == TD_REPORT_SIZE);
+
     /// Emulated tdcall_report function for AzCVMEmu mode
     /// Now returns the exact same error type as the original for perfect compatibility
     pub fn tdcall_report(additional_data: &[u8; 64]) -> Result<TdxReport, TdCallError> {

--- a/src/devices/pci/src/config.rs
+++ b/src/devices/pci/src/config.rs
@@ -439,12 +439,18 @@ impl PciDevice {
                     0 => {
                         let size = self.get_bar_size(current_bar_offset)?;
 
+                        // Only program a BAR whose size we could probe. A malicious
+                        // host emulating PCI config space can return a malformed
+                        // sizing value (size == 0); never fall back to the raw
+                        // host-chosen BAR value, which would place the device MMIO
+                        // region at an unvalidated address outside the allocated
+                        // MMIO window. Treat such a BAR as absent (fail closed).
                         let addr = if size > 0 {
                             let addr = alloc_mmio32(size)?;
                             self.set_bar_addr(current_bar_offset, addr)?;
                             addr
                         } else {
-                            bar
+                            0
                         };
 
                         self.bars[current_bar].bar_type = PciBarType::MemorySpace32;
@@ -456,13 +462,15 @@ impl PciDevice {
 
                         let size = self.get_bar_size64(current_bar_offset)?;
 
+                        // See the 32-bit case above: fail closed instead of
+                        // trusting the raw host-chosen BAR value when sizing fails.
                         let addr = if size > 0 {
                             let addr = alloc_mmio64(size)?;
                             self.set_bar_addr(current_bar_offset, addr as u32)?;
                             self.set_bar_addr(current_bar_offset + 4, (addr >> 32) as u32)?;
                             addr
                         } else {
-                            bar as u64
+                            0
                         };
 
                         self.bars[current_bar].address = addr & PCI_MEM64_BASE_ADDRESS_MASK;
@@ -509,7 +517,7 @@ impl PciDevice {
                 self.bars[current_bar].bar_type = PciBarType::IoSpace;
                 self.bars[current_bar].address = u64::from(bar & 0xffff_fffc);
             } else {
-                // bits 2-1 are the type 0 is 32-but, 2 is 64 bit
+                // bits 2-1 are the type 0 is 32-bit, 2 is 64-bit
                 match bar >> 1 & 3 {
                     0 => {
                         let size = self.get_bar_size(current_bar_offset)?;

--- a/src/devices/vsock/src/stream.rs
+++ b/src/devices/vsock/src/stream.rs
@@ -174,8 +174,8 @@ impl VsockStream {
             rx_cnt: 0,
             tx_cnt: 0,
             last_fwd_cnt: 0,
-            peer_fwd_cnt: packet.fwd_cnt(),
-            peer_buf_alloc: packet.buf_alloc(),
+            peer_fwd_cnt: request.fwd_cnt(),
+            peer_buf_alloc: request.buf_alloc(),
             transport_context: 0,
         };
 

--- a/src/migtd/src/migration/logging.rs
+++ b/src/migtd/src/migration/logging.rs
@@ -17,7 +17,7 @@ use log::{Level, LevelFilter, Metadata, Record, SetLoggerError};
 use raw_cpuid::CpuId;
 use spin::Mutex;
 #[cfg(not(test))]
-use td_payload::mm::shared::alloc_shared_pages;
+use td_payload::mm::shared::{alloc_shared_pages, free_shared_pages};
 #[cfg(not(test))]
 use tdx_tdcall::{td_call, TdcallArgs};
 use zerocopy::{transmute_ref, FromBytes, Immutable, IntoBytes};
@@ -143,8 +143,26 @@ pub fn create_logarea() -> Result<()> {
         let mut provisional_logareavector = PROVISIONAL_LOGAREAPTR.lock();
         for index in 0..num_vcpus {
             // Allocate shared 4KB page for VMM memory logs
-            let data_buffer =
-                unsafe { alloc_shared_pages(1).ok_or(MigrationResult::OutOfResource)? };
+            let data_buffer = match unsafe { alloc_shared_pages(1) } {
+                Some(buffer) => buffer,
+                None => {
+                    // Free everything allocated in previous iterations before
+                    // bailing out, so a mid-loop allocation failure does not leak
+                    // the already-allocated shared and provisional pages.
+                    for buffer_ptr in logareavector.iter() {
+                        unsafe { free_shared_pages(*buffer_ptr, 1) };
+                    }
+                    logareavector.clear();
+                    for buffer_ptr in provisional_logareavector.iter() {
+                        unsafe {
+                            let _ =
+                                alloc::boxed::Box::from_raw(*buffer_ptr as *mut [u8; PAGE_SIZE]);
+                        }
+                    }
+                    provisional_logareavector.clear();
+                    return Err(MigrationResult::OutOfResource);
+                }
+            };
             logareavector.push(data_buffer);
 
             let data_buffer =
@@ -232,6 +250,15 @@ pub fn free_provisional_logarea() {
 }
 
 pub async fn enable_logarea(log_max_level: u8, request_id: u64, data: &mut Vec<u8>) -> Result<()> {
+    // Security: the requested verbosity comes from the (untrusted) VMM via the
+    // EnableLogArea command. The log records are routed into the shared log area
+    // that the VMM can read. In a production (release) image, refuse to elevate
+    // the runtime level above Info so a hostile VMM cannot turn on Debug/Trace and
+    // harvest sensitive material (e.g. SPDM session-key debug dumps) from the
+    // shared area. Debug builds keep full verbosity for development.
+    #[cfg(not(debug_assertions))]
+    let log_max_level = core::cmp::min(log_max_level, 3); // 3 == Info
+
     let padding: u32 = 0;
     let num_vcpus: u32 = LOGGING_INFORMATION.num_vcpus.load(Ordering::SeqCst);
     let logarea_created: bool = LOGGING_INFORMATION.logarea_created.load(Ordering::SeqCst);
@@ -603,7 +630,18 @@ impl log::Log for VmmLoggerBackend {
             log_max_level =
                 u8_to_levelfilter(LOGGING_INFORMATION.maxloglevel.load(Ordering::SeqCst));
         } else if provisional_logs_enabled {
-            log_max_level = LevelFilter::Trace;
+            // Provisional records are captured into private buffers and copied into
+            // the VMM-readable shared area when EnableLogArea succeeds. In release
+            // images cap the provisional level at Info as well, so sensitive
+            // Debug/Trace material cannot reach the shared area through this path.
+            #[cfg(debug_assertions)]
+            {
+                log_max_level = LevelFilter::Trace;
+            }
+            #[cfg(not(debug_assertions))]
+            {
+                log_max_level = LevelFilter::Info;
+            }
         } else {
             log_max_level = log::max_level();
         }

--- a/tools/migtd-collateral-generator/src/collateral.rs
+++ b/tools/migtd-collateral-generator/src/collateral.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 use x509_parser::prelude::*;
 
 use crate::pcs_client::{
-    fetch_data_from_url, fetch_pck_crl, fetch_qe_identity, fetch_root_ca, get_platform_tcb_list,
+    fetch_pck_crl, fetch_qe_identity, fetch_root_ca, fetch_root_ca_crl, get_platform_tcb_list,
     PlatformTcbRaw,
 };
 
@@ -93,7 +93,7 @@ pub async fn get_collateral(config: &dyn crate::PcsConfig) -> Result<Collaterals
         async {
             let (qe_identity, qe_identity_issuer_chain) = fetch_qe_identity(config).await?;
             let root_ca_crl_url = get_root_ca_crl_url(qe_identity_issuer_chain.as_str())?;
-            let root_ca_crl = fetch_data_from_url(&root_ca_crl_url).await?.data;
+            let root_ca_crl = fetch_root_ca_crl(&root_ca_crl_url).await?;
             Ok::<_, anyhow::Error>((qe_identity, qe_identity_issuer_chain, root_ca_crl))
         },
         fetch_root_ca(config),


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Critical | BAR-size wrap -> raw VMM BAR addr -> CommonConfig MemoryRegion in TD private DRAM -> arbitrary mmio_write | handle_pre_mig -> setup_transport -> VirtioPciTransport::init -> PciDevice::init -> PciDevice::get_bar_size -> VirtioPciTransport::init -> mem::MemoryRegion::new -> MemoryRegion::mmio_write | In MemoryRegion::new reject base ranges overlapping TD private DRAM (query td-payload mm for accepted-private range); in PciDevice::init never fall back to raw VMM BAR value  --  fail closed when size==0. | true_positive | The defect is real and confirmed in code: when the host returns a malformed sizing probe so that get_bar_size yields 0, both init() paths previously fell back to } else { bar } / } else { bar as u64 }, storing the raw host-chosen BAR value into bars[].address and bypassing alloc_mmio32/64, which is the only thing that constrains the device MMIO window to a RAM-disjoint range. That is a genuine missing input validation at the VIRTIO_PCI_CONFIG trust boundary. However, the escalation to "write-what-where in TD private DRAM / MSK theft" is a false positive for the shipped firmware, because production virtio MMIO goes through tdvmcall_mmio_write (a TDVMCALL to the host), which cannot reach private encrypted TD memory; the residual is at most host-directed access to a host-chosen address it already controls, i.e. DoS-class, which is out of the TDX threat model. |
| 2 | Low | collateral-generator: root_ca_crl HTTP status unchecked; non-200 body becomes enrolled CRL | main -> get_collateral -> fetch_data_from_url | Check response_code==200 before consuming .data (the dead sibling fetch_root_ca_crl@pcs_client.rs:80 already does this  --  wire it in). | weakness | The collateral generator at collateral.rs:96 consumed fetch_data_from_url(...).await?.data without checking response_code, so a PCS 404/403 error body could be enrolled as the root CA CRL while every sibling fetch function checks for 200. It only affects the build-time collateral artifact, not the firmware binary or runtime TD security: TLS to PCS is enabled, and a corrupt collateral merely makes runtime CRL/TCB lookups fail closed (migrations rejected), giving no memory primitive or trust-boundary bypass. Classifying it as Low/hardening (build-time) is correct, but it is a weakness not true positve. |
| 3 | Info | create_logarea early-return leaks prior shared pages + Box<[u8;4096]> in static Vec | main -> create_logarea -> alloc_shared_pages | On Err, drain LOGAREAPTR/PROVISIONAL_LOGAREAPTR and free_shared_pages each entry before returning. | weakness | In create_logarea the per-vCPU loop pushes a shared page into LOGAREAPTR and a private Box into PROVISIONAL_LOGAREAPTR each iteration, and the original ? on alloc_shared_pages returned immediately on a mid-loop failure, leaking the i shared pages and i private boxes already pushed since logarea_created is never set and nothing frees them later. It is only a weakness because this is a one-time boot-path init called once from main, num_vcpus comes from the trusted TDX module (not VMM-controlled), the leak is bounded and not attacker-amplifiable, and there is no memory primitive or trust-boundary crossing; host-induced resource exhaustion is out of scope for the TDX threat model anyway. |
| 4 | Low | VMM EnableLogArea sets log::set_max_level without authentication | handle_pre_mig -> wait_for_request -> log::set_max_level | Clamp VMM-requested level to <=Info, or measure the chosen level into RTMR so it is attestable. | true_positive | The code path WaitForRequestResponse::EnableLogArea(wfr_info) -> log::set_max_level(u8_to_levelfilter(wfr_info.log_max_level)) takes a VMM-supplied log_max_level and applies it with no authentication and no clamp, so a hostile VMM can raise verbosity to Trace (value 5). Because the default build sets no static release_max_level_* cap, the debug!/trace! calls remain compiled in — including spdmlib's session-key dumps (final_key, exchange data) and traces of transport buffers, policy, and tdreport-related material — and those records are written into the shared, host-readable log area. The threat is therefore a real confidentiality breach: VMM-controlled escalation that changes the class of disclosed data from benign Info-level metadata to cryptographic key material, potentially leaking SPDM session keys. It grants no private-memory write and no code execution, and the leak is bounded to what the code already logs, so it is information-disclosure rather than integrity loss; weighed against the fact that the trigger condition is the default (not an exceptional) build configuration and the attacker is the untrusted VMM |
| 5 | Medium | VsockStream::accept reads peer credit fields from OUTGOING packet (variable shad | <entry> -> accept | Rename response var; read peer_* from incoming request packet. | true_positive | In accept() the peer_fwd_cnt and peer_buf_alloc of the new stream were being read from the outgoing OP_RESPONSE packet (which carries our own fwd_cnt = 0 and buf_alloc = VSOCK_BUF_ALLOC) instead of from the inbound request, so the flow-control credit window started from our own values rather than the peer's advertised ones. The connection itself still opened correctly — addresses, ports, state transition and handshake were all fine; only the initial credit accounting was wrong. The error window was transient because the first peer packet (OP_RW or OP_CREDIT_UPDATE) overwrites both fields with the real values in recv_packet_connected(), and the worst case was a brief stall or over-send, i.e. a liveness issue, not memory unsafety or data corruption. |
| 6 | Info | AzCVMEmu tdcall_report transmutes AzTdReport->TdxReport assuming layout parity | attestation::attest_init -> tdreport::tdcall_report -> tdcall_report_emulated | Add const_assert!(size_of::<AzTdReport>()==TD_REPORT_SIZE) and a field-offset spot-check (e.g. offset_of REPORTDATA) so layout drift fails at compile time. | weakness | The transmute lives only in the AzCVMEmu emulation path, not in shipped TDX firmware, and both AzTdReport and TdxReport are #[repr(C)] views of the same 1024-byte TDX TDREPORT_STRUCT, so the byte-for-byte copy is layout-correct and bounded (copy_size = min(len, 1024), no OOB). The transmute already enforces size_of::<TdxReport>() == 1024 at compile time. The only real risk is silent drift in the upstream az-tdx-vtpm source layout, which would merely produce a malformed report that fails attestation (fail-closed), not memory corruption. |