### PR TITLE
fix(vsock): remove redundant buffer check

### DIFF
--- a/src/devices/vsock/src/protocol.rs
+++ b/src/devices/vsock/src/protocol.rs
@@ -133,10 +133,6 @@ impl<T: AsRef<[u8]>> Packet<T> {
         if op == 0 || op > 7 {
             return Err(VsockError::Malformed);
         }
-        // Validate data_len doesn't exceed the buffer beyond the header
-        if self.header_len() + self.data_len() as usize > self.buffer.as_ref().len() {
-            return Err(VsockError::Truncated);
-        }
         Ok(())
     }
 


### PR DESCRIPTION
Drop the check from `Packet::check` and rely on the existing check in `recv_packet_connected`, which already validates the payload against the buffer it was read into

https://github.com/intel/MigTD/blob/f4b93e403fc9be066905d6824385a920ff669a0f/src/devices/vsock/src/stream.rs#L389-L393

This is the real trust boundary; the protocol.rs addition is redundant as well as incorrect for the split header/payload path.