### PR TITLE
fix(collateral-generator): cap PCS response body before deserialize

### DIFF
--- a/tools/migtd-collateral-generator/src/pcs_client.rs
+++ b/tools/migtd-collateral-generator/src/pcs_client.rs
@@ -206,6 +206,11 @@ fn remove_header_case_insensitive(
 const INITIAL_RETRY_DELAY_SECS: u64 = 10;
 /// Maximum retry delay in seconds. Once the next delay would exceed this, error out.
 const MAX_RETRY_DELAY_SECS: u64 = 180;
+/// Maximum accepted size (in bytes) for a single PCS response body. PCS
+/// collateral (root CA, CRLs, QE identity, TCB info, FMSPC list) is at most a
+/// few tens of KB; this generous cap prevents a compromised or misbehaving
+/// endpoint from exhausting build-host memory with an unbounded response.
+const MAX_PCS_RESPONSE_SIZE: usize = 16 * 1024 * 1024;
 
 pub async fn fetch_data_from_url(url: &str) -> Result<PcsResponse> {
     let client = Client::new();
@@ -234,7 +239,7 @@ pub async fn fetch_data_from_url(url: &str) -> Result<PcsResponse> {
 }
 
 async fn send_request(client: &Client, url: &str) -> Result<PcsResponse> {
-    let response = client.get(url).send().await?;
+    let mut response = client.get(url).send().await?;
     let status = response.status().as_u16() as u32;
 
     // Treat server errors (5xx), 429 (Too Many Requests) and 408 (Request
@@ -256,7 +261,20 @@ async fn send_request(client: &Client, url: &str) -> Result<PcsResponse> {
         );
     }
 
-    let data = response.bytes().await?.to_vec();
+    // Stream the body with a hard cap instead of buffering an unbounded
+    // `bytes()` so a compromised or misbehaving endpoint cannot exhaust
+    // build-host memory with an oversized response.
+    let mut data = Vec::new();
+    while let Some(chunk) = response.chunk().await? {
+        if data.len() + chunk.len() > MAX_PCS_RESPONSE_SIZE {
+            return Err(anyhow!(
+                "Response body from {} exceeds {}-byte cap",
+                url,
+                MAX_PCS_RESPONSE_SIZE
+            ));
+        }
+        data.extend_from_slice(&chunk);
+    }
 
     Ok(PcsResponse {
         response_code: status,


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Low | fetch_fmspc_list serde_json on raw PCS body  --  unbounded array | <entry> -> fetch_fmspc_list | Cap body size before deserialize. | weakness | The missing size cap is real, but the finding mislocates it: by the time serde_json::from_slice runs, the whole body is already buffered in pcs_response.data, so the unbounded allocation is actually the HTTP body read in send_request, and it affects every PCS fetch, not just fetch_fmspc_list. It's a build-time tool behind CFV_BUILDTIME_CONFIG (tier T4), and it only triggers if PCS is compromised or TLS is MITM'd — a threat that already lets an attacker inject arbitrary collateral, making a self-inflicted build-host OOM strictly less severe. |