### PR TITLE
fix(migtd/migration): restrict GetTDReport to emulation builds

### DIFF
--- a/src/migtd/src/bin/migtd/main.rs
+++ b/src/migtd/src/bin/migtd/main.rs
@@ -541,6 +541,7 @@ fn handle_pre_mig() {
                             );
                             REQUESTS.lock().remove(&rebinding_info.mig_request_id);
                         }
+                        #[cfg(feature = "AzCVMEmu")]
                         WaitForRequestResponse::GetTdReport(wfr_info) => {
                             log::trace!(migration_request_id = wfr_info.mig_request_id; "Processing GetTdReport request\n");
                             let status = get_tdreport(

--- a/src/migtd/src/migration/data.rs
+++ b/src/migtd/src/migration/data.rs
@@ -256,6 +256,7 @@ pub enum WaitForRequestResponse {
     StartMigration(MigrationInformation),
     #[cfg(all(feature = "main", feature = "policy_v2"))]
     StartRebinding(MigtdMigrationInformation),
+    #[cfg(feature = "AzCVMEmu")]
     GetTdReport(ReportInfo),
     EnableLogArea(EnableLogAreaInfo),
     #[cfg(feature = "policy_v2")]

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -441,7 +441,22 @@ fn parse_request(
             }
         }
         DataStatusOperation::GetTDReport => {
-            decode_and_dispatch!(ReportInfo, |info| WaitForRequestResponse::GetTdReport(info))
+            #[cfg(feature = "AzCVMEmu")]
+            {
+                decode_and_dispatch!(ReportInfo, |info| WaitForRequestResponse::GetTdReport(info))
+            }
+            #[cfg(not(feature = "AzCVMEmu"))]
+            {
+                log_request_error!(
+                    request_id,
+                    "wait_for_request: GetTDReport is not supported in production builds\n"
+                );
+                reject_request(
+                    pending_error_report,
+                    request_id,
+                    MigrationResult::UnsupportedOperationError,
+                )
+            }
         }
         DataStatusOperation::EnableLogArea => {
             decode_and_dispatch!(EnableLogAreaInfo, |info| {
@@ -1529,14 +1544,22 @@ mod test {
             let buf = build_request_buffer(3, &payload);
             let mut pending = None;
             let result = parse_request(&buf, HDR_LEN, &mut pending);
-            match result {
-                Poll::Ready(Ok(WaitForRequestResponse::GetTdReport(info))) => {
-                    assert_eq!(info.mig_request_id, request_id);
-                    assert_eq!(info.reportdata[0], 0xCC);
+            #[cfg(feature = "AzCVMEmu")]
+            {
+                match result {
+                    Poll::Ready(Ok(WaitForRequestResponse::GetTdReport(info))) => {
+                        assert_eq!(info.mig_request_id, request_id);
+                        assert_eq!(info.reportdata[0], 0xCC);
+                    }
+                    _ => panic!("Expected GetTdReport, got unexpected variant"),
                 }
-                _ => panic!("Expected GetTdReport, got unexpected variant"),
+                cleanup_request(request_id);
             }
-            cleanup_request(request_id);
+            #[cfg(not(feature = "AzCVMEmu"))]
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::UnsupportedOperationError))
+            ));
         }
 
         #[test]
@@ -1546,25 +1569,43 @@ mod test {
             let buf = build_request_buffer(3, &payload);
             let mut pending = None;
             let result = parse_request(&buf, HDR_LEN, &mut pending);
-            match result {
-                Poll::Ready(Ok(WaitForRequestResponse::GetTdReport(info))) => {
-                    assert_eq!(info.mig_request_id, request_id);
-                    assert_eq!(info.reportdata, [0u8; 64]);
+            #[cfg(feature = "AzCVMEmu")]
+            {
+                match result {
+                    Poll::Ready(Ok(WaitForRequestResponse::GetTdReport(info))) => {
+                        assert_eq!(info.mig_request_id, request_id);
+                        assert_eq!(info.reportdata, [0u8; 64]);
+                    }
+                    _ => {
+                        panic!("Expected GetTdReport with zero reportdata, got unexpected variant")
+                    }
                 }
-                _ => panic!("Expected GetTdReport with zero reportdata, got unexpected variant"),
+                cleanup_request(request_id);
             }
-            cleanup_request(request_id);
+            #[cfg(not(feature = "AzCVMEmu"))]
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::UnsupportedOperationError))
+            ));
         }
 
         #[test]
         fn test_parse_get_td_report_wrong_size_rejected() {
-            // 16 bytes is neither 8 nor 72 → read_from_bytes rejects
+            // 16 bytes is neither 8 nor 72. Under AzCVMEmu the payload is decoded
+            // and rejected for its size; production builds reject GetTDReport
+            // outright as unsupported before decoding.
             let buf = build_request_buffer(3, &[0u8; 16]);
             let mut pending = None;
             let result = parse_request(&buf, HDR_LEN, &mut pending);
+            #[cfg(feature = "AzCVMEmu")]
             assert!(matches!(
                 result,
                 Poll::Ready(Err(MigrationResult::InvalidParameter))
+            ));
+            #[cfg(not(feature = "AzCVMEmu"))]
+            assert!(matches!(
+                result,
+                Poll::Ready(Err(MigrationResult::UnsupportedOperationError))
             ));
         }
 


### PR DESCRIPTION
GetTDReport returns a MAC-valid TDREPORT over a VMM-chosen REPORTDATA, giving the host VMM a signing oracle over MigTD's identity (sighting-16709). Combined with the rebinding TDREPORT relay this enables unauthenticated rebinding approval on a same-platform NEW MigTD (sighting-16711).

No production migration or rebinding flow requires the VMM to invoke GetTDReport; all legitimate TDREPORT generation is MigTD-initiated during the RA-TLS handshake. Gate the request dispatch on the AzCVMEmu emulation feature and reject the operation as UnsupportedOperationError in production builds, removing the oracle at its source.


Assisted-by: GitHub Copilot:claude-opus-4-8