### PR TITLE
fix(migtd/spdm): make session failures atomic

### DIFF
--- a/src/migtd/src/migration/rebinding.rs
+++ b/src/migtd/src/migration/rebinding.rs
@@ -202,7 +202,7 @@ pub async fn rebinding_old_prepare(
         );
         MigrationResult::SecureSessionError
     })?;
-    with_timeout(
+    let session_result = with_timeout(
         SPDM_TIMEOUT,
         spdm::spdm_requester_rebind_old(
             &mut spdm_requester,
@@ -225,25 +225,34 @@ pub async fn rebinding_old_prepare(
             "rebinding: spdm_requester_rebind_old timeout error: {:?}\n",
             e
         );
-        e
-    })?
-    .map_err(|e| {
-        #[cfg(feature = "vmcall-raw")]
-        data.extend_from_slice(
-            &format!(
-                "Error: rebinding_old_prepare(): spdm_requester_rebind_old failed ({:?}). Migration ID: {:x}\n",
-                e, info.mig_request_id,
-            )
-            .into_bytes(),
-        );
-        log::error!("rebinding: spdm_requester_rebind_old error: {:?}\n", e);
-        spdm::decode_spdm_session_err(e)
-    })?;
-    log::info!("Rebind completed\n");
+        MigrationResult::from(e)
+    })
+    .and_then(|result| {
+        result.map_err(|e| {
+            #[cfg(feature = "vmcall-raw")]
+            data.extend_from_slice(
+                &format!(
+                    "Error: rebinding_old_prepare(): spdm_requester_rebind_old failed ({:?}). Migration ID: {:x}\n",
+                    e, info.mig_request_id,
+                )
+                .into_bytes(),
+            );
+            log::error!("rebinding: spdm_requester_rebind_old error: {:?}\n", e);
+            spdm::decode_spdm_session_err(e)
+        })
+    });
 
+    spdm::teardown_sessions(&mut spdm_requester.common);
     let mut transport_lock = device_io_ref.lock();
     let transport = transport_lock.deref_mut();
-    shutdown_transport(&mut transport.transport, info.mig_request_id).await?;
+    let shutdown_result = shutdown_transport(&mut transport.transport, info.mig_request_id).await;
+
+    if let Err(error) = session_result {
+        let _ = shutdown_result;
+        return Err(error);
+    }
+    shutdown_result?;
+    log::info!("Rebind completed\n");
     Ok(())
 }
 
@@ -273,7 +282,7 @@ pub async fn rebinding_new_prepare(
         MigrationResult::SecureSessionError
     })?;
 
-    with_timeout(
+    let session_result = with_timeout(
         SPDM_TIMEOUT,
         spdm::spdm_responder_rebind_new(
             &mut spdm_responder,
@@ -296,25 +305,34 @@ pub async fn rebinding_new_prepare(
             "rebinding: spdm_responder_rebind_new timeout error: {:?}\n",
             e
         );
-        e
-    })?
-    .map_err(|e| {
-        #[cfg(feature = "vmcall-raw")]
-        data.extend_from_slice(
-            &format!(
-                "Error: rebinding_new_prepare(): spdm_responder_rebind_new failed ({:?}). Migration ID: {:x}\n",
-                e, info.mig_request_id,
-            )
-            .into_bytes(),
-        );
-        log::error!("rebinding: spdm_responder_rebind_new error: {:?}\n", e);
-        spdm::decode_spdm_session_err(e)
-    })?;
-    log::info!("Rebind completed\n");
+        MigrationResult::from(e)
+    })
+    .and_then(|result| {
+        result.map_err(|e| {
+            #[cfg(feature = "vmcall-raw")]
+            data.extend_from_slice(
+                &format!(
+                    "Error: rebinding_new_prepare(): spdm_responder_rebind_new failed ({:?}). Migration ID: {:x}\n",
+                    e, info.mig_request_id,
+                )
+                .into_bytes(),
+            );
+            log::error!("rebinding: spdm_responder_rebind_new error: {:?}\n", e);
+            spdm::decode_spdm_session_err(e)
+        })
+    });
 
+    spdm::teardown_sessions(&mut spdm_responder.responder_context.common);
     let mut transport_lock = device_io_ref.lock();
     let transport = transport_lock.deref_mut();
-    shutdown_transport(&mut transport.transport, info.mig_request_id).await?;
+    let shutdown_result = shutdown_transport(&mut transport.transport, info.mig_request_id).await;
+
+    if let Err(error) = session_result {
+        let _ = shutdown_result;
+        return Err(error);
+    }
+    shutdown_result?;
+    log::info!("Rebind completed\n");
     Ok(())
 }
 

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -4,8 +4,9 @@
 
 #[cfg(feature = "policy_v2")]
 use crate::migration::pre_session_data::pre_session_data_exchange;
