### PR TITLE
fix(policy): hex parsing and collateral handling from security audit

### DIFF
--- a/src/policy/src/v2/collaterals.rs
+++ b/src/policy/src/v2/collaterals.rs
@@ -18,8 +18,12 @@ pub fn get_fmspc_from_quote(quote: &[u8]) -> Result<[u8; 6], PolicyError> {
     let start_index = mid.find(PEM_CERT_BEGIN).ok_or(PolicyError::InvalidQuote)?;
     let end_index = mid[start_index..]
         .find(PEM_CERT_END)
-        .map(|i| start_index + i + PEM_CERT_END.len())
+        .and_then(|i| i.checked_add(start_index))
+        .and_then(|i| i.checked_add(PEM_CERT_END.len()))
         .ok_or(PolicyError::InvalidQuote)?;
+    if start_index >= end_index {
+        return Err(PolicyError::InvalidQuote);
+    }
 
     let pck_cert = mid[start_index..end_index].as_bytes();
     let pck_der = crypto::pem_cert_to_der(pck_cert).map_err(|_| PolicyError::InvalidQuote)?;

--- a/src/policy/src/v2/mod.rs
+++ b/src/policy/src/v2/mod.rs
@@ -53,21 +53,17 @@ fn verify_event_hash(
 
 /// Convert a hex string to bytes without using external crates
 fn hex_string_to_bytes(hex: &str) -> Result<Vec<u8>, PolicyError> {
-    // Ensure even number of characters
-    if hex.is_empty() || hex.len() % 2 != 0 {
+    // Ensure even number of characters and ASCII-only
+    if hex.is_empty() || hex.len() % 2 != 0 || !hex.is_ascii() {
         return Err(PolicyError::InvalidParameter);
     }
 
     let mut bytes = Vec::with_capacity(hex.len() / 2);
 
-    // Process two hex digits at a time
-    for i in (0..hex.len()).step_by(2) {
-        if i + 2 > hex.len() {
-            break;
-        }
-
-        // Get the hex byte as a string slice
-        let byte_str = &hex[i..i + 2];
+    // Process two hex digits at a time using bytes to avoid char-boundary issues
+    for chunk in hex.as_bytes().chunks_exact(2) {
+        // Safety: we verified is_ascii() above so each byte is a valid single-char str
+        let byte_str = core::str::from_utf8(chunk).map_err(|_| PolicyError::InvalidParameter)?;
 
         // Convert to numeric value
         let byte = u8::from_str_radix(byte_str, 16).map_err(|_| PolicyError::InvalidParameter)?;


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Low | hex_string_to_bytes panics on multi-byte UTF-8 char at odd index in policy hex field | authenticate_remote -> MigPolicy::from_json -> hex_string_to_bytes | Validate hex.is_ascii() before slicing; or iterate .as_bytes().chunks_exact(2). | weakness | The &hex[i..i+2] slice panics only if the input string contains multi-byte UTF-8 characters, which can only happen if the policy JSON (loaded from VMM-provided configuration) contains non-ASCII in a hex field. The impact is exclusively a panic (DoS). The policy JSON is delivered by the VMM which already has full denial-of-service capability over the TD through scheduling, interrupt injection, or simply not providing the configuration at all. The fix is a robustness improvement converting a panic into a clean error, but the original code gave the VMM no new attack class beyond what it already possesses. |