### PR TITLE
fix(tdx-tdcall/logging_emu): validate log area address before deref

### DIFF
--- a/deps/td-shim-AzCVMEmu/tdx-tdcall/src/logging_emu.rs
+++ b/deps/td-shim-AzCVMEmu/tdx-tdcall/src/logging_emu.rs
@@ -153,6 +153,11 @@ impl LogAreaManager {
         buffer_addr: usize,
         last_read_offset: usize,
     ) -> usize {
+        if buffer_addr == 0 {
+            log::warn!("VMM: vCPU {} has null log area address, skipping", vcpu_idx);
+            return last_read_offset;
+        }
+
         let buffer = unsafe { core::slice::from_raw_parts(buffer_addr as *const u8, PAGE_SIZE) };
 
         // Verify signature


### PR DESCRIPTION
`read_vcpu_log_entries_inner()` constructed a `PAGE_SIZE` slice via `core::slice::from_raw_parts()` directly from the `buffer_addr` reported in MigTD's LogArea report, with no null check. A null address (e.g. from a buggy `create_logarea`/`enable_logarea`) would result in an out-of-bounds read in the AzCVMEmu host process (CWE-822, sighting 16732).

Add a guard that rejects a null address before the slice is created, logging a warning and returning the unchanged read offset, mirroring the existing invalid-signature handling.

**Scope:** partial, robustness-only hardening in emulator-only host code; no cross-trust boundary is involved (the address is MigTD's own shared log page in a single process). It intentionally does **not** implement the finding's full "validate against known-allocated pages" suggestion, so a non-null but invalid address is still dereferenced. That case is not reachable from current guest code (the log page is allocated once, never freed, and always non-null), and a range/alignment check is not viable here (the emu log area is a byte-aligned heap allocation, not page-aligned). **CWE-822 is therefore not fully closed by this change.**

**Full coverage** would require tracking the shared log pages the emulator hands out (register each address/size at `alloc_shared_pages` time) and verifying `buffer_addr` lies within a registered region before constructing the slice, rejecting anything else. That adds global allocator-tracking state to this module and is deferred as out of scope for this robustness fix.

Assisted-by: GitHub Copilot:claude-opus-4-8