-#[cfg(not(feature = "spdm_attestation"))]
 use crate::migration::servtd_ext::verify_servtd_attr;
+#[cfg(all(feature = "spdm_attestation", feature = "policy_v2"))]
+use crate::migration::servtd_ext::write_approved_servtd_ext_hash;
 use crate::migration::transport::setup_transport;
 use crate::migration::transport::shutdown_transport;
 use crate::migration::transport::TransportType;
@@ -966,11 +967,17 @@ async fn migration_src_exchange_msk(
         );
         MigrationResult::SecureSessionError
     })?;
+    let exchange_information = exchange_info(&info.mig_info, true).map_err(|e| {
+        log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: exchange_info error: {:?}\n", e);
+        e
+    })?;
+
     let session_result = with_timeout(
         SPDM_TIMEOUT,
         spdm::spdm_requester_transfer_msk(
             &mut spdm_requester,
             &info.mig_info,
+            &exchange_information,
             #[cfg(feature = "policy_v2")]
             peer_data,
         ),
@@ -996,12 +1003,29 @@ async fn migration_src_exchange_msk(
     let shutdown_result =
         shutdown_transport(&mut transport.transport, info.mig_info.mig_request_id).await;
 
-    if let Err(error) = session_result {
-        let _ = shutdown_result;
-        return Err(error);
-    }
+    let remote_information = match session_result {
+        Ok(remote_information) => remote_information,
+        Err(error) => {
+            let _ = shutdown_result;
+            return Err(error);
+        }
+    };
     shutdown_result?;
-    log::info!("MSK exchange completed\n");
+
+    let mig_ver = cal_mig_version(true, &exchange_information, &remote_information).map_err(|e| {
+        log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: cal_mig_version error: {:?}\n", e);
+        e
+    })?;
+    set_mig_version(&info.mig_info, mig_ver).map_err(|e| {
+        log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: set_mig_version error: {:?}\n", e);
+        e
+    })?;
+    write_msk(&info.mig_info, &remote_information.key).map_err(|e| {
+        log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: write_msk error: {:?}\n", e);
+        e
+    })?;
+
+    log::info!(migration_request_id = info.mig_info.mig_request_id; "Set MSK and report status\n");
     Ok(())
 }
 
@@ -1014,6 +1038,10 @@ async fn migration_dst_exchange_msk(
     use core::ops::DerefMut;
 
     const SPDM_TIMEOUT: Duration = Duration::from_secs(60); // 60 seconds
+    let exchange_information = exchange_info(&info.mig_info, false).map_err(|e| {
+        log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: exchange_info error: {:?}\n", e);
+        e
+    })?;
     let (mut spdm_responder, device_io_ref) = spdm::spdm_responder(transport).map_err(|_e| {
         log::error!(
             "exchange_msk(): Failed in spdm_responder transport. Migration ID: {}\n",
@@ -1027,6 +1055,7 @@ async fn migration_dst_exchange_msk(
         spdm::spdm_responder_transfer_msk(
             &mut spdm_responder,
             &info.mig_info,
+            &exchange_information,
             #[cfg(feature = "policy_v2")]
             peer_data,
         ),
@@ -1057,7 +1086,39 @@ async fn migration_dst_exchange_msk(
         return Err(error);
     }
     shutdown_result?;
-    log::info!("MSK exchange completed\n");
+
+    let remote_information = spdm_responder.remote_information.take().ok_or_else(|| {
+        log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: missing remote migration information\n");
+        MigrationResult::SecureSessionError
+    })?;
+    verify_servtd_attr(
+        info.mig_info.binding_handle,
+        &info.mig_info.target_td_uuid,
+    )
+    .map_err(|e| {
+        log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: verify_servtd_attr error: {:?}\n", e);
+        e
+    })?;
+    let mig_ver =
+        cal_mig_version(false, &exchange_information, &remote_information).map_err(|e| {
+            log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: cal_mig_version error: {:?}\n", e);
+            e
+        })?;
+    set_mig_version(&info.mig_info, mig_ver).map_err(|e| {
+        log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: set_mig_version error: {:?}\n", e);
+        e
+    })?;
+    write_msk(&info.mig_info, &remote_information.key).map_err(|e| {
+        log::error!(migration_request_id = info.mig_info.mig_request_id; "exchange_msk: write_msk error: {:?}\n", e);
+        e
+    })?;
+
+    #[cfg(feature = "policy_v2")]
+    if let Some(servtd_ext) = spdm_responder.servtd_ext {
+        write_approved_servtd_ext_hash(&servtd_ext.calculate_approved_servtd_ext_hash()?)?;
+    }
+
+    log::info!(migration_request_id = info.mig_info.mig_request_id; "Set MSK and report status\n");
     Ok(())
 }
 

--- a/src/migtd/src/migration/session.rs
+++ b/src/migtd/src/migration/session.rs
@@ -966,7 +966,7 @@ async fn migration_src_exchange_msk(
         );
         MigrationResult::SecureSessionError
     })?;
-    with_timeout(
+    let session_result = with_timeout(
         SPDM_TIMEOUT,
         spdm::spdm_requester_transfer_msk(
             &mut spdm_requester,
@@ -981,17 +981,27 @@ async fn migration_src_exchange_msk(
             "exchange_msk: spdm_requester_transfer_msk timeout error: {:?}\n",
             e
         );
-        e
-    })?
-    .map_err(|e| {
-        log::error!("exchange_msk: spdm_requester_transfer_msk error: {:?}\n", e);
-        spdm::decode_spdm_session_err(e)
-    })?;
-    log::info!("MSK exchange completed\n");
+        MigrationResult::from(e)
+    })
+    .and_then(|result| {
+        result.map_err(|e| {
+            log::error!("exchange_msk: spdm_requester_transfer_msk error: {:?}\n", e);
+            spdm::decode_spdm_session_err(e)
+        })
+    });
 
+    spdm::teardown_sessions(&mut spdm_requester.common);
     let mut transport_lock = device_io_ref.lock();
     let transport = transport_lock.deref_mut();
-    shutdown_transport(&mut transport.transport, info.mig_info.mig_request_id).await?;
+    let shutdown_result =
+        shutdown_transport(&mut transport.transport, info.mig_info.mig_request_id).await;
+
+    if let Err(error) = session_result {
+        let _ = shutdown_result;
+        return Err(error);
+    }
+    shutdown_result?;
+    log::info!("MSK exchange completed\n");
     Ok(())
 }
 
@@ -1012,7 +1022,7 @@ async fn migration_dst_exchange_msk(
         MigrationResult::SecureSessionError
     })?;
 
