### PR TITLE
fix(pci): BAR sizing and MMIO bounds from security audit

### DIFF
--- a/src/devices/pci/src/config.rs
+++ b/src/devices/pci/src/config.rs
@@ -454,10 +454,7 @@ impl PciDevice {
                     2 => {
                         self.bars[current_bar].bar_type = PciBarType::MemorySpace64;
 
-                        let mut size = self.get_bar_size(current_bar_offset)? as u64;
-                        if size == 0 {
-                            size = (self.get_bar_size(current_bar_offset + 4)? as u64) << 32;
-                        }
+                        let size = self.get_bar_size64(current_bar_offset)?;
 
                         let addr = if size > 0 {
                             let addr = alloc_mmio64(size)?;
@@ -515,34 +512,31 @@ impl PciDevice {
                 // bits 2-1 are the type 0 is 32-but, 2 is 64 bit
                 match bar >> 1 & 3 {
                     0 => {
-                        let size = self.read_u32(current_bar_offset)?;
+                        let size = self.get_bar_size(current_bar_offset)?;
 
-                        let addr = if size > 0 {
+                        if size > 0 {
                             let addr = alloc_mmio32(size)?;
                             self.set_bar_addr(current_bar_offset, addr)?;
-                            addr
+                            self.bars[current_bar].bar_type = PciBarType::MemorySpace32;
+                            self.bars[current_bar].address =
+                                u64::from(addr & PCI_MEM32_BASE_ADDRESS_MASK);
                         } else {
-                            bar
-                        };
-
-                        self.bars[current_bar].bar_type = PciBarType::MemorySpace32;
-                        self.bars[current_bar].address =
-                            u64::from(addr & PCI_MEM32_BASE_ADDRESS_MASK);
+                            self.bars[current_bar].bar_type = PciBarType::MemorySpace32;
+                            self.bars[current_bar].address = 0;
+                        }
                     }
                     2 => {
                         self.bars[current_bar].bar_type = PciBarType::MemorySpace64;
 
-                        let mut size = self.read_u64(current_bar_offset)?;
-                        let addr = if size > 0 {
+                        let size = self.get_bar_size64(current_bar_offset)?;
+                        if size > 0 {
                             let addr = alloc_mmio64(size)?;
                             self.set_bar_addr(current_bar_offset, addr as u32)?;
                             self.set_bar_addr(current_bar_offset + 4, (addr >> 32) as u32)?;
-                            addr
+                            self.bars[current_bar].address = addr & PCI_MEM64_BASE_ADDRESS_MASK;
                         } else {
-                            bar as u64
-                        };
-
-                        self.bars[current_bar].address = addr & PCI_MEM64_BASE_ADDRESS_MASK;
+                            self.bars[current_bar].address = 0;
+                        }
                         current_bar_offset += 4;
                     }
                     _ => return Err(PciError::InvalidBarType),
@@ -572,10 +566,39 @@ impl PciDevice {
         let size = self.read_u32(offset)?;
         self.write_u32(offset, restore)?;
 
-        Ok(if size == 0 {
-            size
+        let masked = size & 0xFFFF_FFF0;
+        Ok(if masked == 0 {
+            0
         } else {
-            !(size & 0xFFFF_FFF0) + 1
+            (!masked).wrapping_add(1)
+        })
+    }
+
+    /// Probe the size of a 64-bit memory BAR.
+    ///
+    /// A 64-bit BAR spans two consecutive 32-bit config registers (`offset` and
+    /// `offset + 4`). The size is determined by writing all ones to both halves,
+    /// reading them back, restoring the original values, and computing the size
+    /// from the combined 64-bit mask. The low 4 bits of the low register encode
+    /// the BAR type, not address bits, so they are masked off; the high register
+    /// is all address bits.
+    fn get_bar_size64(&self, offset: u8) -> Result<u64> {
+        let restore_low = self.read_u32(offset)?;
+        let restore_high = self.read_u32(offset + 4)?;
+
+        self.write_u32(offset, u32::MAX)?;
+        self.write_u32(offset + 4, u32::MAX)?;
+        let low = self.read_u32(offset)?;
+        let high = self.read_u32(offset + 4)?;
+
+        self.write_u32(offset, restore_low)?;
+        self.write_u32(offset + 4, restore_high)?;
+
+        let masked = ((high as u64) << 32) | u64::from(low & 0xFFFF_FFF0);
+        Ok(if masked == 0 {
+            0
+        } else {
+            (!masked).wrapping_add(1)
         })
     }
 

--- a/src/devices/pci/src/mmio.rs
+++ b/src/devices/pci/src/mmio.rs
@@ -25,10 +25,12 @@ pub fn init_mmio() {
     // If an overlap is detected, panic with an error message indicating an invalid MMIO configuration.
     // This ensures that the MMIO space does not conflict with the RAM space.
     for region in memory_map.iter() {
-        if (region.addr < (MMIO32_START + MMIO32_SIZE) as u64
-            && region.addr + region.size > MMIO32_START as u64)
-            || (region.addr < MMIO64_START + MMIO64_SIZE
-                && region.addr + region.size > MMIO64_START)
+        let region_end = region.addr.saturating_add(region.size);
+        let mmio32_end = (MMIO32_START as u64).saturating_add(MMIO32_SIZE as u64);
+        let mmio64_end = MMIO64_START.saturating_add(MMIO64_SIZE);
+
+        if (region.addr < mmio32_end && region_end > MMIO32_START as u64)
+            || (region.addr < mmio64_end && region_end > MMIO64_START)
         {
             panic!("Invalid MMIO configuration: MMIO space overlaps with the RAM space.");
         }
@@ -79,6 +81,10 @@ pub fn alloc_mmio64(size: u64) -> Result<u64> {
 pub fn alloc_mmio64(size: u64) -> Result<u64> {
     let cur = *MMIO64.lock();
     let addr = align_up(cur, size).ok_or(PciError::InvalidParameter)? as u64;
+
+    if size > MMIO64_SIZE || addr > MMIO64_START + MMIO64_SIZE - size {
+        return Err(PciError::MmioOutofResource);
+    }
 
     *MMIO64.lock() = addr.checked_add(size).ok_or(PciError::InvalidParameter)?;
     Ok(addr)


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | High | PCI BAR raw VMM address stored when get_bar_size()==0 or IoSpace | <entry> -> PciDevice::init | Reject size==0 BARs; never store raw host BAR addr  --  always route through alloc_mmio* or reject. | true_positive |  |
| 2 | Medium | get_bar_size: !(size&0xFFFFFFF0)+1 wraps u32->0 when host returns size in 1..=0xF | <entry> -> PciDevice::get_bar_size | Mask first, check ==0, then use wrapping_neg or explicit (!x).wrapping_add(1) with zero-check. | weakness | A hostile VMM supplying 0x1..=0xF would just result in size 0 and the BAR being treated as unimplemented — no actual exploit. The fix improves correctness and clarity but the old code was not exploitable in production. |
| 3 | Medium | alloc_mmio64 lacks upper-bound check; init_mmio overlap check can wrap | <entry> -> alloc_mmio64 | Add MMIO64_START+MMIO64_SIZE bound; use checked_add in init_mmio overlap test. | weakness | The old code used plain + which in release mode wraps on overflow and in debug mode panics, but the operands come from trusted sources: MMIO constants are small compile-time values that cannot overflow u64, and the memory map is populated from TD-Shim HOBs during early trusted initialization with physical addresses limited to 52 bits on x86. No realistic input can trigger the overflow. The saturating_add change improves defensive coding style but does not fix an exploitable or reachable bug. |
