### PR TITLE
fix(crypto/rustls): pin RA-TLS CertificateVerify to ECDSA P-384/SHA-384

### DIFF
--- a/src/crypto/src/rustls_impl/tls.rs
+++ b/src/crypto/src/rustls_impl/tls.rs
@@ -293,6 +293,15 @@ impl ServerCertVerifier for Verifier {
         cert: &CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> core::result::Result<HandshakeSignatureValid, rustls::Error> {
+        // Pin the CertificateVerify signature scheme to ECDSA P-384/SHA-384,
+        // consistent with the cipher suite and key-exchange group pinned in
+        // `crypto_provider()`. Reject any other scheme so the handshake
+        // transcript can only be bound with the expected algorithm.
+        if dss.scheme != rustls::SignatureScheme::ECDSA_NISTP384_SHA384 {
+            return Err(rustls::Error::PeerIncompatible(
+                rustls::PeerIncompatible::NoSignatureSchemesInCommon,
+            ));
+        }
         verify_tls13_signature(
             message,
             cert,
@@ -316,9 +325,7 @@ impl ServerCertVerifier for Verifier {
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        default_provider()
-            .signature_verification_algorithms
-            .supported_schemes()
+        vec![rustls::SignatureScheme::ECDSA_NISTP384_SHA384]
     }
 }
 
@@ -347,6 +354,15 @@ impl ClientCertVerifier for Verifier {
         cert: &CertificateDer<'_>,
         dss: &rustls::DigitallySignedStruct,
     ) -> core::result::Result<HandshakeSignatureValid, rustls::Error> {
+        // Pin the CertificateVerify signature scheme to ECDSA P-384/SHA-384,
+        // consistent with the cipher suite and key-exchange group pinned in
+        // `crypto_provider()`. Reject any other scheme so the handshake
+        // transcript can only be bound with the expected algorithm.
+        if dss.scheme != rustls::SignatureScheme::ECDSA_NISTP384_SHA384 {
+            return Err(rustls::Error::PeerIncompatible(
+                rustls::PeerIncompatible::NoSignatureSchemesInCommon,
+            ));
+        }
         verify_tls13_signature(
             message,
             cert,
@@ -370,9 +386,7 @@ impl ClientCertVerifier for Verifier {
     }
 
     fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
-        default_provider()
-            .signature_verification_algorithms
-            .supported_schemes()
+        vec![rustls::SignatureScheme::ECDSA_NISTP384_SHA384]
     }
 
     fn root_hint_subjects(&self) -> &[rustls::DistinguishedName] {


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Low | TLS CertificateVerify sig-scheme not pinned  --  supported_verify_schemes() returns full default list | rustls::ClientConnection::process_tls_records -> <Verifier as ServerCertVerifier>::verify_tls13_signature | Override provider.signature_verification_algorithms to only ECDSA_P384_SHA384 and return [ECDSA_NISTP384_SHA384] from supported_verify_schemes(). | weakness | The CertificateVerify signature scheme is not pinned, but the scheme is inseparable from the certificate's key type, and that key is already forced to P-384 by the app-layer RA-TLS callback, which rejects any non-P-384 SPKI before the transcript signature matters. rustls verifies CertificateVerify against the end-entity key, so a peer declaring RSA or P-256 simply fails the key/algorithm mismatch, and there is no weaker P-384 variant to downgrade to (ECDSA_NISTP384_SHA384 is the only one). Most decisively, producing any valid CertificateVerify under any scheme requires the peer's private key: without it no forgery is possible, and with it the attacker is a legitimate peer, so pinning the scheme adds nothing to authentication. No reachable path lets the unpinned scheme grant a new capability, so the residual is purely formal algorithm-agility hygiene. |