-    with_timeout(
+    let session_result = with_timeout(
         SPDM_TIMEOUT,
         spdm::spdm_responder_transfer_msk(
             &mut spdm_responder,
@@ -1027,17 +1037,27 @@ async fn migration_dst_exchange_msk(
             "exchange_msk: spdm_responder_transfer_msk timeout error: {:?}\n",
             e
         );
-        e
-    })?
-    .map_err(|e| {
-        log::error!("exchange_msk: spdm_responder_transfer_msk error: {:?}\n", e);
-        spdm::decode_spdm_session_err(e)
-    })?;
-    log::info!("MSK exchange completed\n");
+        MigrationResult::from(e)
+    })
+    .and_then(|result| {
+        result.map_err(|e| {
+            log::error!("exchange_msk: spdm_responder_transfer_msk error: {:?}\n", e);
+            spdm::decode_spdm_session_err(e)
+        })
+    });
 
+    spdm::teardown_sessions(&mut spdm_responder.responder_context.common);
     let mut transport_lock = device_io_ref.lock();
     let transport = transport_lock.deref_mut();
-    shutdown_transport(&mut transport.transport, info.mig_info.mig_request_id).await?;
+    let shutdown_result =
+        shutdown_transport(&mut transport.transport, info.mig_info.mig_request_id).await;
+
+    if let Err(error) = session_result {
+        let _ = shutdown_result;
+        return Err(error);
+    }
+    shutdown_result?;
+    log::info!("MSK exchange completed\n");
     Ok(())
 }
 

--- a/src/migtd/src/spdm/mod.rs
+++ b/src/migtd/src/spdm/mod.rs
@@ -9,6 +9,8 @@ mod spdm_rebind;
 mod spdm_req;
 mod spdm_rsp;
 mod spdm_vdm;
+#[cfg(test)]
+mod tests;
 mod vmcall_msg;
 
 use alloc::boxed::Box;
@@ -20,7 +22,7 @@ use codec::Codec;
 use codec::Reader;
 use codec::Writer;
 use log::error;
-use spdmlib::common::SpdmDeviceIo;
+use spdmlib::common::{SpdmContext, SpdmDeviceIo};
 use spdmlib::error::*;
 use spdmlib::protocol::{SpdmDigestStruct, SPDM_MAX_HASH_SIZE};
 use spin::Mutex;
@@ -48,6 +50,20 @@ use crate::spdm::vmcall_msg::VMCALL_SPDM_MESSAGE_HEADER_SIZE;
 pub(crate) type SpdmDeviceIoArc<T> = Arc<Mutex<MigtdTransport<T>>>;
 pub struct MigtdTransport<T: AsyncRead + AsyncWrite + Unpin + Send> {
     pub transport: T,
+}
+
+pub(crate) fn teardown_session(context: &mut SpdmContext, session_id: u32) {
+    if let Some(session) = context.get_session_via_id(session_id) {
+        session.teardown();
+    }
+}
+
+pub(crate) fn teardown_sessions(context: &mut SpdmContext) {
+    // FINISH clears last_session_id while the established session still holds keys.
+    // Each context belongs to one exchange, so retire every slot before shutdown.
+    for session in &mut context.session {
+        session.teardown();
+    }
 }
 
 #[async_trait]

