### PR TITLE
docs(migtd): add AI assistance policy to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,3 +101,57 @@ Use your real name (sorry, no pseudonyms or anonymous contributions.)
 
 If you set your `user.name` and `user.email` git configs, you can sign your
 commit automatically with `git commit -s`.
+
+### AI assistance
+
+Contributions may be developed with the help of AI coding assistants. When they
+are, three rules apply. They follow from the fact that the DCO is a
+certification that **only a human** can make. Generative-AI assistance must be
+declared with the name and version of the tool used.
+This mirrors the [Linux kernel policy on AI coding assistants](https://docs.kernel.org/process/coding-assistants.html).
+
+#### 1. Do NOT attribute AI in `Signed-off-by`
+
+An AI tool **must not** be named in a `Signed-off-by` line, and a contributor
+must never sign off on behalf of an AI tool. The `Signed-off-by` line is the DCO
+certification described above: it is a legal statement that a human makes and
+takes responsibility for. A human contributor remains fully responsible for an
+AI-assisted contribution, including:
+
+- reviewing and understanding all AI-generated code;
+- confirming it is correct and complies with the project's license; and
+- certifying the DCO with their own `Signed-off-by` line.
+
+#### 2. Do NOT attribute AI in `Co-authored-by`
+
+An AI tool **must not** be named in a `Co-authored-by` line. That trailer marks
+a co-author of the commit, and authorship of a contribution to this project
+rests with the human contributors who are responsible for it, not with the AI
+tool that assisted them. Record AI involvement with `Assisted-by` instead (see
+below).
+
+#### 3. DO attribute AI in `Assisted-by`
+
+If a commit was generated or assisted by an AI tool, **declare it** with an
+`Assisted-by` trailer that includes the tool's name and the model version.
+Use the format:
+
+```
+Assisted-by: AGENT_NAME:MODEL_VERSION [TOOL1] [TOOL2]
+```
+
+- `AGENT_NAME` — the name of the AI tool or agent.
+- `MODEL_VERSION` — the specific model and version used.
+- `[TOOL1] [TOOL2]` — optional; additional specialized analysis tools.
+  Everyday utilities (git, the compiler, make, editors, etc.) should be omitted.
+
+Example commit trailer block:
+
+```
+Signed-off-by: Jane Developer <jane.developer@example.com>
+Assisted-by: Claude Code:claude-opus-4-8
+```
+
+The `Signed-off-by` line is still required and is still the human contributor's
+own certification; the `Assisted-by` line is added in addition to it, never
+instead of it.


### PR DESCRIPTION
Add a three-rule section on the use of AI coding assistants, mirroring the Linux kernel policy on AI coding assistants:

1. AI must not be named in Signed-off-by (DCO is a human-only certification).
2. AI must not be named in Co-authored-by (authorship rests with the human contributors responsible for the change).
3. AI assistance must be declared with Assisted-by, including the tool name and model version.