### PR TITLE
fix(virtio_serial): port_id validation and DMA free ordering from sec…

### DIFF
--- a/src/devices/virtio_serial/src/lib.rs
+++ b/src/devices/virtio_serial/src/lib.rs
@@ -502,10 +502,12 @@ impl VirtioSerial {
                     let control_msg =
                         unsafe { core::slice::from_raw_parts(vq_buf.addr as *const u8, safe_len) };
 
-                    self.handle_control_msg(control_msg)?;
+                    let result = self.handle_control_msg(control_msg);
 
                     self.free_dma_memory(vq_buf.addr)
                         .ok_or(VirtioSerialError::OutOfResource)?;
+
+                    result?;
                 }
             }
         }
@@ -594,6 +596,9 @@ impl VirtioSerial {
         if data.is_empty() || data.len() > u32::MAX as usize {
             return Err(VirtioSerialError::InvalidParameter);
         }
+        if port_id >= MAX_PORT_SUPPORTED as u32 {
+            return Err(VirtioSerialError::InvalidParameter);
+        }
 
         let mut g2h = Vec::new();
         let dma = self
@@ -628,7 +633,7 @@ impl VirtioSerial {
         if port_id == 0 {
             0
         } else {
-            2 + port_id as u16 * 2
+            2u16.saturating_add((port_id as u16).saturating_mul(2))
         }
     }
 


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Medium | virtio_serial recv_control: handle_control_msg `?` returns before free_dma_memory | virtio_serial_device_init -> VirtioSerial::recv_control -> VirtioSerial::handle_control_msg | Move free_dma_memory before handle_control_msg, or capture result and free in all branches. | true_positive |  |
| 2 | Low | virtio_serial enqueue indexes self.queues with unchecked port_id | <entry> -> VirtioSerial::enqueue | Validate port_id<MAX_PORT_SUPPORTED at entry; return Err. | true_positive |  |
| 3 | Info | port_queue_index: 2+(port_id as u16)*2 wraps u16 for port_id>=32767 | handle_control_msg -> enqueue -> port_queue_index | Use checked arithmetic: 2u16.checked_add((port_id as u16).checked_mul(2)?)? or assert port_id < MAX_PORT_SUPPORTED inside port_queue_index. | weakness | The overflow path is currently unreachable because all callers cap port_id to {0,1} via the handle_control_msg guard at line 530. The saturating arithmetic alone does not produce a correct index for large values — it merely prevents silent wraparound. This is defense-in-depth hardening against a theoretical future regression, not an exploitable bug today. |