### PR TITLE
fix(vsock): packet/credit/dump validation from security audit

### DIFF
--- a/src/devices/vsock/src/protocol.rs
+++ b/src/devices/vsock/src/protocol.rs
@@ -133,6 +133,10 @@ impl<T: AsRef<[u8]>> Packet<T> {
         if op == 0 || op > 7 {
             return Err(VsockError::Malformed);
         }
+        // Validate data_len doesn't exceed the buffer beyond the header
+        if self.header_len() + self.data_len() as usize > self.buffer.as_ref().len() {
+            return Err(VsockError::Truncated);
+        }
         Ok(())
     }
 

--- a/src/devices/vsock/src/stream.rs
+++ b/src/devices/vsock/src/stream.rs
@@ -386,12 +386,12 @@ impl VsockStream {
                 if packet.data_len() > 0 {
                     let mut recv = vsock_transport_dequeue(self, DEFAULT_TIMEOUT).await?;
 
-                    self.rx_cnt += packet.data_len();
                     if packet.data_len() as usize <= recv.len() {
                         recv.truncate(packet.data_len() as usize);
                     } else {
                         return Err(VsockError::Illegal);
                     }
+                    self.rx_cnt = self.rx_cnt.wrapping_add(packet.data_len());
 
                     // Send credit update if the free space is less than a max packet size
                     if self.free_space() < MAX_VSOCK_PKT_DATA_LEN as u32 {

--- a/src/devices/vsock/src/transport/vmcall.rs
+++ b/src/devices/vsock/src/transport/vmcall.rs
@@ -26,6 +26,8 @@ const COMMAND_RECV: u8 = 4;
 const MAX_VSOCK_MTU: usize = 0x1000 * 16;
 const VMCALL_COMMON_HEADER_LEN: usize = 36;
 const VMCALL_STATUS_RESERVED: u32 = 0xffff_ffff;
+// Reply data layout: [0] version, [1] command, [2..4] reserved, [4..12] MigRequestId
+const VMCALL_REPLY_DATA_HEADER_LEN: usize = 12;
 const VMCALL_VECTOR: u8 = 0x52;
 pub(crate) const MAX_VSOCK_PKT_DATA_LEN: usize =
     MAX_VSOCK_MTU - VMCALL_COMMON_HEADER_LEN - HEADER_LEN;
@@ -193,11 +195,16 @@ async fn vmcall_service_migtd_send(
         }
 
         // Do the sanity check
-        if reply.guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes()
+        if reply.data().len() < VMCALL_REPLY_DATA_HEADER_LEN
+            || reply.guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes()
             || reply.status() != 0
             || reply.data()[0] != CURRENT_VERSION
             || reply.data()[1] != COMMAND_SEND
-            || u64::from_le_bytes(reply.data()[4..12].try_into().unwrap()) != mid
+            || u64::from_le_bytes(
+                reply.data()[4..VMCALL_REPLY_DATA_HEADER_LEN]
+                    .try_into()
+                    .unwrap(),
+            ) != mid
         {
             return Poll::Ready(Err(VsockTransportError::InvalidParameter));
         }
@@ -231,16 +238,21 @@ async fn vmcall_service_migtd_receive(
         }
 
         // Do the sanity check
-        if reply.guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes()
+        if reply.data().len() < VMCALL_REPLY_DATA_HEADER_LEN
+            || reply.guid() != VMCALL_SERVICE_MIGTD_GUID.as_bytes()
             || reply.status() != 0
             || reply.data()[0] != CURRENT_VERSION
             || reply.data()[1] != COMMAND_RECV
-            || u64::from_le_bytes(reply.data()[4..12].try_into().unwrap()) != mid
+            || u64::from_le_bytes(
+                reply.data()[4..VMCALL_REPLY_DATA_HEADER_LEN]
+                    .try_into()
+                    .unwrap(),
+            ) != mid
         {
             return Poll::Ready(Err(VsockTransportError::InvalidParameter));
         }
 
-        recv_packet(&reply.data()[12..])?;
+        recv_packet(&reply.data()[VMCALL_REPLY_DATA_HEADER_LEN..])?;
         Poll::Ready(pop_stream_queues(addrs).ok_or(VsockTransportError::InvalidVsockPacket))
     })
     .await


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Medium | vsock Packet::check validates header len but not data_len vs buffer | <entry> -> check | In check(), require HEADER_LEN+data_len()<=buf.len(); return Err otherwise. | true_positive |  |
| 2 | Low | vsock credit counters rx_cnt/tx_cnt unchecked u32 add (wrap) | <entry> -> recv_packet_connected | Use wrapping_add intentionally per virtio-vsock spec, but move rx_cnt update AFTER data_len<=recv.len() check. | true_positive |  |
| 3 | Low | Slice index panic on VMM-controlled response length: Response::new() (vmcall.rs: |  | Review the finding context and add appropriate input validation or guard checks. | weakness | The reply.data()[0], reply.data()[1], and reply.data()[4..12] accesses can panic if the VMM returns a response with length == 24 (valid per Response::new() but leaving data() empty). The impact is exclusively a panic (DoS). The response buffer resides in shared memory fully controlled by the VMM, which already has unlimited DoS capability over MigTD through scheduling denial, VMCALL non-response, or simply returning VMCALL_STATUS_RESERVED indefinitely. |
| 4 | High | INV-1 violated: VMM shared-mem parsed in-place, not copied to private | handle_pre_mig -> vsock_transport_dequeue -> vmcall_service_migtd_receive -> Response::new -> Response::data | Copy response[..length] into private Vec<u8> immediately after Response::new validation; parse from private copy. Same fix for vmcall_raw process_buffer and session.rs:746. | true_positive | Both the send and receive poll_fn sanity checks read reply.data()[0], data()[1] and data()[4..12] with no prior length check, so a VMM setting the response length field to 24 makes data() empty and data()[0] panic the guest - a genuine host-triggered denial of service reachable directly from untrusted VMM input on every vmcall-vsock request. The broader "parse-in-place / re-read across polls" framing is weaker (the real payload is copied into a private Vec in recv_packet and bound to the request via mid), but the concrete out-of-bounds panic is a real, exploitable defect |
