### PR TITLE
fix(migtd): implement security mitigations for memory safety findings

### DIFF
--- a/deps/td-shim-AzCVMEmu/tdx-tdcall/src/logging_emu.rs
+++ b/deps/td-shim-AzCVMEmu/tdx-tdcall/src/logging_emu.rs
@@ -153,6 +153,14 @@ impl LogAreaManager {
         buffer_addr: usize,
         last_read_offset: usize,
     ) -> usize {
+        // Defensive: the buffer address is reported by the guest's log-area
+        // setup. Reject a null address before constructing a slice over it so a
+        // bad/uninitialized report cannot dereference a null pointer.
+        if buffer_addr == 0 {
+            log::warn!("VMM: vCPU {} log area has null address", vcpu_idx);
+            return last_read_offset;
+        }
+
         let buffer = unsafe { core::slice::from_raw_parts(buffer_addr as *const u8, PAGE_SIZE) };
 
         // Verify signature

--- a/src/devices/virtio/src/virtqueue.rs
+++ b/src/devices/virtio/src/virtqueue.rs
@@ -47,6 +47,15 @@ pub struct VirtQueue {
     free_head: u16,
     avail_idx: u16,
     last_used_idx: u16,
+    /// Private, host-inaccessible copy of the descriptor metadata the driver
+    /// programmed. The descriptor table lives in shared DMA that the host can
+    /// overwrite at any time. Per the TDX Virtual Firmware security requirement
+    /// ("if the data is in shared memory, copy it to private memory, then
+    /// validate and use"), the driver must never trust values read back from
+    /// the shared table. On recycle and free-list traversal it reads
+    /// addr/len/flags/next from this private shadow instead, which neutralizes
+    /// host forgery of desc.addr/len/next.
+    desc_shadow: [DescriptorShadow; MAX_QUEUE_SIZE],
 }
 
 impl VirtQueue {
@@ -82,8 +91,10 @@ impl VirtQueue {
             unsafe { &mut *((dma_addr as usize + layout.used_offset) as *mut UsedRing) };
 
         // link descriptors together
+        let mut desc_shadow = [DescriptorShadow::default(); MAX_QUEUE_SIZE];
         for i in 0..(queue_size - 1) {
             desc[i as usize].next.write(i + 1);
+            desc_shadow[i as usize].next = i + 1;
         }
 
         Ok(VirtQueue {
@@ -96,6 +107,7 @@ impl VirtQueue {
             free_head: 0,
             avail_idx: 0,
             last_used_idx: 0,
+            desc_shadow,
         })
     }
 
@@ -120,14 +132,20 @@ impl VirtQueue {
             last = self.add_descriptor(buf, DescFlags::NEXT | DescFlags::WRITE)?;
         }
 
-        // Clear the 'NEXT' flag of the last added descriptor
-        let desc = self
-            .desc
-            .get_mut(last as usize)
+        // Clear the 'NEXT' flag of the last added descriptor. Update the
+        // private shadow first, then mirror it into the shared table.
+        let last_idx = last as usize;
+        let shadow = self
+            .desc_shadow
+            .get_mut(last_idx)
             .ok_or(VirtioError::InvalidDescriptorIndex)?;
-        let mut flags = desc.flags.read();
-        flags.remove(DescFlags::NEXT);
-        desc.flags.write(flags);
+        shadow.flags.remove(DescFlags::NEXT);
+        let flags = shadow.flags;
+        self.desc
+            .get_mut(last_idx)
+            .ok_or(VirtioError::InvalidDescriptorIndex)?
+            .flags
+            .write(flags);
 
         self.num_used += (g2h.len() + h2g.len()) as u16;
 
@@ -160,16 +178,25 @@ impl VirtQueue {
     }
 
     fn add_descriptor(&mut self, buf: &VirtqueueBuf, flag: DescFlags) -> Result<u16> {
+        let index = self.free_head as usize;
         let desc = self
             .desc
-            .get_mut(self.free_head as usize)
+            .get_mut(index)
             .ok_or(VirtioError::InvalidDescriptorIndex)?;
         desc.set_buf(buf);
         desc.flags.write(flag);
 
+        // Mirror the values the driver just programmed into the private shadow.
+        // The free-list link is advanced from the shadow, never from the shared
+        // table, so a host-forged desc.next cannot corrupt free_head.
+        let shadow = &mut self.desc_shadow[index];
+        shadow.addr = buf.addr;
+        shadow.len = buf.len;
+        shadow.flags = flag;
+
         // Update the free head
         let last = self.free_head;
-        self.free_head = desc.next.read();
+        self.free_head = shadow.next;
 
         Ok(last)
     }
@@ -187,16 +214,22 @@ impl VirtQueue {
         self.free_head = head;
 
         while self.num_used > 0 {
-            let desc = self
-                .desc
-                .get_mut(head as usize)
-                .ok_or(VirtioError::InvalidDescriptorIndex)?;
+            let index = head as usize;
+            // `head` is seeded from the host-controlled used-ring id, so it must
+            // be range-checked before indexing the private shadow.
+            if index >= self.queue_size as usize {
+                return Err(VirtioError::InvalidDescriptorIndex);
+            }
 
-            let flags = desc.flags.read();
+            // Read descriptor metadata from the private shadow, NOT from the
+            // host-writable shared table, so a forged desc.addr/len/next cannot
+            // influence which buffer is recycled or freed.
+            let shadow = self.desc_shadow[index];
+            let flags = shadow.flags;
             self.num_used -= 1;
 
-            let addr = desc.addr.read();
-            let len = desc.len.read();
+            let addr = shadow.addr;
+            let len = shadow.len;
 
             if flags.contains(DescFlags::WRITE) {
                 h2g.push(VirtqueueBuf::new(addr, len));
@@ -208,9 +241,14 @@ impl VirtQueue {
                 if self.num_used == 0 {
                     return Err(VirtioError::InvalidDescriptor);
                 }
-                head = desc.next.read();
+                head = shadow.next;
             } else {
-                desc.next.write(origin_free_head);
+                self.desc_shadow[index].next = origin_free_head;
+                self.desc
+                    .get_mut(index)
+                    .ok_or(VirtioError::InvalidDescriptorIndex)?
+                    .next
+                    .write(origin_free_head);
                 break;
             }
         }
@@ -295,6 +333,30 @@ impl Descriptor {
     fn set_buf(&mut self, buf: &VirtqueueBuf) {
         self.addr.write(buf.addr);
         self.len.write(buf.len);
+    }
+}
+
+/// Private, host-inaccessible copy of the metadata the driver programs into a
+/// descriptor. The shared descriptor table can be overwritten by the host at
+/// any time, so the driver keeps this shadow and reads back addr/len/flags/next
+/// from it on recycle and free-list traversal instead of trusting the shared
+/// table.
+#[derive(Clone, Copy)]
+struct DescriptorShadow {
+    addr: u64,
+    len: u32,
+    flags: DescFlags,
+    next: u16,
+}
+
+impl Default for DescriptorShadow {
+    fn default() -> Self {
+        Self {
+            addr: 0,
+            len: 0,
+            flags: DescFlags::empty(),
+            next: 0,
+        }
     }
 }
 

--- a/src/devices/vsock/src/transport/virtio_pci.rs
+++ b/src/devices/vsock/src/transport/virtio_pci.rs
@@ -19,7 +19,6 @@ use core::task::Poll;
 use lazy_static::lazy_static;
 use spin::{Mutex, Once};
 use td_payload::arch::idt::InterruptStack;
-use td_payload::mm::shared::{alloc_shared_pages, free_shared_pages};
 use virtio::virtqueue::{VirtQueue, VirtQueueLayout, VirtqueueBuf};
 use virtio::{consts::*, VirtioError, VirtioTransport};
 
@@ -63,6 +62,13 @@ pub struct VirtioVsock {
     event: VirtQueue,
     /// DMA record table
     dma_record: BTreeMap<u64, DmaRecord>,
+    /// Base address of the shared pages backing the rx/tx/event virtqueue rings.
+    /// A malicious host can forge `desc.addr` in the shared descriptor table to
+    /// equal this base; `free_dma_memory` must refuse it, otherwise the ring is
+    /// returned to the shared pool while the `VirtQueue` structs still hold
+    /// `&'static mut` references into it (use-after-free / aliasing). The ring is
+    /// only legitimately released on teardown in `Drop`.
+    queue_dma_pages: u64,
     rx_buf_num: usize,
 }
 
@@ -112,8 +118,9 @@ impl VirtioVsock {
             VirtQueueLayout::new(QUEUE_SIZE as u16).ok_or(VirtioError::CreateVirtioQueue)?;
         // We have three queue for vsock (rx, tx and event)
         let queue_size = queue_layout.size() << 2;
-        let queue_dma_pages = unsafe { alloc_shared_pages(queue_size / PAGE_SIZE) }
-            .ok_or(VsockTransportError::DmaAllocation)? as u64;
+        let queue_dma_pages = dma_allocator
+            .alloc_pages(queue_size / PAGE_SIZE)
+            .ok_or(VsockTransportError::DmaAllocation)?;
         dma_record.insert(queue_dma_pages, DmaRecord::new(queue_dma_pages, queue_size));
 
         // program queue rx(idx 0)
@@ -145,6 +152,7 @@ impl VirtioVsock {
             tx: queue_tx,
             event: queue_event,
             dma_record,
+            queue_dma_pages,
             rx_buf_num: 0,
         })
     }
@@ -304,6 +312,15 @@ impl VirtioVsock {
     }
 
     fn free_dma_memory(&mut self, dma_addr: u64) -> Option<u64> {
+        // Never free the virtqueue ring pages at runtime. A malicious host can
+        // forge `desc.addr` in the shared descriptor table to equal the ring
+        // base; freeing it here would leave the live `VirtQueue` references
+        // dangling (use-after-free) and hand the ring pages back out as RX data
+        // buffers. The ring is only released on teardown in `Drop`.
+        if dma_addr == self.queue_dma_pages {
+            return None;
+        }
+
         let record = self.dma_record.get(&dma_addr)?;
 
         self.dma_allocator
@@ -455,7 +472,8 @@ pub fn vsock_transport_can_recv() -> Result<bool> {
 impl Drop for VirtioVsock {
     fn drop(&mut self) {
         for record in &self.dma_record {
-            unsafe { free_shared_pages(record.1.dma_addr as usize, record.1.dma_size / PAGE_SIZE) }
+            self.dma_allocator
+                .free_pages(record.1.dma_addr, record.1.dma_size / PAGE_SIZE);
         }
     }
 }


### PR DESCRIPTION
| # | Assessed Severity | Bug | Call Chain / Location | Fix | Classification | Disposition Reason |
|---|---|---|---|---|---|---|
| 1 | Critical | VMM-forged desc.addr -> free_dma_memory frees queue ring pages -> ring reallocated as data buffer -> host fully controls private ring view | VirtioVsock::new -> VirtQueue::new -> VirtioVsock::pop_used_rx -> VirtioVsock::recv_pkt -> VirtioVsock::free_dma_memory -> dma_allocator.free_pages | Never insert ring/queue infrastructure pages into dma_record; assert in free_dma_memory that addr is not one of self.queue_dma_pages. | true_positive | The unverified precondition is confirmed in code: the ring base queue_dma_pages is inserted into dma_record at VirtioVsock::new (L124), and free_dma_memory will free any matching key, so a host that forges desc.addr == queue_dma_pages in the shared descriptor table makes the guest free its own live ring while VirtQueue still holds &'static mut into it — a genuine use-after-free / &mut aliasing / double-free-at-Drop defect in guest memory safety. That part is real and warrants the fix.<br><br>The escalation to Critical is false. The ring and all data buffers come from alloc_shared_pages, and reallocation returns the page to the shared pool, which is disjoint from the TD-private heap, so the page can never be reissued as private memory. The host already has full DMA read/write access to that shared page by design of the virtio transport, so "host fully controls private ring view" and "addr pointing at TD private heap" overstate it — nothing private is exposed. The realistic impact is a shared-domain UAF/state-corruption/DoS on the guest, not confidentiality loss, so it sits around Medium. |
| 2 | Critical | INV-3 violated: virtqueue desc.next/addr/flags read from shared DMA, no private shadow | vsock_transport_dequeue -> VirtioVsock::pop_used_rx -> VirtQueue::pop_used -> VirtQueue::recycle_descriptors | Maintain private shadow [Descriptor;32] populated at add(); on pop_used validate id<queue_size AND desc.addr/len/next match shadow before use. Reject mismatch. | true_positive | The core claim holds against the code: the descriptor table is a &mut slice over host-writable shared DMA, and recycle_descriptors re-read addr/len/flags/next live from it each iteration with no private copy, which violates the TDX VFW normative rule that shared-memory data must be copied to private memory before validation and use (CWE-823).<br><br>The finding overstates is the impact escalation. The "slice_from_raw_parts at attacker addr" claim does not reach arbitrary TD-private memory, because every consumer sink gates the forged address: recv_pkt only dereferences pkt[0].addr when dma_record.contains_key holds and len == HEADER_LEN, and pkt[1].addr only when dma_record.get returns a record with safe_len = min(len, dma_size). A forged desc.addr can therefore only land on a buffer the guest already allocated in the shared pool, so the realistic primitive is cross-buffer confusion, premature free, free-list cycling, and free_head corruption — that is, DoS and aliasing within the shared DMA pool, not an arbitrary private-memory read or free. |
| 3 | Medium | logging_emu from_raw_parts on buffer_addr parsed from response_data | <entry> -> read_vcpu_log_entries_inner | Validate buffer_addr against known-allocated log pages before constructing slice. | weakness | The unchecked from_raw_parts(buffer_addr, PAGE_SIZE) is real, but the finding's trust model is inverted: this is AzCVMEmu-only host code, and buffer_addr comes from the guest's own log-area report (its own alloc_shared_pages addresses flowing through tdvmcall_migtd_reportstatus → enable_log_area), not from an external untrusted VMM, and everything runs in one process so no privilege boundary is crossed. The realistic impact is a segfault/OOB in the emulator on a buggy or malformed report, which is a robustness defect rather than an exploitable cross-trust vulnerability. |
| 4 | Medium | VirtioVsock::drop frees dma_record entries via free_shared_pages regardless of a | <entry> -> <VirtioVsock as Drop>::drop | Track allocator per dma_record entry; free with matching deallocator. | weakness | In the real MigTD production build the injected Allocator defines alloc_pages as alloc_shared_pages and free_pages as free_shared_pages, so the old Drop that freed every dma_record entry through free_shared_pages happened to hit the exact same allocator — no mismatch, no UB, no heap corruption, and Drop is deterministic teardown rather than anything an untrusted VMM can drive, so the "T1 reachable from untrusted VMM" framing is wrong. The genuine defect is latent inconsistency: Drop bypassed the injected dma_allocator and hardcoded free_shared_pages, while free_dma_memory correctly frees through self.dma_allocator.free_pages, so any non-shared allocator (e.g. the fuzz harness's DmaAlloc, or a future platform) would be allocated by one allocator and freed by another — a true CWE-590 mismatch |
