### PR TITLE
fix(migtd/spdm): make ExchangeMigrationInfoReq one-shot

### DIFF
--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -53,6 +53,7 @@ pub struct ResponderContextEx<'a> {
     pub responder_context: ResponderContext,
     pub peer_data: Vec<u8>,
     pub info: ResponderContextExInfo<'a>,
+    pub mig_info_exchanged: bool,
     #[cfg(feature = "policy_v2")]
     pub servtd_ext: Option<ServtdExt>,
 }
@@ -140,6 +141,7 @@ pub fn spdm_responder<'a, T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'sta
         responder_context,
         peer_data: Vec::new(),
         info: ResponderContextExInfo::None,
+        mig_info_exchanged: false,
         #[cfg(feature = "policy_v2")]
         servtd_ext: None,
     };
@@ -807,6 +809,14 @@ pub fn handle_exchange_mig_info_req(
         return Err(SPDM_STATUS_INVALID_PARAMETER);
     };
 
+    if unsafe { upcast_mut(responder_context).mig_info_exchanged } {
+        error!("ExchangeMigrationInfoReq replay detected after MSK exchange!\n");
+        if let Some(session) = responder_context.common.get_session_via_id(session_id) {
+            session.teardown();
+        }
+        return Err(SPDM_STATUS_INVALID_STATE_LOCAL);
+    }
+
     let session = responder_context
         .common
         .get_session_via_id(session_id)
@@ -895,6 +905,10 @@ pub fn handle_exchange_mig_info_req(
         &responder_app_context.migration_info,
         &remote_information.key,
     )?;
+
+    unsafe {
+        upcast_mut(responder_context).mig_info_exchanged = true;
+    }
 
     // Write APPROVED_SERVTD_EXT_HASH if SERVTD_EXT was received during attestation
     #[cfg(feature = "policy_v2")]


### PR DESCRIPTION
handle_exchange_mig_info_req had no idempotency latch, so the responder loop would re-run set_mig_version / write_msk if a second ExchangeMigrationInfoReq arrived on an already-established session, overwriting TDCS_FIELD_MIG_VERSION and TDCS_FIELD_MIG_DEC_KEY with peer-chosen values.

The message is only reachable by a mutually-attested, policy-approved peer inside the migrated TD's extended TCB, and the migration version is bounded by the platform's own import-version range, so this is a robustness weakness rather than an exploitable flaw. This change closes it as defense-in-depth and guards against future refactors that might loosen the pre-MSK policy gate.

Add a mig_info_exchanged latch on the MigTD-owned ResponderContextEx (rather than spdmlib's session runtime_info). The handler rejects and tears down the session on any replay, and sets the latch only after the MSK and migration version have been written successfully.


Assisted-by: GitHub Copilot:claude-opus-4.8