### PR TITLE
fix(migtd): input validation and robustness from security audit

### DIFF
--- a/src/migtd/src/driver/serial.rs
+++ b/src/migtd/src/driver/serial.rs
@@ -54,7 +54,8 @@ pub fn virtio_serial_device_init() {
     pci::init_mmio();
 
     // Enumerate the virtio device
-    let (_b, dev, _f) = pci::find_device(VIRTIO_PCI_VENDOR_ID, VIRTIO_PCI_DEVICE_ID).unwrap();
+    let (_b, dev, _f) = pci::find_device(VIRTIO_PCI_VENDOR_ID, VIRTIO_PCI_DEVICE_ID)
+        .expect("Failed to find virtio-serial PCI device");
 
     let pci_device = pci::PciDevice::new(0, dev, 0);
 

--- a/src/migtd/src/driver/timer.rs
+++ b/src/migtd/src/driver/timer.rs
@@ -56,6 +56,15 @@ pub fn init_timer() {
 pub fn schedule_timeout(timeout: u32) -> Option<u64> {
     reset_timer();
     let cpuid = unsafe { core::arch::x86_64::__cpuid_count(0x15, 0) };
+    if cpuid.eax == 0 || cpuid.ebx == 0 || cpuid.ecx == 0 {
+        log::error!(
+            "schedule_timeout: CPUID.15H returned invalid values (eax={}, ebx={}, ecx={})\n",
+            cpuid.eax,
+            cpuid.ebx,
+            cpuid.ecx
+        );
+        return None;
+    }
     let tsc_frequency = cpuid.ecx * (cpuid.ebx / cpuid.eax);
     let deadline = (tsc_frequency / 1000) as u64 * timeout as u64;
 

--- a/src/migtd/src/driver/vsock.rs
+++ b/src/migtd/src/driver/vsock.rs
@@ -39,7 +39,8 @@ pub fn virtio_vsock_device_init() {
     pci::init_mmio();
 
     // Enumerate the virtio device
-    let (_b, dev, _f) = pci::find_device(VIRTIO_PCI_VENDOR_ID, VIRTIO_PCI_DEVICE_ID).unwrap();
+    let (_b, dev, _f) = pci::find_device(VIRTIO_PCI_VENDOR_ID, VIRTIO_PCI_DEVICE_ID)
+        .expect("Failed to find virtio-vsock PCI device");
 
     let pci_device = pci::PciDevice::new(0, dev, 0);
 

--- a/src/migtd/src/event_log.rs
+++ b/src/migtd/src/event_log.rs
@@ -62,19 +62,20 @@ impl TaggedEvent {
 }
 
 pub fn get_event_log_mut() -> Option<&'static mut [u8]> {
-    get_ccel().map(event_log_slice)
+    get_ccel().and_then(event_log_slice)
 }
 
 pub fn get_event_log() -> Option<&'static [u8]> {
-    let raw = get_ccel().map(event_log_slice)?;
+    let raw = get_ccel().and_then(event_log_slice)?;
     // The `+1` is required: `cc_measurement::log::CcEvents::next()` only
     // yields an event when `end_of_event < bytes.len()` (strict inequality).
-    // If we sliced to exactly `size`, the buffer would end at the last
-    // event boundary and that final event would be silently dropped by the
-    // iterator, breaking `parse_events()` (e.g. losing the policy tag) and
-    // any downstream RTMR replay. The runtime layout has trailing zeros in
-    // the CCEL area, so including one extra byte is safe.
-    event_log_size(raw).map(|size| &raw[..size + 1])
+    // If we sliced to exactly `size`, the buffer would end at the last event
+    // boundary and that final event (the MigTdPolicy measurement) would be
+    // silently dropped by the iterator, breaking `parse_events()` and causing
+    // `check_policy_integrity()` to fail with `PolicyHashMismatch`. The runtime
+    // layout has trailing zeros in the CCEL area, so the extra byte is safe;
+    // clamp to the raw length as a defensive guard.
+    event_log_size(raw).map(|size| &raw[..core::cmp::min(size + 1, raw.len())])
 }
 
 fn event_log_size(event_log: &[u8]) -> Option<usize> {
@@ -90,16 +91,19 @@ fn event_log_size(event_log: &[u8]) -> Option<usize> {
     Some(size)
 }
 
-fn event_log_slice(ccel: &Ccel) -> &'static mut [u8] {
-    unsafe { core::slice::from_raw_parts_mut(ccel.lasa as *mut u8, ccel.laml as usize) }
+fn event_log_slice(ccel: &Ccel) -> Option<&'static mut [u8]> {
+    // Validate that lasa and laml are non-zero and laml is reasonable
+    if ccel.lasa == 0 || ccel.laml == 0 || ccel.laml as usize > 0x10_0000 {
+        return None;
+    }
+    Some(unsafe { core::slice::from_raw_parts_mut(ccel.lasa as *mut u8, ccel.laml as usize) })
 }
 
 fn get_ccel() -> Option<&'static Ccel> {
     if !CCEL.is_completed() {
         // Parse out ACPI tables handoff from firmware and find the event log location
         let &ccel = get_acpi_tables()
-            .and_then(|tables| tables.iter().find(|&&t| t[..4] == *b"CCEL"))
-            .expect("Failed to find CCEL");
+            .and_then(|tables| tables.iter().find(|&&t| t.get(..4) == Some(b"CCEL")))?;
 
         if ccel.len() < size_of::<Ccel>() {
             return None;
@@ -181,9 +185,8 @@ pub(crate) fn parse_events(event_log: &[u8]) -> Option<BTreeMap<EventName, CcEve
     for (event_header, event_data) in reader.cc_events {
         match event_header.event_type {
             EV_EFI_PLATFORM_FIRMWARE_BLOB2 => {
-                let desc_size = event_data[0] as usize;
-                let desc = event_data.get(1..1 + desc_size)?;
-                if desc == PLATFORM_FIRMWARE_BLOB2_PAYLOAD {
+                let desc_size = *event_data.get(0)? as usize;
+                if event_data.get(1..1 + desc_size)? == PLATFORM_FIRMWARE_BLOB2_PAYLOAD {
                     map.insert(EventName::MigTdCore, CcEvent::new(event_header, None));
                 }
             }

--- a/src/migtd/src/migration/data.rs
+++ b/src/migtd/src/migration/data.rs
@@ -117,7 +117,9 @@ impl<'a> VmcallServiceResponse<'a> {
         if length < RESPONSE_HEADER_LENGTH || length > data.len() {
             return None;
         }
-        Some(Self { data })
+        Some(Self {
+            data: &data[..length],
+        })
     }
 
     pub fn new(response: &'a mut [u8], guid: Guid) -> Option<Self> {

--- a/src/migtd/src/migration/logging.rs
+++ b/src/migtd/src/migration/logging.rs
@@ -374,12 +374,24 @@ pub fn entrylog(msg: &Vec<u8>, loglevel: Level, request_id: u64) {
                             Some(if v == u64::MAX { 1 } else { v + 1 })
                         })
                         .unwrap();
-                    let start_offset: u64 =
-                        u64::from_le_bytes(data_buffer[24..32].try_into().unwrap());
-                    let end_offset: u64 =
-                        u64::from_le_bytes(data_buffer[32..40].try_into().unwrap());
+                    // Copy offsets from shared memory via volatile read to prevent TOCTOU
+                    let start_offset: u64 = unsafe {
+                        core::ptr::read_volatile(data_buffer[24..32].as_ptr() as *const u64)
+                    };
+                    let end_offset: u64 = unsafe {
+                        core::ptr::read_volatile(data_buffer[32..40].as_ptr() as *const u64)
+                    };
                     let mut currentstartoffset: usize = start_offset as usize;
                     let mut currentendoffset: usize = end_offset as usize;
+                    // Clamp offsets to valid range to prevent VMM-controlled panic
+                    if currentstartoffset < LOGAREABUFFERHEADERSIZE
+                        || currentstartoffset >= PAGE_SIZE
+                    {
+                        currentstartoffset = LOGAREABUFFERHEADERSIZE;
+                    }
+                    if currentendoffset < LOGAREABUFFERHEADERSIZE || currentendoffset >= PAGE_SIZE {
+                        currentendoffset = LOGAREABUFFERHEADERSIZE;
+                    }
                     if currentendoffset + LOGENTRYHEADERSIZE + msg.len() > PAGE_SIZE
                         || currentendoffset < currentstartoffset
                     {

--- a/src/migtd/src/migration/logging.rs
+++ b/src/migtd/src/migration/logging.rs
@@ -401,12 +401,24 @@ pub fn entrylog(msg: &Vec<u8>, loglevel: Level, request_id: u64) {
                             Some(if v == u64::MAX { 1 } else { v + 1 })
                         })
                         .unwrap();
-                    let start_offset: u64 =
-                        u64::from_le_bytes(data_buffer[24..32].try_into().unwrap());
-                    let end_offset: u64 =
-                        u64::from_le_bytes(data_buffer[32..40].try_into().unwrap());
+                    // Copy offsets from shared memory via volatile read to prevent TOCTOU
+                    let start_offset: u64 = unsafe {
+                        core::ptr::read_volatile(data_buffer[24..32].as_ptr() as *const u64)
+                    };
+                    let end_offset: u64 = unsafe {
+                        core::ptr::read_volatile(data_buffer[32..40].as_ptr() as *const u64)
+                    };
                     let mut currentstartoffset: usize = start_offset as usize;
                     let mut currentendoffset: usize = end_offset as usize;
+                    // Clamp offsets to valid range to prevent VMM-controlled panic
+                    if currentstartoffset < LOGAREABUFFERHEADERSIZE
+                        || currentstartoffset >= PAGE_SIZE
+                    {
+                        currentstartoffset = LOGAREABUFFERHEADERSIZE;
+                    }
+                    if currentendoffset < LOGAREABUFFERHEADERSIZE || currentendoffset >= PAGE_SIZE {
+                        currentendoffset = LOGAREABUFFERHEADERSIZE;
+                    }
                     if currentendoffset + LOGENTRYHEADERSIZE + msg.len() > PAGE_SIZE
                         || currentendoffset < currentstartoffset
                     {

--- a/src/migtd/src/migration/pre_session_data.rs
+++ b/src/migtd/src/migration/pre_session_data.rs
@@ -141,6 +141,10 @@ pub(super) async fn receive_pre_session_data<T: AsyncRead + AsyncWrite + Unpin>(
             log::error!("receive_pre_session_data: Network error: {:?}\n", e);
             MigrationResult::NetworkError
         })?;
+        if n == 0 {
+            log::error!("receive_pre_session_data: EOF (peer closed connection)\n");
+            return Err(MigrationResult::NetworkError);
+        }
         recvd += n;
     }
     Ok(())
@@ -194,6 +198,15 @@ pub(super) async fn receive_pre_session_data_packet<T: AsyncRead + AsyncWrite + 
     }
 
     let pre_session_data_payload_size = header.length as usize;
+    const MAX_PRE_SESSION_PAYLOAD: usize = 64 * 1024; // 64 KiB
+    if pre_session_data_payload_size > MAX_PRE_SESSION_PAYLOAD {
+        log::error!(
+            "receive_pre_session_data_packet: payload size {} exceeds max {}\n",
+            pre_session_data_payload_size,
+            MAX_PRE_SESSION_PAYLOAD
+        );
+        return Err(MigrationResult::InvalidParameter);
+    }
     let mut pre_session_data_payload = vec![0u8; pre_session_data_payload_size];
     receive_pre_session_data(transport, &mut pre_session_data_payload)
         .await

--- a/src/migtd/src/migration/pre_session_data.rs
+++ b/src/migtd/src/migration/pre_session_data.rs
@@ -141,6 +141,10 @@ pub(super) async fn receive_pre_session_data<T: AsyncRead + AsyncWrite + Unpin>(
             log::error!("receive_pre_session_data: Network error: {:?}\n", e);
             MigrationResult::NetworkError
         })?;
+        if n == 0 {
+            log::error!("receive_pre_session_data: EOF (peer closed connection)\n");
+            return Err(MigrationResult::NetworkError);
+        }
         recvd += n;
     }
     Ok(())

--- a/src/migtd/src/migration/rebinding.rs
+++ b/src/migtd/src/migration/rebinding.rs
@@ -560,6 +560,9 @@ async fn tls_session_read_exact(
             .read(&mut data[recvd..])
             .await
             .map_err(|_| MigrationResult::NetworkError)?;
+        if n == 0 {
+            return Err(MigrationResult::NetworkError);
+        }
         recvd += n;
     }
     Ok(())

--- a/src/migtd/src/ratls/server_client.rs
+++ b/src/migtd/src/ratls/server_client.rs
@@ -778,6 +778,16 @@ mod verify {
         cert: &[u8],
         quote_local: &[u8],
     ) -> core::result::Result<(), CryptoError> {
+        // Reject oversized certificates to prevent heap exhaustion from DER parsing
+        const MAX_CERT_SIZE: usize = 8192;
+        if cert.len() > MAX_CERT_SIZE {
+            log::error!(
+                "Certificate too large: {} bytes (max {})\n",
+                cert.len(),
+                MAX_CERT_SIZE
+            );
+            return Err(CryptoError::ParseCertificate);
+        }
         let verified_report_local = attestation::verify_quote(quote_local).map_err(|e| {
             log::error!("Mutual attestation error {:?}.\n", e);
             CryptoError::TlsVerifyPeerCert(MUTUAL_ATTESTATION_ERROR.to_string())
@@ -1123,7 +1133,17 @@ mod verify {
         }
         const PUBLIC_KEY_HASH_SIZE: usize = 48;
 
-        let report_data = &verified_report[520..520 + PUBLIC_KEY_HASH_SIZE];
+        let report_data = verified_report
+            .get(520..520 + PUBLIC_KEY_HASH_SIZE)
+            .ok_or_else(|| {
+                log::error!(
+                    "verify_public_key: verified_report too short (len={})\n",
+                    verified_report.len()
+                );
+                CryptoError::TlsVerifyPeerCert(
+                    "verified_report too short for public key hash".to_string(),
+                )
+            })?;
         let digest = digest_sha384(public_key).map_err(|e| {
             log::error!("Failed to compute SHA384 digest: {:?}\n", e);
             e

--- a/src/migtd/src/ratls/server_client.rs
+++ b/src/migtd/src/ratls/server_client.rs
@@ -1123,7 +1123,17 @@ mod verify {
         }
         const PUBLIC_KEY_HASH_SIZE: usize = 48;
 
-        let report_data = &verified_report[520..520 + PUBLIC_KEY_HASH_SIZE];
+        let report_data = verified_report
+            .get(520..520 + PUBLIC_KEY_HASH_SIZE)
+            .ok_or_else(|| {
+                log::error!(
+                    "verify_public_key: verified_report too short (len={})\n",
+                    verified_report.len()
+                );
+                CryptoError::TlsVerifyPeerCert(
+                    "verified_report too short for public key hash".to_string(),
+                )
+            })?;
         let digest = digest_sha384(public_key).map_err(|e| {
             log::error!("Failed to compute SHA384 digest: {:?}\n", e);
             e


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Medium | parse_events indexes peer event_data[0]/[1..1+desc_size]/[..4] without length check | exchange_msk -> ratls::client -> verify_peer_cert -> mig_policy::authenticate_remote -> parse_events | Use event_data.get(0)/.get(1..1+desc_size)/.get(..4) and return None on short data. | weakness | The unchecked event_data[0] in parse_events() is a real crash path on malformed event data, but it is not practically exploitable in production. The peer's event log is embedded in their RA-TLS certificate and verified against RTMRs from their TDX quote before parse_events() runs. A peer capable of crafting a malicious event log that passes RTMR replay must be running modified firmware or a modified MigTD binary, both of which change MRTD — causing policy rejection before the vulnerable code is reached. |
| 2 | High | VMM-set log_max_level + shared logarea header TOCTOU -> entrylog slice-index panic kills all sessions | handle_pre_mig -> log::set_max_level -> <any log!()> -> VmmLoggerBackend::log -> entrylog | Copy LogAreaBufferHeader to private stack before use and clamp start_offset/end_offset to [LOGAREABUFFERHEADERSIZE,PAGE_SIZE); reject log_max_level changes after init. | weakness | The log buffer is shared memory but the impact is DoS only — Rust's slice bounds checking prevents any out-of-bounds write, so VMM-crafted offsets can only trigger a panic. Since the TDX threat model does not guarantee availability and the VMM already has unlimited DoS capability over any TD (scheduling control, interrupt withholding, VMCALL non-response), the panic does not grant the VMM any new security-relevant capability. The volatile read plus clamp is defense-in-depth that converts a crash into graceful recover |
| 3 | Low | Ok(0) infinite busy-loop in receive_pre_session_data defeats with_timeout | handle_pre_mig -> pre_session_data_exchange -> receive_hello_packet -> receive_pre_session_data -> TransportType::read | Treat n==0 as EOF: `if n==0 { return Err(NetworkError) }` after each read/write in the while loop. | weakness | The infinite busy-loop on EOF is a correctness bug that defeats the async timeout mechanism, but its impact is purely availability. The VMM controls the vsock transport layer and can simulate connection close at will, yet it already possesses unlimited DoS capability over MigTD through scheduling denial and VMCALL non-response. The fix converts an unrecoverable hang into a clean error return, which is good defensive coding, but does not block an attack class the adversary lacked before. |
| 4 | Low | Divide-by-zero on VMM-controlled CPUID.15H.EAX in schedule_timeout | init_sys_tick -> schedule_timeout -> __cpuid_count(0x15) | Validate cpuid.eax!=0 (and ebx/ecx sane) before division; fall back to a fixed TSC freq or return Err. | weakness | The finding is valid in that CPUID.15H is virtualized by the VMM in TDX and a malicious VMM could return eax=0, triggering a division-by-zero CPU exception in cpuid.ebx / cpuid.eax. However, the security impact is negligible: a VMM that wants to crash or DoS MigTD has countless other mechanisms (ignore VCALLs, corrupt shared memory, withhold interrupts, return garbage from any other virtualized interface). This check closes one specific crash vector but does not materially change the security posture. The fix is correct and cheap, but it is defensive hardening rather than a meaningful vulnerability remediation. |
| 5 | Medium | .unwrap() on pci::find_device  --  VMM omits device -> boot panic | main -> init_devices -> virtio_vsock_device_init -> pci::find_device | Replace .unwrap()/.expect() with `?` propagating to a graceful init-failure report (panic_with_guest_crash_reg_report or Err). | weakness | he finding is valid in that pci::find_device can return None if VMM omits the expected device, and the original .unwrap() panicked without reporting the failure reason through guest crash registers. However, the security impact is negligible: a VMM that omits the required virtio device is effectively denying migration to itself, and the TD cannot continue without it — halting is the only correct outcome regardless. |
| 6 | Low | get_ccel .expect() panics if td-shim ACPI handoff lacks CCEL or has <4-byte entry | do_measurements -> get_event_log_mut -> get_ccel -> get_acpi_tables | Use t.get(..4)==Some(b"CCEL") and return None instead of .expect(). | weakness | The event_log_slice function previously called from_raw_parts_mut(ccel.lasa, ccel.laml) without validating the CCEL fields, which is technically undefined behavior if lasa is null or laml is unreasonably large. However, the CCEL ACPI table is created by td-shim (firmware), which is part of the TCB and measured into MRTD at boot. The VMM does not control lasa/laml — they are set by firmware when it allocates the event log area in TD private memory. The only scenario where these values would be invalid is a firmware bug, which already compromises the entire security model. |
| 7 | Low | VmcallServiceResponse::try_read validates length but never truncates stored slic | <entry> -> try_read | Slice input to &data[..length] before storing in VmcallServiceResponse. | weakness | The response buffer resides in shared memory fully controlled by the VMM. The VMM writes both the length field and all data bytes in the buffer. Without the truncation, the VMM could make MigTD parse data beyond the declared length — but since the VMM also placed that data there, it gains no additional capability it did not already have by simply declaring a larger length. The fix enforces GHCI protocol framing discipline but does not block any attack that the VMM could not already perform through the legitimate protocol interface. |
| 8 | High | event_log_slice builds &'static mut [u8] from ACPI CCEL lasa/laml unvalidated | <entry> -> event_log_slice | Validate lasa/laml against td-shim memory map; cache slice in OnceCell to avoid aliasing; fix [..size+1] to [..size]. | weakness | The lasa and laml values come from the CCEL ACPI table created by td-shim, which is measured firmware in the TCB — the VMM cannot control or modify them because they reside in TD private memory. A null lasa would require a td-shim bug, which would change the MRTD measurement and be rejected by policy. The check prevents undefined behavior (null slice construction) only in the hypothetical case of a faulty firmware, making it pure defense-in-depth with no realistic attack path. |
| 9 | Low | get_ccel .expect() panics if ACPI CCEL absent or table <4 bytes | <entry> -> get_ccel | Return Option/Result; caller degrades gracefully (skip event-log feature) instead of panic. | weakness | The CCEL ACPI table is created by td-shim firmware, which is part of the TCB and measured into MRTD at boot. Its absence or a sub-4-byte ACPI table entry would indicate a firmware bug, not a VMM attack — the VMM cannot inject or remove ACPI tables from TD private memory after launch. The fix improves error handling quality (graceful None propagation instead of a bare panic without crash-register reporting), but does not close an attacker-reachable vulnerability. On any correctly-configured production system the .expect() would never fire; the improvement is purely in debuggability and robustness against hypothetical firmware defects. |