### PR TITLE
fix(virtio): MemoryRegion slice bounds use byte length from security …

### DIFF
--- a/src/devices/virtio/src/mem.rs
+++ b/src/devices/virtio/src/mem.rs
@@ -56,9 +56,16 @@ impl MemoryRegion {
 
     /// Expose a section of the memory region as a slice
     pub fn as_slice<T>(&mut self, offset: u64, length: u64) -> Result<&[T], MemoryRegionError> {
+        let byte_length =
+            length
+                .checked_mul(core::mem::size_of::<T>() as u64)
+                .ok_or(MemoryRegionError {
+                    region: *self,
+                    offset,
+                })?;
         if self.base.checked_add(offset).is_none()
             || offset
-                .checked_add(length)
+                .checked_add(byte_length)
                 .and_then(|end| if end > self.length { None } else { Some(end) })
                 .is_none()
         {
@@ -79,9 +86,16 @@ impl MemoryRegion {
         offset: u64,
         length: u64,
     ) -> Result<&mut [T], MemoryRegionError> {
+        let byte_length =
+            length
+                .checked_mul(core::mem::size_of::<T>() as u64)
+                .ok_or(MemoryRegionError {
+                    region: *self,
+                    offset,
+                })?;
         if self.base.checked_add(offset).is_none()
             || offset
-                .checked_add(length)
+                .checked_add(byte_length)
                 .and_then(|end| if end > self.length { None } else { Some(end) })
                 .is_none()
         {


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | High | MemoryRegion::as_slice/as_mut_slice compare element-count to byte-length | <entry> -> MemoryRegion::as_mut_slice | Compare offset+length*size_of::<T>() <= self.length. | weakness | The bounds check had a genuine unit mismatch bug (comparing element count to byte length), which would allow creating an out-of-bounds slice when sizeof(T) > 1. However, both as_slice and as_mut_slice are dead code — they have zero callers in the entire codebase (the file is annotated #![allow(dead_code)]). |