### PR TITLE
fix(migtd): reject zero-progress pre-session writes

### DIFF
--- a/src/migtd/src/migration/pre_session_data.rs
+++ b/src/migtd/src/migration/pre_session_data.rs
@@ -123,6 +123,11 @@ pub(super) async fn send_pre_session_data<T: AsyncRead + AsyncWrite + Unpin>(
             log::error!("send_pre_session_data: Network error: {:?}\n", e);
             MigrationResult::NetworkError
         })?;
+        // Fail closed if the transport reports success without progress.
+        if n == 0 {
+            log::error!("send_pre_session_data: zero-length transport write\n");
+            return Err(MigrationResult::NetworkError);
+        }
         sent += n;
     }
     Ok(())


### PR DESCRIPTION
## Rationale

`send_pre_session_data` retries until the full buffer is written, but an `AsyncWrite` implementation may return `Ok(0)` without making progress. Treat that result as a logged `MigrationResult::NetworkError` so the migration pre-session path cannot spin indefinitely.

This matches the fail-closed behavior already used by the SPDM exact-I/O path in intel/MigTD#1022.

## Validation

- `cargo fmt --check`
- Full non-EMU CI gauntlet: preparation, format/check/Clippy, deny, library, and all 32 main image builds
- Current Intel `integration-emu.yml` matrix, all 14 scenarios run sequentially:
  - Build and Test (Skip RA)
  - Policy v2 with Mock Report
  - Policy v2 with Mock Report and IGVM Attest
  - Rebind Prepare (Skip RA)
  - Rebind Prepare (Mock Report)
  - SPDM Migration (Skip RA)
  - SPDM Policy v2 with Mock Report
  - SPDM Rebind Prepare (Skip RA)
  - Mock Quote Retry, including retry-log assertions
  - Policy v2 Key Rotation (Mock Report)
  - Policy v2 Key Rotation with IGVM Attest
  - SPDM Policy v2 Key Rotation (Mock Report)
  - Policy v2 Policy + TCB Mapping Leaf Rotation (Mock Report)
  - Policy v2 All Three Chains Rotation (Mock Report)