--- a/src/migtd/src/spdm/spdm_rebind.rs
+++ b/src/migtd/src/spdm/spdm_rebind.rs
@@ -54,25 +54,33 @@ async fn spdm_requester_rebind_old_inner(
     ))
     .await?;
 
-    Box::pin(send_and_receive_sdm_rebind_attest_info(
-        spdm_requester,
-        rebind_info,
-        session_id,
-        peer_data,
-    ))
-    .await?;
+    let result = async {
+        Box::pin(send_and_receive_sdm_rebind_attest_info(
+            spdm_requester,
+            rebind_info,
+            session_id,
+            peer_data,
+        ))
+        .await?;
 
-    Box::pin(spdm_requester.send_receive_spdm_finish(Some(0xff), session_id)).await?;
+        Box::pin(spdm_requester.send_receive_spdm_finish(Some(0xff), session_id)).await?;
 
-    Box::pin(send_and_receive_sdm_rebind_info(
-        spdm_requester,
-        rebind_info,
-        Some(session_id),
-    ))
-    .await?;
+        Box::pin(send_and_receive_sdm_rebind_info(
+            spdm_requester,
+            rebind_info,
+            Some(session_id),
+        ))
+        .await?;
 
-    Box::pin(spdm_requester.send_receive_spdm_end_session(session_id)).await?;
-    Ok(())
+        Box::pin(spdm_requester.send_receive_spdm_end_session(session_id)).await?;
+        Ok(())
+    }
+    .await;
+
+    if result.is_err() {
+        crate::spdm::teardown_session(&mut spdm_requester.common, session_id);
+    }
+    result
 }
 
 pub async fn spdm_responder_rebind_new<'a>(

