### PR TITLE
fix(migtd-hash): reconstruct IGVM CFV pages by GPA

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1432,9 +1432,11 @@ dependencies = [
  "clap",
  "crypto",
  "env_logger",
+ "igvm",
  "log",
  "migtd",
  "serde_json",
+ "td-layout",
  "td-shim-interface",
  "td-shim-tools",
 ]

--- a/tools/migtd-hash/Cargo.toml
+++ b/tools/migtd-hash/Cargo.toml
@@ -10,8 +10,10 @@ anyhow = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 crypto = { path = "../../src/crypto" }
 env_logger = "0.10"
+igvm = "0.3.4"
 log = "0.4"
 migtd = { path = "../../src/migtd", default-features = false }
 serde_json = "1.0"
+td-layout = { path = "../../deps/td-shim/td-layout" }
 td-shim-tools = { path = "../../deps/td-shim/td-shim-tools", default-features = false, features = ["tee"] }
 td-shim-interface = { path = "../../deps/td-shim/td-shim-interface" }

--- a/tools/migtd-hash/src/lib.rs
+++ b/tools/migtd-hash/src/lib.rs
@@ -4,6 +4,7 @@
 
 use anyhow::{anyhow, Error, Result};
 use crypto::{hash::digest_sha384, SHA384_DIGEST_SIZE};
+use igvm::{IgvmDirectiveHeader, IgvmFile};
 use migtd::{
     config::{
         CONFIG_VOLUME_SIZE, MIGTD_POLICY_FFS_GUID, MIGTD_POLICY_ISSUER_CHAIN_FFS_GUID,
@@ -16,6 +17,7 @@ use std::{
     io::{Read, Seek, SeekFrom},
     mem::size_of,
 };
+use td_layout::build_time::TD_SHIM_CONFIG_BASE;
 use td_shim_interface::td_uefi_pi::{fv, pi};
 use td_shim_tools::tee_info_hash::{Manifest, TdInfoStruct};
 
@@ -66,9 +68,9 @@ pub fn build_td_info(
     let mut cfv = vec![0u8; CONFIG_VOLUME_SIZE];
     image.seek(SeekFrom::Start(0))?;
     if igvmformat {
-        cfv = td_info.read_igvmcfvdata(&mut image);
+        cfv = read_igvm_cfv_data(&mut image)?;
     } else {
-        image.read(&mut cfv)?;
+        image.read_exact(&mut cfv)?;
     }
 
     let rtmr1 = rtmr1(&cfv, &td_info.rtmr1, is_policy_v2)?;
@@ -109,6 +111,46 @@ pub fn build_td_info(
     }
 
     Ok(td_info)
+}
+
+fn read_igvm_cfv_data(image: &mut File) -> Result<Vec<u8>> {
+    let mut contents = Vec::new();
+    image.read_to_end(&mut contents)?;
+    let igvm = IgvmFile::new_from_binary(&contents, None)
+        .map_err(|e| anyhow!("failed to parse IGVM image: {e:?}"))?;
+    let cfv_base = u64::from(TD_SHIM_CONFIG_BASE);
+    let cfv_end = cfv_base + CONFIG_VOLUME_SIZE as u64;
+    let mut cfv = vec![0u8; CONFIG_VOLUME_SIZE];
+
+    for directive in igvm.directives() {
+        let IgvmDirectiveHeader::PageData { gpa, data, .. } = directive else {
+            continue;
+        };
+        copy_igvm_cfv_page(&mut cfv, cfv_base, cfv_end, *gpa, data)?;
+    }
+
+    Ok(cfv)
+}
+
+fn copy_igvm_cfv_page(
+    cfv: &mut [u8],
+    cfv_base: u64,
+    cfv_end: u64,
+    gpa: u64,
+    data: &[u8],
+) -> Result<()> {
+    if gpa < cfv_base || gpa >= cfv_end || data.is_empty() {
+        return Ok(());
+    }
+
+    let start = usize::try_from(gpa - cfv_base)
+        .map_err(|_| anyhow!("IGVM CFV page GPA {gpa:#x} does not fit usize"))?;
+    let end = start
+        .checked_add(data.len())
+        .filter(|end| *end <= cfv.len())
+        .ok_or_else(|| anyhow!("IGVM CFV page at GPA {gpa:#x} exceeds the CFV range"))?;
+    cfv[start..end].copy_from_slice(data);
+    Ok(())
 }
 
 pub fn calculate_servtd_info_hash(td_info: TdInfoStruct) -> Result<Vec<u8>, Error> {
@@ -219,4 +261,27 @@ fn calculate_digest(data: &[u8]) -> Result<Vec<u8>, Error> {
     }
 
     Ok(digest)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::copy_igvm_cfv_page;
+
+    #[test]
+    fn igvm_cfv_pages_preserve_gpa_gaps() {
+        let mut cfv = [0u8; 16];
+        copy_igvm_cfv_page(&mut cfv, 0x1000, 0x1010, 0x1008, &[1, 2, 3, 4]).unwrap();
+
+        assert_eq!(&cfv[..8], &[0u8; 8]);
+        assert_eq!(&cfv[8..12], &[1, 2, 3, 4]);
+        assert_eq!(&cfv[12..], &[0u8; 4]);
+    }
+
+    #[test]
+    fn igvm_cfv_pages_reject_range_overflow() {
+        let mut cfv = [0u8; 16];
+        assert!(copy_igvm_cfv_page(&mut cfv, 0x1000, 0x1010, 0x100f, &[1, 2]).is_err());
+        assert!(copy_igvm_cfv_page(&mut cfv, 0x1000, 0x1010, 0x2000, &[1, 2]).is_ok());
+        assert_eq!(cfv, [0u8; 16]);
+    }
 }


### PR DESCRIPTION
## Problem

The legacy IGVM configuration-volume extractor counts populated CFV pages, copies that many payload pages from the serialized IGVM stream, and pads the remainder with zeroes. This assumes payloads are serialized contiguously in GPA order.

That assumption was previously hidden because generated IGVMs happened to use that layout. With sparse or reordered page payloads, enrolled policy and issuer-chain files can be shifted or omitted from the reconstructed CFV, causing offline RTMR1/RTMR2 and TDINFO measurements to differ from runtime memory.

## Fix

Parse IGVM `PageData` directives and place each payload at its declared guest physical address relative to the CFV base. Preserve sparse gaps and reject pages that extend past the configuration-volume range.

This fix is independent of the proposed one-hash TCB mapping work and applies directly to the existing `migtd-hash` IGVM measurement path.

## Validation

- `cargo test -p migtd-hash`
- `cargo fmt -- --check`
- `cargo check`
- Intel library build and test suite
- All 32 firmware build combinations
- All six tool-package builds
- Cargo deny advisories, sources, and bans
- All 14 Integration (Emulation Mode) scenarios