### PR TITLE
build(xtask): remap Rust paths in firmware builds

### DIFF
--- a/xtask/src/build.rs
+++ b/xtask/src/build.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-2-Clause-Patent
 
 use crate::config;
-use anyhow::{Context, Ok, Result};
+use anyhow::{Context, Result};
 use clap::{Args, ValueEnum};
 use lazy_static::lazy_static;
 use std::{
@@ -245,6 +245,7 @@ impl BuildArgs {
         self.build_shim_layout()?;
 
         let sh = Shell::new()?;
+        sh.set_var("RUSTFLAGS", Self::remap_rustflags()?);
         sh.change_dir(SHIM_FOLDER.as_path());
         if self.profile() == "release" {
             cmd!(sh, "cargo build -p td-shim --target x86_64-unknown-none --features=main,tdx,log/max_level_off --no-default-features --release")
@@ -308,6 +309,7 @@ impl BuildArgs {
         let sh = Shell::new()?;
         sh.set_var("CC_x86_64_unknown_none", "clang");
         sh.set_var("AR_x86_64_unknown_none", "llvm-ar");
+        sh.set_var("RUSTFLAGS", Self::remap_rustflags()?);
         sh.set_var(
             "SPDM_CONFIG",
             PROJECT_ROOT
@@ -399,6 +401,40 @@ impl BuildArgs {
         } else {
             "release"
         }
+    }
+
+    fn remap_rustflags() -> Result<String> {
+        let project = PROJECT_ROOT
+            .to_str()
+            .context("project root is not valid UTF-8")?;
+        let cargo_home = match env::var("CARGO_HOME") {
+            Ok(path) => path,
+            Err(env::VarError::NotPresent) => env::var("HOME")
+                .map(|home| format!("{home}/.cargo"))
+                .context("CARGO_HOME and HOME are unavailable")?,
+            Err(error) => return Err(error).context("CARGO_HOME is not valid UTF-8"),
+        };
+        let rustup_home = match env::var("RUSTUP_HOME") {
+            Ok(path) => path,
+            Err(env::VarError::NotPresent) => env::var("HOME")
+                .map(|home| format!("{home}/.rustup"))
+                .context("RUSTUP_HOME and HOME are unavailable")?,
+            Err(error) => return Err(error).context("RUSTUP_HOME is not valid UTF-8"),
+        };
+        let mut flags = match env::var("RUSTFLAGS") {
+            Ok(flags) => flags,
+            Err(env::VarError::NotPresent) => String::new(),
+            Err(error) => return Err(error).context("RUSTFLAGS is not valid UTF-8"),
+        };
+        if !flags.is_empty() {
+            flags.push(' ');
+        }
+        flags.push_str(&format!(
+            "--remap-path-prefix={cargo_home}=/cargo \
+             --remap-path-prefix={rustup_home}=/rustup \
+             --remap-path-prefix={project}=/migtd"
+        ));
+        Ok(flags)
     }
 
     fn features(&self) -> String {


### PR DESCRIPTION
## Summary

- append stable `--remap-path-prefix` flags to the td-shim and MigTD builds launched by xtask
- preserve caller-provided `RUSTFLAGS`
- normalize the checkout root, `CARGO_HOME`, and `RUSTUP_HOME` without changing profiles, LTO, C toolchain flags, Docker, or build outputs other than embedded paths

## Why this is needed

The build container masks path variance by cloning MigTD at `/root/MigTD` with fixed `/root/.cargo` and `/root/.rustup` homes. However, the documented `cargo image` flow and the main CI image matrix both build natively, where those absolute paths depend on the checkout and user.

Before this change, identical default builds from two absolute checkout roots produced different TDVF image SHA-256 values:

- checkout A: `f43a483ce8ab833ff86bce493f639f7a4146b590ec136c9736490fbd271ca11f`
- checkout B: `90f67e2daa56d2d1955964e7a7e156f23fe77336921e70f5a8aa68b348f79328`

The MigTD ELF contained 86 checkout-root, 22 Cargo-home, and 9 Rustup-home string occurrences. This patch removes those Rust path inputs independently of Docker. The default production image also links vendored C objects containing source paths; that separate source of variance is intentionally outside this Rust-only change, so this PR does not claim complete native production-image reproducibility.

## Two-path reproducibility check

To isolate the xtask Rust pipeline, I built the documented native debug IGVM test configuration from two independent absolute checkout roots:

```text
cargo image --debug --no-default-features \
  --features vmcall-raw,stack-guard,test_disable_ra_and_accept_all,vmcall-interrupt,oneshot-apic \
  --log-level info --image-format igvm --output target/remap-check.igvm
cargo hash --image target/remap-check.igvm \
  --test-disable-ra-and-accept-all \
  --output target/remap-check.servtd_info_hash
```

Both checkouts produced:

- IGVM SHA-256: `f36187a44249ca9da688d0dbcddea0591ce22dcb164f08fee30d763de58e5f35`
- `SERVTD_INFO_HASH`: `aa3103a2f30df203bf6d230d3ac42ac084c4cdaa917fef42bd7904b3c66f33e6bc031b48871cdc9873125df8f569413f`
- hash-file SHA-256: `695e42fbe2d9b0901c8a46fb853f406fe5d1b03b72ededbc0eb9702fc955e9f5`

The IGVM images and measurement files compared byte-identical, and the resulting MigTD ELF contained zero occurrences of either checkout root, the original Cargo home, or the original Rustup home.

## Validation

- `cargo fmt --check`
- `cargo test -p xtask`
- targeted default TDVF and debug IGVM image builds
- CI gauntlet: preparation, format/check/clippy, cargo-deny, library build/tests, all 32 main image builds, and all 14 current EMU workflow scenarios