### PR TITLE
fix(migtd): add TD_INFO compatibility build mode

### DIFF
--- a/.github/workflows/integration-tdx.yml
+++ b/.github/workflows/integration-tdx.yml
@@ -48,7 +48,7 @@ jobs:
         run: bash sh_script/preparation.sh
 
       - name: Build Migration TD binary (policy v1 + TLS + Release)
-        run: cargo image --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+        run: cargo image --no-tdinfo --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
       
       - name: Run Tests
         run: |
@@ -60,7 +60,7 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v2 + TLS + Release)
-        run: cargo image  --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+        run: cargo image --no-tdinfo --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
       
       - name: Run Tests
         run: |
@@ -75,7 +75,7 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v2 + SPDM + Release)
-        run: cargo image --features spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem
+        run: cargo image --no-tdinfo --features spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem
 
       - name: Run Tests - Test pre-binding
         run: |
@@ -106,7 +106,7 @@ jobs:
         run: bash sh_script/preparation.sh
 
       - name: Build Migration TD binary (policy v1 + TLS + Release)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+        run: cargo image --no-tdinfo --no-default-features --features stack-guard,virtio-serial --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
       
       - name: Run Tests
         run: |
@@ -115,7 +115,7 @@ jobs:
           popd
       
       - name: Build all test binaries
-        run: bash sh_script/build_final.sh -t test -c -a on -d serial
+        run: bash sh_script/build_final.sh --no-tdinfo -t test -c -a on -d serial
 
       - name: Run Tests
         run: |
@@ -127,7 +127,7 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v1 + TLS + Debug)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer --debug
+        run: cargo image --no-tdinfo --no-default-features --features stack-guard,virtio-serial --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer --debug
       
       - name: Run Tests
         run: |
@@ -139,7 +139,7 @@ jobs:
         run: cargo clean
       
       - name: Build Migration TD binary (policy v2 + TLS + Release)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+        run: cargo image --no-tdinfo --no-default-features --features stack-guard,virtio-serial --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
       
       - name: Run Tests
         run: |
@@ -151,7 +151,7 @@ jobs:
         run: cargo clean
       
       - name: Build Migration TD binary (policy v2 + TLS + Debug)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer --debug
+        run: cargo image --no-tdinfo --no-default-features --features stack-guard,virtio-serial --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer --debug
       
       - name: Run Tests
         run: |
@@ -166,7 +166,7 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v1 + SPDM + Release)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+        run: cargo image --no-tdinfo --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
 
       - name: Run Tests
         run: |
@@ -181,7 +181,7 @@ jobs:
           popd
       
       - name: Build Migration TD binary (policy v1 + SPDM + Debug)
-        run: cargo image --debug --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+        run: cargo image --no-tdinfo --debug --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
 
       - name: Run Tests
         run: |
@@ -196,7 +196,7 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v2 + SPDM + Release)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem
+        run: cargo image --no-tdinfo --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem
 
       - name: Run Tests
         run: |
@@ -208,7 +208,7 @@ jobs:
         run: cargo clean
 
       - name: Build Migration TD binary (policy v2 + SPDM + Debug)
-        run: cargo image --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --debug
+        run: cargo image --no-tdinfo --no-default-features --features stack-guard,virtio-serial,spdm_attestation --policy-v2 --policy config/templates/policy_v2_signed.json --policy-issuer-chain config/templates/policy_issuer_chain.pem --debug
 
       - name: Run Tests
         run: |

--- a/config/image_layout_no_tdinfo.json
+++ b/config/image_layout_no_tdinfo.json
@@ -1,0 +1,10 @@
+{
+    "Config": "0x0A0000",
+    "Mailbox": "0x001000",
+    "TempStack": "0x010000",
+    "TempHeap": "0x010000",
+    "Metadata": "0x001000",
+    "Payload": "0xEE6000",
+    "Ipl": "0x50000",
+    "ResetVector": "0x008000"
+}

