### PR TITLE
fix(sh_script): create target/release before linking/enrolling images

### DIFF
--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -91,6 +91,7 @@ function cp2bin() {
 function final_test_td_payload() {
     echo "-- Build final binary with test td payload"
     cleanup
+    mkdir -p ./target/release
 
     pushd tests
     cargo build -p test-td-payload --target x86_64-unknown-none --release --features=main,tdx --no-default-features
@@ -299,6 +300,7 @@ function sign() {
 # para 1 - linked migtd name
 # para 2 - Output binary name
 function link() {
+    mkdir -p ./target/release
     pushd deps/td-shim
     cargo run -p td-shim-tools --bin td-shim-ld --no-default-features --features=linker -- \
             target/x86_64-unknown-none/release/ResetVector.bin \
@@ -314,6 +316,7 @@ function link() {
 # para 2 - policy file name
 # para 3 - Output binary name
 function enroll() {
+    mkdir -p ./target/release
     pushd deps/td-shim
     if [[ $1 == *sb* ]]
     then


### PR DESCRIPTION
**Problem**

sh_script/build_final.sh fails during the link step:

```
[ERROR td_shim_tools] Can not open output file ../../target/release/migtd_sb1.bin: No such file or directory (os error 2)
Error: Os { code: 2, kind: NotFound, message: "No such file or directory" }
td-shim-ld (and td-shim-enroll) open their -o target directly and do not create parent directories, so the build aborts if target/release/ is missing.
```

**Root cause of the regression**

PR #936 changed build_migtd() to build the non-attestation configuration with the dev profile instead of --release, because test_disable_ra_and_accept_all is now blocked in release builds by a compile_error! fence in src/migtd/src/lib.rs.

Previously the --release build incidentally created the host target/release/ tree (for build scripts and proc-macro dependencies), which link() and enroll() silently relied on. With the dev-profile build, cargo creates target/debug/ instead and target/release/ is never created. cleanup() also runs cargo clean, removing target/ wholesale, so the directory cannot be created once at startup.

PR #936 already added mkdir -p ./target/x86_64-unknown-none/release for the cross-compiled path, but missed the host target/release/ path used for the final linked and enrolled images.