--- a/src/migtd/src/spdm/spdm_req.rs
+++ b/src/migtd/src/spdm/spdm_req.rs
@@ -5,9 +5,7 @@ use crate::mig_policy;
 use crate::migration::MigrationResult;
 use crate::{
     migration::{
-        data::MigrationSessionKey,
-        session::{cal_mig_version, exchange_info, set_mig_version, write_msk},
-        MigtdMigrationInformation,
+        data::MigrationSessionKey, session::ExchangeInformation, MigtdMigrationInformation,
     },
     spdm::{
         build_report_data, gen_quote_spdm, spdm_rsp::SECRET_ASYM_IMPL_INSTANCE, spdm_verify_quote,
@@ -29,9 +27,9 @@ use spdmlib::{
 use spin::Mutex;
 use zeroize::Zeroize;
 extern crate alloc;
+use crate::event_log::get_event_log;
 #[cfg(feature = "policy_v2")]
 use crate::migration::pre_session_data::local_peer_data;
-use crate::{event_log::get_event_log, migration::session::ExchangeInformation};
 use alloc::sync::Arc;
 use log::error;
 
@@ -91,8 +89,9 @@ pub fn spdm_requester<T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static>
 pub async fn spdm_requester_transfer_msk(
     spdm_requester: &mut RequesterContext,
     mig_info: &MigtdMigrationInformation,
+    exchange_information: &ExchangeInformation,
     #[cfg(feature = "policy_v2")] peer_data: Vec<u8>,
-) -> Result<(), SpdmStatus> {
+) -> Result<ExchangeInformation, SpdmStatus> {
     // `send_and_receive_pub_key` encodes the requester's ephemeral ECDSA
     // private key into `spdm_requester.common.app_context_data_buffer` so
     // libspdm's asymmetric signing callback can read it. The libspdm
@@ -101,6 +100,7 @@ pub async fn spdm_requester_transfer_msk(
     let result = spdm_requester_transfer_msk_inner(
         spdm_requester,
         mig_info,
+        exchange_information,
         #[cfg(feature = "policy_v2")]
         peer_data,
     )
@@ -112,8 +112,9 @@ pub async fn spdm_requester_transfer_msk(
 async fn spdm_requester_transfer_msk_inner(
     spdm_requester: &mut RequesterContext,
     mig_info: &MigtdMigrationInformation,
+    exchange_information: &ExchangeInformation,
     #[cfg(feature = "policy_v2")] peer_data: Vec<u8>,
-) -> Result<(), SpdmStatus> {
+) -> Result<ExchangeInformation, SpdmStatus> {
     Box::pin(spdm_requester.send_receive_spdm_version()).await?;
     Box::pin(spdm_requester.send_receive_spdm_capability()).await?;
     Box::pin(spdm_requester.send_receive_spdm_algorithm()).await?;
@@ -136,15 +137,15 @@ async fn spdm_requester_transfer_msk_inner(
         .await?;
 
         Box::pin(spdm_requester.send_receive_spdm_finish(Some(0xff), session_id)).await?;
-        Box::pin(send_and_receive_sdm_exchange_migration_info(
+        let remote_information = Box::pin(send_and_receive_sdm_exchange_migration_info(
             spdm_requester,
-            mig_info,
+            exchange_information,
             Some(session_id),
         ))
         .await?;
         Box::pin(spdm_requester.send_receive_spdm_end_session(session_id)).await?;
 
-        Ok(())
+        Ok(remote_information)
     }
     .await;
 
@@ -754,14 +755,12 @@ fn verify_peer_attestation_v2(
 
 async fn send_and_receive_sdm_exchange_migration_info(
     spdm_requester: &mut RequesterContext,
-    mig_info: &MigtdMigrationInformation,
+    exchange_information: &ExchangeInformation,
     session_id: Option<u32>,
-) -> SpdmResult {
+) -> SpdmResult<ExchangeInformation> {
     let mut vendor_id = [0u8; MAX_SPDM_VENDOR_DEFINED_VENDOR_ID_LEN];
     vendor_id[..VDM_MESSAGE_VENDOR_ID_LEN].copy_from_slice(&VDM_MESSAGE_VENDOR_ID);
     let vendor_id = VendorIDStruct { len: 4, vendor_id };
-
-    let exchange_information = exchange_info(mig_info, true)?;
 
     let mut payload = vec![0u8; MAX_SPDM_VENDOR_DEFINED_PAYLOAD_SIZE];
     let mut writer = Writer::init(&mut payload);
@@ -924,12 +923,7 @@ async fn send_and_receive_sdm_exchange_migration_info(
         },
     };
 
-    let mig_ver = cal_mig_version(true, &exchange_information, &remote_information)?;
-    set_mig_version(mig_info, mig_ver)?;
-    write_msk(mig_info, &remote_information.key)?;
-    log::info!("Set MSK and report status\n");
-
-    Ok(())
+    Ok(remote_information)
 }
 
 #[cfg(all(feature = "main", feature = "policy_v2", feature = "vmcall-raw"))]

--- a/src/migtd/src/spdm/spdm_req.rs
+++ b/src/migtd/src/spdm/spdm_req.rs
@@ -125,25 +125,33 @@ async fn spdm_requester_transfer_msk_inner(
     ))
     .await?;
 
-    Box::pin(send_and_receive_sdm_migration_attest_info(
-        spdm_requester,
-        mig_info,
-        session_id,
-        #[cfg(feature = "policy_v2")]
-        peer_data,
-    ))
-    .await?;
+    let result = async {
+        Box::pin(send_and_receive_sdm_migration_attest_info(
+            spdm_requester,
+            mig_info,
+            session_id,
+            #[cfg(feature = "policy_v2")]
+            peer_data,
+        ))
+        .await?;
 
-    Box::pin(spdm_requester.send_receive_spdm_finish(Some(0xff), session_id)).await?;
-    Box::pin(send_and_receive_sdm_exchange_migration_info(
-        spdm_requester,
-        mig_info,
-        Some(session_id),
-    ))
-    .await?;
-    Box::pin(spdm_requester.send_receive_spdm_end_session(session_id)).await?;
+        Box::pin(spdm_requester.send_receive_spdm_finish(Some(0xff), session_id)).await?;
+        Box::pin(send_and_receive_sdm_exchange_migration_info(
+            spdm_requester,
+            mig_info,
+            Some(session_id),
+        ))
+        .await?;
+        Box::pin(spdm_requester.send_receive_spdm_end_session(session_id)).await?;
 
-    Ok(())
+        Ok(())
+    }
+    .await;
+
+    if result.is_err() {
+        teardown_session(&mut spdm_requester.common, session_id);
+    }
+    result
 }
 
 pub async fn send_and_receive_pub_key(spdm_requester: &mut RequesterContext) -> SpdmResult {

--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -7,19 +7,13 @@ use crate::mig_policy;
 use crate::migration::pre_session_data::local_peer_data;
 #[cfg(all(feature = "main", feature = "policy_v2", feature = "vmcall-raw"))]
 use crate::migration::rebinding::{write_rebinding_session_token, write_servtd_rebind_attr};
-#[cfg(not(feature = "policy_v2"))]
-use crate::migration::servtd_ext::verify_servtd_attr;
 #[cfg(feature = "policy_v2")]
-use crate::migration::servtd_ext::{verify_servtd_attr, write_approved_servtd_ext_hash, ServtdExt};
+use crate::migration::servtd_ext::{write_approved_servtd_ext_hash, ServtdExt};
 use crate::migration::MigrationResult;
 use crate::{
     event_log::get_event_log,
     migration::{
-        data::MigrationSessionKey,
-        session::{
-            cal_mig_version, exchange_info, set_mig_version, write_msk, ExchangeInformation,
-        },
-        MigtdMigrationInformation,
+        data::MigrationSessionKey, session::ExchangeInformation, MigtdMigrationInformation,
     },
 };
 use alloc::sync::Arc;
@@ -54,12 +48,16 @@ pub struct ResponderContextEx<'a> {
     pub peer_data: Vec<u8>,
     pub info: ResponderContextExInfo<'a>,
     pub mig_info_exchanged: bool,
+    pub remote_information: Option<ExchangeInformation>,
     #[cfg(feature = "policy_v2")]
     pub servtd_ext: Option<ServtdExt>,
 }
 
 pub enum ResponderContextExInfo<'a> {
-    MigrationInformation(&'a MigtdMigrationInformation),
+    MigrationInformation {
+        mig_info: &'a MigtdMigrationInformation,
+        exchange_information: &'a ExchangeInformation,
+    },
     #[cfg(all(feature = "main", feature = "policy_v2", feature = "vmcall-raw"))]
     RebindInformation(&'a MigtdMigrationInformation),
     None,
@@ -142,6 +140,7 @@ pub fn spdm_responder<'a, T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'sta
         peer_data: Vec::new(),
         info: ResponderContextExInfo::None,
         mig_info_exchanged: false,
+        remote_information: None,
         #[cfg(feature = "policy_v2")]
         servtd_ext: None,
     };
@@ -152,16 +151,19 @@ pub fn spdm_responder<'a, T: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'sta
 pub async fn spdm_responder_transfer_msk<'a>(
     spdm_responder_ex: &mut ResponderContextEx<'a>,
     mig_info: &'a MigtdMigrationInformation,
+    exchange_information: &'a ExchangeInformation,
     #[cfg(feature = "policy_v2")] peer_data: Vec<u8>,
 ) -> Result<(), SpdmStatus> {
     #[cfg(not(feature = "policy_v2"))]
     let peer_data = Vec::new();
 
     spdm_responder_ex.peer_data = peer_data;
-    // Mark this responder as operating in migration mode so the migration-mode
-    // handlers (mig-attest op 0x03, mig-info op 0x05) accept the request; their
-    // MigrationInformation variant guard rejects rebind-mode confusion.
-    spdm_responder_ex.info = ResponderContextExInfo::MigrationInformation(mig_info);
+    spdm_responder_ex.info = ResponderContextExInfo::MigrationInformation {
+        mig_info,
+        exchange_information,
+    };
+    spdm_responder_ex.mig_info_exchanged = false;
+    spdm_responder_ex.remote_information = None;
 
     // Zeroize the responder key buffer on every return path.
     let result = spdm_responder_transfer_msk_inner(spdm_responder_ex, mig_info).await;
@@ -373,7 +375,7 @@ pub fn handle_exchange_mig_attest_info_req(
     let spdm_responder_ex = unsafe { upcast_mut(responder_context) };
     if !matches!(
         &spdm_responder_ex.info,
-        ResponderContextExInfo::MigrationInformation(_)
+        ResponderContextExInfo::MigrationInformation { .. }
     ) {
         error!("Migration info is not set in responder context.\n");
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);
@@ -805,7 +807,7 @@ pub fn handle_exchange_mig_info_req(
     let spdm_responder_ex = unsafe { upcast_mut(responder_context) };
     if !matches!(
         &spdm_responder_ex.info,
-        ResponderContextExInfo::MigrationInformation(_)
+        ResponderContextExInfo::MigrationInformation { .. }
     ) {
         error!("Migration info is not set in responder context.\n");
         return Err(SPDM_STATUS_INVALID_MSG_FIELD);
@@ -898,44 +900,24 @@ pub fn handle_exchange_mig_info_req(
         },
     };
 
-    let mut reader = Reader::init(responder_context.common.app_context_data_buffer.as_ref());
-    let responder_app_context =
-        SpdmAppContextData::read(&mut reader).ok_or(SPDM_STATUS_INVALID_MSG_SIZE)?;
-    let exchange_information = exchange_info(&responder_app_context.migration_info, false)?;
-
-    verify_servtd_attr(
-        responder_app_context.migration_info.binding_handle,
-        &responder_app_context.migration_info.target_td_uuid,
-    )?;
-
-    let mig_ver = cal_mig_version(false, &exchange_information, &remote_information)?;
-    set_mig_version(&responder_app_context.migration_info, mig_ver)?;
-    write_msk(
-        &responder_app_context.migration_info,
-        &remote_information.key,
-    )?;
-
-    unsafe {
-        upcast_mut(responder_context).mig_info_exchanged = true;
-    }
-
-    // Write APPROVED_SERVTD_EXT_HASH if SERVTD_EXT was received during attestation
-    #[cfg(feature = "policy_v2")]
-    {
-        let servtd_ext = unsafe {
-            let spdm_responder_ex = upcast_mut(responder_context);
-            spdm_responder_ex.servtd_ext
-        };
-        if let Some(ext) = servtd_ext {
-            write_approved_servtd_ext_hash(&ext.calculate_approved_servtd_ext_hash()?)?;
+    let spdm_responder_ex = unsafe { upcast_mut(responder_context) };
+    let exchange_information = match &spdm_responder_ex.info {
+        ResponderContextExInfo::MigrationInformation {
+            exchange_information,
+            ..
+        } => *exchange_information,
+        _ => {
+            error!("Migration info is not set in responder context.\n");
+            return Err(SPDM_STATUS_INVALID_STATE_LOCAL);
         }
-    }
-
-    log::info!("Set MSK and report status\n");
+    };
 
     let min_import_version = exchange_information.min_ver;
     let max_import_version = exchange_information.max_ver;
     let mig_session_key = exchange_information.key.as_bytes().to_vec();
+
+    spdm_responder_ex.remote_information = Some(remote_information);
+    spdm_responder_ex.mig_info_exchanged = true;
 
     let mut writer = Writer::init(vendor_defined_rsp_payload);
     let mut cnt = 0;

--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -201,20 +201,6 @@ pub async fn rsp_handle_message(spdm_responder: &mut ResponderContext) -> Result
         raw_packet.zeroize();
         let res = Box::pin(spdm_responder.process_message(false, 0, raw_packet)).await;
 
-        let session_id = spdm_responder.common.runtime_info.get_last_session_id();
-        if session_id.is_some() {
-            sid = session_id;
-        }
-        if sid.is_some()
-            && spdm_responder
-                .common
-                .get_session_via_id(sid.unwrap())
-                .is_none()
-        {
-            //Terminate the responder upon end_session received.
-            break;
-        }
-
         match res {
             Ok(spdm_result) => {
                 match spdm_result {
@@ -235,6 +221,20 @@ pub async fn rsp_handle_message(spdm_responder: &mut ResponderContext) -> Result
             Err(_) => {
                 return Err(SPDM_STATUS_RECEIVE_FAIL);
             }
+        }
+
+        let session_id = spdm_responder.common.runtime_info.get_last_session_id();
+        if session_id.is_some() {
+            sid = session_id;
+        }
+        if sid.is_some()
+            && spdm_responder
+                .common
+                .get_session_via_id(sid.unwrap())
+                .is_none()
+        {
+            //Terminate the responder upon end_session received.
+            break;
         }
     }
     Ok(())

--- a/src/migtd/src/spdm/spdm_rsp.rs
+++ b/src/migtd/src/spdm/spdm_rsp.rs
@@ -201,32 +201,25 @@ pub async fn rsp_handle_message(spdm_responder: &mut ResponderContext) -> Result
         raw_packet.zeroize();
         let res = Box::pin(spdm_responder.process_message(false, 0, raw_packet)).await;
 
-        match res {
-            Ok(spdm_result) => {
-                match spdm_result {
-                    Ok(_) => {}
-                    Err(spdm_status) => {
-                        if spdm_status.severity == StatusSeverity::ERROR
-                            && matches!(spdm_status.status_code, StatusCode::VDM(_))
-                        {
-                            return Err(spdm_status);
-                        }
-                        if spdm_status == SPDM_STATUS_INVALID_STATE_LOCAL {
-                            //Terminate the responder upon invalid state.
-                            return Err(spdm_status);
-                        }
-                    }
-                }
-            }
-            Err(_) => {
-                return Err(SPDM_STATUS_RECEIVE_FAIL);
-            }
-        }
-
         let session_id = spdm_responder.common.runtime_info.get_last_session_id();
         if session_id.is_some() {
             sid = session_id;
         }
+
+        match res {
+            Ok(Ok(_)) => {}
+            Ok(Err(spdm_status)) => {
+                if let Some(session_id) = sid {
+                    teardown_session(&mut spdm_responder.common, session_id);
+                }
+                return Err(spdm_status);
+            }
+            Err(_) => {
+                teardown_sessions(&mut spdm_responder.common);
+                return Err(SPDM_STATUS_RECEIVE_FAIL);
+            }
+        }
+
         if sid.is_some()
             && spdm_responder
                 .common

--- a/src/migtd/src/spdm/tests.rs
+++ b/src/migtd/src/spdm/tests.rs
@@ -1,0 +1,63 @@
+// Copyright (c) 2026 Microsoft Corporation
+//
+// SPDX-License-Identifier: BSD-2-Clause-Patent
+
+use super::*;
+use spdmlib::common::{session::SpdmSessionState, INVALID_SESSION_ID};
+
+struct TestTransport;
+
+impl AsyncRead for TestTransport {
+    async fn read(&mut self, _buffer: &mut [u8]) -> async_io::Result<usize> {
+        unreachable!("session teardown must not read from the transport");
+    }
+}
+
+impl AsyncWrite for TestTransport {
+    async fn write(&mut self, _buffer: &[u8]) -> async_io::Result<usize> {
+        unreachable!("session teardown must not write to the transport");
+    }
+}
+
+fn assert_teardown_clears_sessions(context: &mut SpdmContext) {
+    for last_session_id in [Some(1), None] {
+        for (index, session) in context.session.iter_mut().enumerate() {
+            session.setup(u32::try_from(index + 1).unwrap()).unwrap();
+            session.set_session_state(if last_session_id.is_some() {
+                SpdmSessionState::SpdmSessionHandshaking
+            } else {
+                SpdmSessionState::SpdmSessionEstablished
+            });
+            let mut secret = session.get_application_secret();
+            secret.request_direction.encryption_key.data.fill(0xa5);
+            secret.request_direction.encryption_key.data_size = 32;
+            session.set_application_secret(secret);
+        }
+        // FINISH clears this field without removing the established session.
+        context.runtime_info.set_last_session_id(last_session_id);
+
+        for _ in 0..2 {
+            teardown_sessions(context);
+            for session in &context.session {
+                assert_eq!(session.get_session_id(), INVALID_SESSION_ID);
+                assert_eq!(
+                    session.get_session_state(),
+                    SpdmSessionState::SpdmSessionNotStarted
+                );
+                assert_eq!(session.get_application_secret(), Default::default());
+            }
+        }
+    }
+}
+
+#[test]
+fn requester_teardown_clears_handshaking_and_established_sessions() {
+    let (mut requester, _) = spdm_requester(TestTransport).unwrap();
+    assert_teardown_clears_sessions(&mut requester.common);
+}
+
+#[test]
+fn responder_teardown_clears_handshaking_and_established_sessions() {
+    let (mut responder, _) = spdm_responder(TestTransport).unwrap();
+    assert_teardown_clears_sessions(&mut responder.responder_context.common);
+}

--- a/xtask/src/library.rs
+++ b/xtask/src/library.rs
@@ -50,16 +50,22 @@ impl LibraryCrates {
                 // vmcall-raw variant of MigtdMigrationInformation are exercised.
                 // Restricted to --lib because the bin target's `main` symbol
                 // conflicts under `cfg(test) + main + !AzCVMEmu`.
-                cmd!(sh, "cargo test")
-                    .args([
-                        "--lib",
-                        "-p",
-                        name.as_str(),
-                        "--no-default-features",
-                        "--features",
-                        "main,policy_v2,vmcall-raw",
-                    ])
-                    .run()?;
+                for features in [
+                    "main,policy_v2,vmcall-raw",
+                    "main,vmcall-raw,spdm_attestation",
+                    "main,policy_v2,vmcall-raw,spdm_attestation",
+                ] {
+                    cmd!(sh, "cargo test")
+                        .args([
+                            "--lib",
+                            "-p",
+                            name.as_str(),
+                            "--no-default-features",
+                            "--features",
+                            features,
+                        ])
+                        .run()?;
+                }
             } else if name.as_str() == "policy" {
                 // Run tests for policy V1 and V2
                 cmd!(sh, "cargo test").args(["-p", name.as_str()]).run()?;


### PR DESCRIPTION
## Summary

Harden SPDM migration and rebind failure atomicity across three ordered commits:

1. Propagate responder processing errors before interpreting a removed session as successful `END_SESSION`.
2. Tear down every keyed requester/responder session on post-key-exchange failures, including timeout/cancellation paths, and perform best-effort transport shutdown without replacing the primary protocol error.
3. Stage exchanged migration information and install the migration version, MSK, and approved SERVTD_EXT hash only after successful `END_SESSION` and transport shutdown. Responder exchange remains one-shot so replay cannot replace staged state.

The change preserves the existing quote and TDREPORT binding paths and does not import policy-series refactors, one-hash/CoRIM/RTMR1 changes, test bypasses, or diagnostic logging.

## Validation

- `bash sh_script/preparation.sh`
- `cargo fmt --check`
- `cargo check`
- `cargo test -p migtd --lib` (23 passed)
- Targeted SPDM Clippy (`main,stack-guard,vmcall-raw,spdm_attestation,policy_v2`)
- Intel workflow Clippy (`stack-guard,virtio-vsock,virtio-serial,vmcall-interrupt`)
- `cargo deny check advisories`, `sources`, and `bans`
- `cargo xtask lib-build` and `cargo xtask lib-test`
- All 32 Intel image matrix builds
- All 14 current Intel `integration-emu.yml` scenarios, run sequentially