--- a/config/metadata_no_tdinfo.json
+++ b/config/metadata_no_tdinfo.json
@@ -1,0 +1,60 @@
+{
+    "Sections": [
+        {
+            "DataOffset": "0xFA7000",
+            "RawDataSize": "0x59000",
+            "MemoryAddress": "0xFFFA7000",
+            "MemoryDataSize": "0x59000",
+            "Type": "BFV",
+            "Attributes": "0x1"
+        },
+        {
+            "DataOffset": "0xC1000",
+            "RawDataSize": "0xEE6000",
+            "MemoryAddress": "0xFF0C1000",
+            "MemoryDataSize": "0xEE6000",
+            "Type": "Payload",
+            "Attributes": "0x1"
+        },
+        {
+            "DataOffset": "0x0",
+            "RawDataSize": "0xA0000",
+            "MemoryAddress": "0xFF000000",
+            "MemoryDataSize": "0xA0000",
+            "Type": "CFV",
+            "Attributes": "0x0"
+        },
+        {
+            "DataOffset": "0x0",
+            "RawDataSize": "0x0",
+            "MemoryAddress": "0xFF0A1000",
+            "MemoryDataSize": "0x10000",
+            "Type": "TempMem",
+            "Attributes": "0x0"
+        },
+        {
+            "DataOffset": "0x0",
+            "RawDataSize": "0x0",
+            "MemoryAddress": "0xFF0B1000",
+            "MemoryDataSize": "0x10000",
+            "Type": "TempMem",
+            "Attributes": "0x0"
+        },
+        {
+            "DataOffset": "0x0",
+            "RawDataSize": "0x0",
+            "MemoryAddress": "0x0",
+            "MemoryDataSize": "0x2000000",
+            "Type": "PermMem",
+            "Attributes": "0x2"
+        },
+        {
+            "DataOffset": "0x0",
+            "RawDataSize": "0x0",
+            "MemoryAddress": "0xFF0A0000",
+            "MemoryDataSize": "0x1000",
+            "Type": "TempMem",
+            "Attributes": "0x0"
+        }
+    ]
+}

--- a/doc/integration_test.md
+++ b/doc/integration_test.md
@@ -27,9 +27,11 @@ guest_img = "/home/env/guest.img"
 stress_test_cycles = 1
 ```
 ## Build & Test
+The commands below use `--no-tdinfo` for compatibility with QEMU versions that do not support TDVF Type 7.
+
 ### Build Migration TD binary - Vsock
 ```
-cargo image --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+cargo image --no-tdinfo --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
 ```
 ### Run Test
 Set stress_test_cycles to 1 in configration file.
@@ -40,7 +42,7 @@ popd
 ```
 ### Build Migration TD Test binaries - Vsock
 ```
-bash sh_script/build_final.sh -t test -c -a on
+bash sh_script/build_final.sh --no-tdinfo -t test -c -a on
 ```
 ### Run Test
 ```
@@ -50,7 +52,7 @@ popd
 ```
 ### Build Migration TD binary - Serial
 ```
-cargo image --no-default-features --features stack-guard,virtio-serial --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
+cargo image --no-tdinfo --no-default-features --features stack-guard,virtio-serial --policy config/policy_pre_production_fmspc.json --root-ca config/Intel_SGX_Provisioning_Certification_RootCA_preproduction.cer
 ```
 ### Run Test
 Set stress_test_cycles to 1 in configration file.
@@ -61,7 +63,7 @@ popd
 ```
 ### Build Migration TD Test binaries - Serial
 ```
-bash sh_script/build_final.sh -t test -c -a on -d serial
+bash sh_script/build_final.sh --no-tdinfo -t test -c -a on -d serial
 ```
 ### Run Test
 ```

--- a/sh_script/build_final.sh
+++ b/sh_script/build_final.sh
@@ -8,6 +8,10 @@ export AS=nasm
 
 type="full"
 TestBinaries="Bin"
+no_tdinfo=false
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE_LAYOUT_CONFIG="$ROOT_DIR/config/image_layout.json"
+METADATA_CONFIG="$ROOT_DIR/config/metadata.json"
 
 function cleanup() {
     cargo clean
@@ -18,6 +22,17 @@ function cleanup() {
 }
 
 function proccess_args() {
+    local filtered_args=()
+    for arg in "$@"; do
+        if [[ "$arg" == "--no-tdinfo" ]]; then
+            no_tdinfo=true
+        else
+            filtered_args+=("$arg")
+        fi
+    done
+    set -- "${filtered_args[@]}"
+    OPTIND=1
+
     while getopts ":t:a:v:d:c" option; do
         case "${option}" in
             t) type=${OPTARG};;
@@ -54,6 +69,11 @@ function proccess_args() {
         spdm_attestation_serial) MIGTD_FEATURE+=",spdm_attestation,virtio-serial";;
         *) MIGTD_FEATURE+=",virtio-vsock";;
     esac
