### PR TITLE
fix(vmcall_raw): return constructed error instead of discarding it

### DIFF
--- a/src/devices/vmcall_raw/src/stream.rs
+++ b/src/devices/vmcall_raw/src/stream.rs
@@ -48,7 +48,7 @@ impl VmcallRaw {
     }
 
     pub async fn connect(&mut self) -> Result {
-        let _ = vmcall_raw_transport_init();
+        vmcall_raw_transport_init()?;
         VMCALL_MIG_CONTEXT_FLAGS
             .lock()
             .insert(self.addr.transport_context(), AtomicBool::new(false));


### PR DESCRIPTION
 | # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
 |---|---|---|---|---|---|---|
 | 1 | High | vmcall_raw `let _ = Poll::Ready(Err(...))` constructs error then discards it | <entry> -> vmcall_service_migtd_send | Change to `return Poll::Ready(Err(VmcallRawError::Illegal));` in both send and receive. | true_positive |  |