+
+    if [[ ${no_tdinfo} == true ]]; then
+        IMAGE_LAYOUT_CONFIG="$ROOT_DIR/config/image_layout_no_tdinfo.json"
+        METADATA_CONFIG="$ROOT_DIR/config/metadata_no_tdinfo.json"
+    fi
 }
 
 function check_file_exist() {
@@ -69,6 +89,7 @@ function check_file_exist() {
 function populate_layout() {
     pushd deps/td-shim/devtools/td-layout-config
     cargo run -- -t memory ../../../../config/shim_layout.json -o ../../td-layout/src/runtime/exec.rs
+    cargo run -- -t image "$IMAGE_LAYOUT_CONFIG" -o ../../td-layout/src/build_time.rs
     popd
 }
 
@@ -107,7 +128,7 @@ function final_test_td_payload() {
     cargo run -p td-shim-tools --features="linker" --no-default-features --bin td-shim-ld -- \
             target/x86_64-unknown-none/release/ResetVector.bin \
             target/x86_64-unknown-none/release/td-shim \
-            -m ../../config/metadata.json \
+            -m "$METADATA_CONFIG" \
             -p ../../target/x86_64-unknown-none/release/test-td-payload \
             -o target/x86_64-unknown-none/release/final-test.bin
     
@@ -305,7 +326,7 @@ function link() {
     cargo run -p td-shim-tools --bin td-shim-ld --no-default-features --features=linker -- \
             target/x86_64-unknown-none/release/ResetVector.bin \
             target/x86_64-unknown-none/release/td-shim \
-            -m ../../config/metadata.json \
+            -m "$METADATA_CONFIG" \
             -p ../../target/x86_64-unknown-none/release/$1 \
             -o ../../target/release/$2
     popd
@@ -342,9 +363,9 @@ function enroll() {
 
 ./sh_script/preparation.sh
 
-populate_layout
+proccess_args "$@"
 
-proccess_args $@
+populate_layout
 
 case "${type}" in
     migtd) final_migtd ;;

--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use crate::config;
-use anyhow::{Ok, Result};
+use anyhow::{Context, Ok, Result};
 use clap::{Args, ValueEnum};
 use lazy_static::lazy_static;
 use std::{
@@ -17,6 +17,9 @@ const MIGTD_KVM_FEATURES: &str = MIGTD_DEFAULT_FEATURES;
 const DEFAULT_TDVF_IMAGE_NAME: &str = "migtd.bin";
 const DEFAULT_IGVM_IMAGE_NAME: &str = "migtd.igvm";
 const DEFAULT_IMAGE_FORMAT: &str = "tdvf";
+const MIGTD_TD_INFO_GUID: &str = "dbbdfad7-9cba-4aae-b498-c0fd425860b4";
+const MIGTD_MAX_MIGRATION_CHANNEL_COUNT: u32 = 12;
+const MIGTD_MAX_VCPU_COUNT: u32 = 1;
 
 lazy_static! {
     static ref PROJECT_ROOT: &'static Path =
@@ -27,8 +30,12 @@ lazy_static! {
     static ref DEFAULT_CA: PathBuf =
         PROJECT_ROOT.join("config/Intel_SGX_Provisioning_Certification_RootCA.cer");
     static ref DEFAULT_METADATA: PathBuf = PROJECT_ROOT.join("config/metadata.json");
+    static ref DEFAULT_METADATA_NO_TDINFO: PathBuf =
+        PROJECT_ROOT.join("config/metadata_no_tdinfo.json");
     static ref DEFAULT_SHIM_LAYOUT: PathBuf = PROJECT_ROOT.join("config/shim_layout.json");
     static ref DEFAULT_IMAGE_LAYOUT: PathBuf = PROJECT_ROOT.join("config/image_layout.json");
+    static ref DEFAULT_IMAGE_LAYOUT_NO_TDINFO: PathBuf =
+        PROJECT_ROOT.join("config/image_layout_no_tdinfo.json");
     static ref DEFAULT_SERVTD_INFO: PathBuf = PROJECT_ROOT.join("config/servtd_info.json");
     static ref MMIO_LAYOUT_SOURCE: PathBuf = PROJECT_ROOT.join("src/devices/pci/src/layout.rs");
 }
@@ -82,6 +89,12 @@ pub(crate) struct BuildArgs {
     /// Issuer chain of migration policy v2, required if `policy_v2` is set
     #[clap(long)]
     policy_issuer_chain: Option<PathBuf>,
+    /// Security Version Number recorded in the MigTD TD_INFO structure
+    #[clap(long, default_value_t = 1)]
+    td_info_svn: u32,
+    /// Omit TD_INFO for compatibility with VMMs that do not support TDVF Type 7
+    #[clap(long)]
+    no_tdinfo: bool,
 }
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -134,11 +147,66 @@ impl BuildArgs {
         let migtd = self.build_migtd()?;
         let bin = self.build_final(reset_vector.as_path(), shim.as_path(), migtd.as_path())?;
         self.enroll(bin.as_path())?;
+        self.patch_td_info(bin.as_path())?;
 
         Ok(bin)
     }
 
+    fn patch_td_info(&self, bin: &Path) -> Result<()> {
+        if self.no_tdinfo || self.image_format() != DEFAULT_IMAGE_FORMAT {
+            return Ok(());
+        }
+
+        let payload_path = bin.with_extension("td-info-payload.bin");
+        let mut payload = Vec::with_capacity(8);
+        payload.extend_from_slice(&MIGTD_MAX_MIGRATION_CHANNEL_COUNT.to_le_bytes());
+        payload.extend_from_slice(&MIGTD_MAX_VCPU_COUNT.to_le_bytes());
+        fs::write(&payload_path, payload)?;
+
+        let sh = Shell::new()?;
+        sh.change_dir(SHIM_FOLDER.as_path());
+        let version = self.migtd_version()?;
+        let svn = self.td_info_svn.to_string();
+        let patch_result = cmd!(
+            sh,
+            "cargo run -p td-shim-tools --bin td-shim-patch -- td-info"
+        )
+        .args(["--in", bin.to_str().unwrap()])
+        .args(["--out", bin.to_str().unwrap()])
+        .args(["--guid", MIGTD_TD_INFO_GUID])
+        .args(["--version", version.as_str()])
+        .args(["--svn", svn.as_str()])
+        .args(["--payload-info", payload_path.to_str().unwrap()])
+        .run();
+
+        fs::remove_file(payload_path)?;
+        patch_result?;
+        Ok(())
+    }
+
+    fn migtd_version(&self) -> Result<String> {
+        let sh = Shell::new()?;
+        sh.change_dir(*PROJECT_ROOT);
+        let metadata = cmd!(sh, "cargo metadata --format-version 1 --no-deps").read()?;
+        let metadata: serde_json::Value = serde_json::from_str(&metadata)?;
+        metadata["packages"]
+            .as_array()
+            .and_then(|packages| packages.iter().find(|package| package["name"] == "migtd"))
+            .and_then(|package| package["version"].as_str())
+            .map(ToOwned::to_owned)
+            .context("migtd package version not found in cargo metadata")
+    }
+
     fn check_arguments(&self) -> Result<()> {
+        if !self.no_tdinfo && self.image_format() == DEFAULT_IMAGE_FORMAT && self.td_info_svn == 0 {
+            return Err(anyhow::anyhow!("TD_INFO SVN must be non-zero"));
+        }
+
+        if self.no_tdinfo {
+            self.ensure_td_info_absent(&self.image_layout()?)?;
+            self.ensure_td_info_absent(&self.metadata()?)?;
+        }
+
         if self.policy_v2 {
             if self.policy.is_none() {
                 return Err(anyhow::anyhow!(
@@ -150,6 +218,25 @@ impl BuildArgs {
                     "policy_v2 is enabled but no policy_issuer_chain file is provided"
                 ));
             }
+        }
+        Ok(())
+    }
+
+    fn ensure_td_info_absent(&self, path: &Path) -> Result<()> {
+        let content = fs::read_to_string(path)?;
+        let config: serde_json::Value = serde_json::from_str(&content)?;
+        let contains_td_info = config.get("TdInfo").is_some_and(|value| !value.is_null())
+            || config["Sections"].as_array().is_some_and(|sections| {
+                sections
+                    .iter()
+                    .any(|section| section["Type"].as_str() == Some("TdInfo"))
+            });
+
+        if contains_td_info {
+            return Err(anyhow::anyhow!(
+                "{} contains TdInfo and cannot be used with --no-tdinfo",
+                path.display()
+            ));
         }
         Ok(())
     }
@@ -411,7 +498,12 @@ impl BuildArgs {
     }
 
     fn metadata(&self) -> Result<PathBuf> {
-        let path = self.metadata.as_ref().unwrap_or(&DEFAULT_METADATA);
+        let default: &Path = if self.no_tdinfo {
+            DEFAULT_METADATA_NO_TDINFO.as_path()
+        } else {
+            DEFAULT_METADATA.as_path()
+        };
+        let path = self.metadata.as_deref().unwrap_or(default);
         fs::canonicalize(path).map_err(|e| e.into())
     }
 
@@ -475,7 +567,12 @@ impl BuildArgs {
     }
 
     fn image_layout(&self) -> Result<PathBuf> {
-        let path = self.image_layout.as_ref().unwrap_or(&DEFAULT_IMAGE_LAYOUT);
+        let default: &Path = if self.no_tdinfo {
+            DEFAULT_IMAGE_LAYOUT_NO_TDINFO.as_path()
+        } else {
+            DEFAULT_IMAGE_LAYOUT.as_path()
+        };
+        let path = self.image_layout.as_deref().unwrap_or(default);
         fs::canonicalize(path).map_err(|e| e.into())
     }
 }


### PR DESCRIPTION
Populate the default MigTD TD_INFO structure after image enrollment, while adding --no-tdinfo to select the legacy image layout for QEMU implementations that reject TDVF Type 7.

Use compatibility mode in the TDX integration workflow and legacy test builds without changing the spec-compliant default.


Assisted-by: GitHub Copilot:GPT-5.6 Sol

fixes #1016 